### PR TITLE
Add study agent persistence endpoints and frontend integration

### DIFF
--- a/src/app/api/study-agent/me/pomodoro-settings/route.ts
+++ b/src/app/api/study-agent/me/pomodoro-settings/route.ts
@@ -1,42 +1,50 @@
 import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
 import { db } from "~/server/db";
 import { studyAgentPomodoroSettings } from "~/server/db/schema";
+import { resolveSessionForUser } from "~/server/study-agent/session";
 
-const DEFAULT_SETTINGS = {
-    focusMinutes: 25,
-    shortBreakMinutes: 5,
-    longBreakMinutes: 15,
-    sessionsBeforeLongBreak: 4,
-    autoStartBreaks: false,
-    autoStartPomodoros: false,
-};
+function parseSessionId(request: Request) {
+    const sessionIdParam = new URL(request.url).searchParams.get("sessionId");
+    const parsedSessionId = sessionIdParam ? Number(sessionIdParam) : undefined;
+    return Number.isNaN(parsedSessionId) ? undefined : parsedSessionId;
+}
 
-export async function GET() {
+export async function GET(request: Request) {
     try {
         const { userId } = await auth();
         if (!userId) {
             return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
         }
 
+        const session = await resolveSessionForUser(userId, parseSessionId(request));
+        if (!session) {
+            return NextResponse.json({ error: "Session not found" }, { status: 404 });
+        }
+
         const [settings] = await db
             .select()
             .from(studyAgentPomodoroSettings)
-            .where(eq(studyAgentPomodoroSettings.userId, userId));
+            .where(
+                and(
+                    eq(studyAgentPomodoroSettings.userId, userId),
+                    eq(studyAgentPomodoroSettings.sessionId, session.id)
+                )
+            );
 
-        return NextResponse.json({ settings: settings ?? DEFAULT_SETTINGS });
+        return NextResponse.json({ pomodoroSettings: settings ?? null, session });
     } catch (error) {
-        console.error("Error fetching Pomodoro settings", error);
+        console.error("Error fetching pomodoro settings", error);
         return NextResponse.json(
-            { error: "Failed to load Pomodoro settings" },
+            { error: "Failed to load pomodoro settings" },
             { status: 500 }
         );
     }
 }
 
-export async function PUT(request: Request) {
+export async function POST(request: Request) {
     try {
         const { userId } = await auth();
         if (!userId) {
@@ -44,64 +52,89 @@ export async function PUT(request: Request) {
         }
 
         const body = await request.json();
+        const session = await resolveSessionForUser(
+            userId,
+            body.sessionId ?? parseSessionId(request)
+        );
+
+        if (!session) {
+            return NextResponse.json({ error: "Session not found" }, { status: 404 });
+        }
+
         const payload = {
-            focusMinutes: body.focusMinutes ?? DEFAULT_SETTINGS.focusMinutes,
-            shortBreakMinutes:
-                body.shortBreakMinutes ?? DEFAULT_SETTINGS.shortBreakMinutes,
-            longBreakMinutes: body.longBreakMinutes ?? DEFAULT_SETTINGS.longBreakMinutes,
-            sessionsBeforeLongBreak:
-                body.sessionsBeforeLongBreak ?? DEFAULT_SETTINGS.sessionsBeforeLongBreak,
-            autoStartBreaks: body.autoStartBreaks ?? DEFAULT_SETTINGS.autoStartBreaks,
-            autoStartPomodoros:
-                body.autoStartPomodoros ?? DEFAULT_SETTINGS.autoStartPomodoros,
+            focusMinutes: body.focusMinutes ?? 25,
+            shortBreakMinutes: body.shortBreakMinutes ?? 5,
+            longBreakMinutes: body.longBreakMinutes ?? 15,
+            sessionsBeforeLongBreak: body.sessionsBeforeLongBreak ?? 4,
+            autoStartBreaks: Boolean(body.autoStartBreaks),
+            autoStartPomodoros: Boolean(body.autoStartPomodoros),
         };
 
         const [existing] = await db
             .select()
             .from(studyAgentPomodoroSettings)
-            .where(eq(studyAgentPomodoroSettings.userId, userId));
+            .where(
+                and(
+                    eq(studyAgentPomodoroSettings.userId, userId),
+                    eq(studyAgentPomodoroSettings.sessionId, session.id)
+                )
+            );
 
         if (existing) {
             const [updated] = await db
                 .update(studyAgentPomodoroSettings)
                 .set(payload)
-                .where(eq(studyAgentPomodoroSettings.userId, userId))
+                .where(
+                    and(
+                        eq(studyAgentPomodoroSettings.userId, userId),
+                        eq(studyAgentPomodoroSettings.sessionId, session.id)
+                    )
+                )
                 .returning();
 
-            return NextResponse.json({ settings: updated });
+            return NextResponse.json({ pomodoroSettings: updated, session });
         }
 
         const [created] = await db
             .insert(studyAgentPomodoroSettings)
-            .values({ ...payload, userId })
+            .values({ ...payload, userId, sessionId: session.id })
             .returning();
 
-        return NextResponse.json({ settings: created }, { status: 201 });
+        return NextResponse.json({ pomodoroSettings: created, session }, { status: 201 });
     } catch (error) {
-        console.error("Error saving Pomodoro settings", error);
+        console.error("Error saving pomodoro settings", error);
         return NextResponse.json(
-            { error: "Failed to save Pomodoro settings" },
+            { error: "Failed to save pomodoro settings" },
             { status: 500 }
         );
     }
 }
 
-export async function DELETE() {
+export async function DELETE(request: Request) {
     try {
         const { userId } = await auth();
         if (!userId) {
             return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
         }
 
+        const session = await resolveSessionForUser(userId, parseSessionId(request));
+        if (!session) {
+            return NextResponse.json({ error: "Session not found" }, { status: 404 });
+        }
+
         await db
             .delete(studyAgentPomodoroSettings)
-            .where(eq(studyAgentPomodoroSettings.userId, userId));
-
+            .where(
+                and(
+                    eq(studyAgentPomodoroSettings.userId, userId),
+                    eq(studyAgentPomodoroSettings.sessionId, session.id)
+                )
+            );
         return NextResponse.json({ success: true });
     } catch (error) {
-        console.error("Error clearing Pomodoro settings", error);
+        console.error("Error deleting pomodoro settings", error);
         return NextResponse.json(
-            { error: "Failed to delete Pomodoro settings" },
+            { error: "Failed to delete pomodoro settings" },
             { status: 500 }
         );
     }

--- a/src/app/api/study-agent/me/pomodoro-settings/route.ts
+++ b/src/app/api/study-agent/me/pomodoro-settings/route.ts
@@ -1,0 +1,108 @@
+import { NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { eq } from "drizzle-orm";
+
+import { db } from "~/server/db";
+import { studyAgentPomodoroSettings } from "~/server/db/schema";
+
+const DEFAULT_SETTINGS = {
+    focusMinutes: 25,
+    shortBreakMinutes: 5,
+    longBreakMinutes: 15,
+    sessionsBeforeLongBreak: 4,
+    autoStartBreaks: false,
+    autoStartPomodoros: false,
+};
+
+export async function GET() {
+    try {
+        const { userId } = await auth();
+        if (!userId) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+
+        const [settings] = await db
+            .select()
+            .from(studyAgentPomodoroSettings)
+            .where(eq(studyAgentPomodoroSettings.userId, userId));
+
+        return NextResponse.json({ settings: settings ?? DEFAULT_SETTINGS });
+    } catch (error) {
+        console.error("Error fetching Pomodoro settings", error);
+        return NextResponse.json(
+            { error: "Failed to load Pomodoro settings" },
+            { status: 500 }
+        );
+    }
+}
+
+export async function PUT(request: Request) {
+    try {
+        const { userId } = await auth();
+        if (!userId) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+
+        const body = await request.json();
+        const payload = {
+            focusMinutes: body.focusMinutes ?? DEFAULT_SETTINGS.focusMinutes,
+            shortBreakMinutes:
+                body.shortBreakMinutes ?? DEFAULT_SETTINGS.shortBreakMinutes,
+            longBreakMinutes: body.longBreakMinutes ?? DEFAULT_SETTINGS.longBreakMinutes,
+            sessionsBeforeLongBreak:
+                body.sessionsBeforeLongBreak ?? DEFAULT_SETTINGS.sessionsBeforeLongBreak,
+            autoStartBreaks: body.autoStartBreaks ?? DEFAULT_SETTINGS.autoStartBreaks,
+            autoStartPomodoros:
+                body.autoStartPomodoros ?? DEFAULT_SETTINGS.autoStartPomodoros,
+        };
+
+        const [existing] = await db
+            .select()
+            .from(studyAgentPomodoroSettings)
+            .where(eq(studyAgentPomodoroSettings.userId, userId));
+
+        if (existing) {
+            const [updated] = await db
+                .update(studyAgentPomodoroSettings)
+                .set(payload)
+                .where(eq(studyAgentPomodoroSettings.userId, userId))
+                .returning();
+
+            return NextResponse.json({ settings: updated });
+        }
+
+        const [created] = await db
+            .insert(studyAgentPomodoroSettings)
+            .values({ ...payload, userId })
+            .returning();
+
+        return NextResponse.json({ settings: created }, { status: 201 });
+    } catch (error) {
+        console.error("Error saving Pomodoro settings", error);
+        return NextResponse.json(
+            { error: "Failed to save Pomodoro settings" },
+            { status: 500 }
+        );
+    }
+}
+
+export async function DELETE() {
+    try {
+        const { userId } = await auth();
+        if (!userId) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+
+        await db
+            .delete(studyAgentPomodoroSettings)
+            .where(eq(studyAgentPomodoroSettings.userId, userId));
+
+        return NextResponse.json({ success: true });
+    } catch (error) {
+        console.error("Error clearing Pomodoro settings", error);
+        return NextResponse.json(
+            { error: "Failed to delete Pomodoro settings" },
+            { status: 500 }
+        );
+    }
+}

--- a/src/app/api/study-agent/me/preferences/route.ts
+++ b/src/app/api/study-agent/me/preferences/route.ts
@@ -1,0 +1,88 @@
+import { NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { eq } from "drizzle-orm";
+
+import { db } from "~/server/db";
+import { studyAgentPreferences } from "~/server/db/schema";
+
+export async function GET() {
+    try {
+        const { userId } = await auth();
+        if (!userId) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+
+        const [preferences] = await db
+            .select()
+            .from(studyAgentPreferences)
+            .where(eq(studyAgentPreferences.userId, userId));
+
+        return NextResponse.json({ preferences: preferences?.preferences ?? null });
+    } catch (error) {
+        console.error("Error fetching study agent preferences", error);
+        return NextResponse.json(
+            { error: "Failed to load preferences" },
+            { status: 500 }
+        );
+    }
+}
+
+export async function POST(request: Request) {
+    try {
+        const { userId } = await auth();
+        if (!userId) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+
+        const preferences = await request.json();
+
+        const [existing] = await db
+            .select()
+            .from(studyAgentPreferences)
+            .where(eq(studyAgentPreferences.userId, userId));
+
+        if (existing) {
+            const [updated] = await db
+                .update(studyAgentPreferences)
+                .set({ preferences })
+                .where(eq(studyAgentPreferences.userId, userId))
+                .returning();
+
+            return NextResponse.json({ preferences: updated.preferences });
+        }
+
+        const [created] = await db
+            .insert(studyAgentPreferences)
+            .values({ userId, preferences })
+            .returning();
+
+        return NextResponse.json({ preferences: created.preferences }, { status: 201 });
+    } catch (error) {
+        console.error("Error saving study agent preferences", error);
+        return NextResponse.json(
+            { error: "Failed to save preferences" },
+            { status: 500 }
+        );
+    }
+}
+
+export async function DELETE() {
+    try {
+        const { userId } = await auth();
+        if (!userId) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+
+        await db
+            .delete(studyAgentPreferences)
+            .where(eq(studyAgentPreferences.userId, userId));
+
+        return NextResponse.json({ success: true });
+    } catch (error) {
+        console.error("Error deleting study agent preferences", error);
+        return NextResponse.json(
+            { error: "Failed to delete preferences" },
+            { status: 500 }
+        );
+    }
+}

--- a/src/app/api/study-agent/me/profile/route.ts
+++ b/src/app/api/study-agent/me/profile/route.ts
@@ -1,0 +1,91 @@
+import { NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { eq } from "drizzle-orm";
+
+import { db } from "~/server/db";
+import { studyAgentProfile } from "~/server/db/schema";
+
+export async function GET() {
+    try {
+        const { userId } = await auth();
+        if (!userId) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+
+        const [profile] = await db
+            .select()
+            .from(studyAgentProfile)
+            .where(eq(studyAgentProfile.userId, userId));
+
+        return NextResponse.json({ profile: profile ?? null });
+    } catch (error) {
+        console.error("Error fetching study agent profile", error);
+        return NextResponse.json(
+            { error: "Failed to load profile" },
+            { status: 500 }
+        );
+    }
+}
+
+export async function POST(request: Request) {
+    try {
+        const { userId } = await auth();
+        if (!userId) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+
+        const body = await request.json();
+        const payload = {
+            name: body.name ?? null,
+            grade: body.grade ?? null,
+            gender: body.gender ?? null,
+            fieldOfStudy: body.fieldOfStudy ?? null,
+        };
+
+        const [existing] = await db
+            .select()
+            .from(studyAgentProfile)
+            .where(eq(studyAgentProfile.userId, userId));
+
+        if (existing) {
+            const [updated] = await db
+                .update(studyAgentProfile)
+                .set(payload)
+                .where(eq(studyAgentProfile.userId, userId))
+                .returning();
+
+            return NextResponse.json({ profile: updated });
+        }
+
+        const [created] = await db
+            .insert(studyAgentProfile)
+            .values({ ...payload, userId })
+            .returning();
+
+        return NextResponse.json({ profile: created }, { status: 201 });
+    } catch (error) {
+        console.error("Error saving study agent profile", error);
+        return NextResponse.json(
+            { error: "Failed to save profile" },
+            { status: 500 }
+        );
+    }
+}
+
+export async function DELETE() {
+    try {
+        const { userId } = await auth();
+        if (!userId) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+
+        await db.delete(studyAgentProfile).where(eq(studyAgentProfile.userId, userId));
+        return NextResponse.json({ success: true });
+    } catch (error) {
+        console.error("Error deleting study agent profile", error);
+        return NextResponse.json(
+            { error: "Failed to delete profile" },
+            { status: 500 }
+        );
+    }
+}

--- a/src/app/api/study-agent/me/route.ts
+++ b/src/app/api/study-agent/me/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { eq } from "drizzle-orm";
+
+import { db } from "~/server/db";
+import {
+    studyAgentGoals,
+    studyAgentPomodoroSettings,
+    studyAgentPreferences,
+    studyAgentProfile,
+} from "~/server/db/schema";
+
+export async function GET() {
+    try {
+        const { userId } = await auth();
+        if (!userId) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+
+        const [profile] = await db
+            .select()
+            .from(studyAgentProfile)
+            .where(eq(studyAgentProfile.userId, userId));
+
+        const [preferences] = await db
+            .select()
+            .from(studyAgentPreferences)
+            .where(eq(studyAgentPreferences.userId, userId));
+
+        const goals = await db
+            .select()
+            .from(studyAgentGoals)
+            .where(eq(studyAgentGoals.userId, userId));
+
+        const [pomodoroSettings] = await db
+            .select()
+            .from(studyAgentPomodoroSettings)
+            .where(eq(studyAgentPomodoroSettings.userId, userId));
+
+        return NextResponse.json({
+            profile: profile ?? null,
+            preferences: preferences?.preferences ?? null,
+            goals: goals.map((goal) => ({ ...goal, id: goal.id.toString() })),
+            pomodoroSettings: pomodoroSettings ?? null,
+        });
+    } catch (error) {
+        console.error("Error loading study agent data", error);
+        return NextResponse.json(
+            { error: "Failed to load study agent data" },
+            { status: 500 }
+        );
+    }
+}

--- a/src/app/api/study-agent/me/route.ts
+++ b/src/app/api/study-agent/me/route.ts
@@ -1,46 +1,91 @@
 import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 
 import { db } from "~/server/db";
 import {
     studyAgentGoals,
+    studyAgentNotes,
     studyAgentPomodoroSettings,
     studyAgentPreferences,
     studyAgentProfile,
 } from "~/server/db/schema";
+import { resolveSessionForUser } from "~/server/study-agent/session";
 
-export async function GET() {
+export async function GET(request: Request) {
     try {
         const { userId } = await auth();
         if (!userId) {
             return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
         }
 
+        const sessionIdParam = new URL(request.url).searchParams.get("sessionId");
+        const parsedSessionId = sessionIdParam ? Number(sessionIdParam) : undefined;
+        const session = await resolveSessionForUser(
+            userId,
+            Number.isNaN(parsedSessionId) ? undefined : parsedSessionId
+        );
+
+        if (!session) {
+            return NextResponse.json({ error: "Session not found" }, { status: 404 });
+        }
+
         const [profile] = await db
             .select()
             .from(studyAgentProfile)
-            .where(eq(studyAgentProfile.userId, userId));
+            .where(
+                and(
+                    eq(studyAgentProfile.userId, userId),
+                    eq(studyAgentProfile.sessionId, session.id)
+                )
+            );
 
         const [preferences] = await db
             .select()
             .from(studyAgentPreferences)
-            .where(eq(studyAgentPreferences.userId, userId));
+            .where(
+                and(
+                    eq(studyAgentPreferences.userId, userId),
+                    eq(studyAgentPreferences.sessionId, session.id)
+                )
+            );
 
         const goals = await db
             .select()
             .from(studyAgentGoals)
-            .where(eq(studyAgentGoals.userId, userId));
+            .where(
+                and(
+                    eq(studyAgentGoals.userId, userId),
+                    eq(studyAgentGoals.sessionId, session.id)
+                )
+            );
+
+        const notes = await db
+            .select()
+            .from(studyAgentNotes)
+            .where(
+                and(
+                    eq(studyAgentNotes.userId, userId),
+                    eq(studyAgentNotes.sessionId, session.id)
+                )
+            );
 
         const [pomodoroSettings] = await db
             .select()
             .from(studyAgentPomodoroSettings)
-            .where(eq(studyAgentPomodoroSettings.userId, userId));
+            .where(
+                and(
+                    eq(studyAgentPomodoroSettings.userId, userId),
+                    eq(studyAgentPomodoroSettings.sessionId, session.id)
+                )
+            );
 
         return NextResponse.json({
+            session,
             profile: profile ?? null,
             preferences: preferences?.preferences ?? null,
             goals: goals.map((goal) => ({ ...goal, id: goal.id.toString() })),
+            notes: notes.map((note) => ({ ...note, id: note.id.toString() })),
             pomodoroSettings: pomodoroSettings ?? null,
         });
     } catch (error) {

--- a/src/app/api/study-agent/me/study-goals/route.ts
+++ b/src/app/api/study-agent/me/study-goals/route.ts
@@ -4,6 +4,7 @@ import { and, eq } from "drizzle-orm";
 
 import { db } from "~/server/db";
 import { studyAgentGoals } from "~/server/db/schema";
+import { resolveSessionForUser } from "~/server/study-agent/session";
 
 function mapGoal(goal: typeof studyAgentGoals.$inferSelect) {
     return {
@@ -12,19 +13,35 @@ function mapGoal(goal: typeof studyAgentGoals.$inferSelect) {
     };
 }
 
-export async function GET() {
+function parseSessionId(request: Request) {
+    const sessionIdParam = new URL(request.url).searchParams.get("sessionId");
+    const parsedSessionId = sessionIdParam ? Number(sessionIdParam) : undefined;
+    return Number.isNaN(parsedSessionId) ? undefined : parsedSessionId;
+}
+
+export async function GET(request: Request) {
     try {
         const { userId } = await auth();
         if (!userId) {
             return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
         }
 
+        const session = await resolveSessionForUser(userId, parseSessionId(request));
+        if (!session) {
+            return NextResponse.json({ error: "Session not found" }, { status: 404 });
+        }
+
         const goals = await db
             .select()
             .from(studyAgentGoals)
-            .where(eq(studyAgentGoals.userId, userId));
+            .where(
+                and(
+                    eq(studyAgentGoals.userId, userId),
+                    eq(studyAgentGoals.sessionId, session.id)
+                )
+            );
 
-        return NextResponse.json({ goals: goals.map(mapGoal) });
+        return NextResponse.json({ goals: goals.map(mapGoal), session });
     } catch (error) {
         console.error("Error fetching study goals", error);
         return NextResponse.json({ error: "Failed to load study goals" }, { status: 500 });
@@ -39,16 +56,32 @@ export async function POST(request: Request) {
         }
 
         const body = await request.json();
+        const session = await resolveSessionForUser(
+            userId,
+            body.sessionId ?? parseSessionId(request)
+        );
+
+        if (!session) {
+            return NextResponse.json({ error: "Session not found" }, { status: 404 });
+        }
 
         // Bulk replace goals if items array provided
         if (Array.isArray(body.items)) {
-            await db.delete(studyAgentGoals).where(eq(studyAgentGoals.userId, userId));
+            await db
+                .delete(studyAgentGoals)
+                .where(
+                    and(
+                        eq(studyAgentGoals.userId, userId),
+                        eq(studyAgentGoals.sessionId, session.id)
+                    )
+                );
 
             const inserted = await db
                 .insert(studyAgentGoals)
                 .values(
                     body.items.map((item: any) => ({
                         userId,
+                        sessionId: session.id,
                         title: item.title ?? "",
                         description: item.description ?? null,
                         materials: item.materials ?? [],
@@ -57,13 +90,14 @@ export async function POST(request: Request) {
                 )
                 .returning();
 
-            return NextResponse.json({ goals: inserted.map(mapGoal) }, { status: 201 });
+            return NextResponse.json({ goals: inserted.map(mapGoal), session }, { status: 201 });
         }
 
         const [created] = await db
             .insert(studyAgentGoals)
             .values({
                 userId,
+                sessionId: session.id,
                 title: body.title ?? "",
                 description: body.description ?? null,
                 materials: body.materials ?? [],
@@ -71,7 +105,7 @@ export async function POST(request: Request) {
             })
             .returning();
 
-        return NextResponse.json({ goal: mapGoal(created) }, { status: 201 });
+        return NextResponse.json({ goal: mapGoal(created), session }, { status: 201 });
     } catch (error) {
         console.error("Error saving study goals", error);
         return NextResponse.json({ error: "Failed to save study goals" }, { status: 500 });
@@ -90,6 +124,15 @@ export async function PUT(request: Request) {
             return NextResponse.json({ error: "Goal ID is required" }, { status: 400 });
         }
 
+        const session = await resolveSessionForUser(
+            userId,
+            body.sessionId ?? parseSessionId(request)
+        );
+
+        if (!session) {
+            return NextResponse.json({ error: "Session not found" }, { status: 404 });
+        }
+
         const [updated] = await db
             .update(studyAgentGoals)
             .set({
@@ -101,7 +144,8 @@ export async function PUT(request: Request) {
             .where(
                 and(
                     eq(studyAgentGoals.id, Number(body.id)),
-                    eq(studyAgentGoals.userId, userId)
+                    eq(studyAgentGoals.userId, userId),
+                    eq(studyAgentGoals.sessionId, session.id)
                 )
             )
             .returning();
@@ -110,7 +154,7 @@ export async function PUT(request: Request) {
             return NextResponse.json({ error: "Goal not found" }, { status: 404 });
         }
 
-        return NextResponse.json({ goal: mapGoal(updated) });
+        return NextResponse.json({ goal: mapGoal(updated), session });
     } catch (error) {
         console.error("Error updating study goal", error);
         return NextResponse.json({ error: "Failed to update study goal" }, { status: 500 });
@@ -129,12 +173,22 @@ export async function DELETE(request: Request) {
             return NextResponse.json({ error: "Goal ID is required" }, { status: 400 });
         }
 
+        const session = await resolveSessionForUser(
+            userId,
+            body.sessionId ?? parseSessionId(request)
+        );
+
+        if (!session) {
+            return NextResponse.json({ error: "Session not found" }, { status: 404 });
+        }
+
         await db
             .delete(studyAgentGoals)
             .where(
                 and(
                     eq(studyAgentGoals.id, Number(body.id)),
-                    eq(studyAgentGoals.userId, userId)
+                    eq(studyAgentGoals.userId, userId),
+                    eq(studyAgentGoals.sessionId, session.id)
                 )
             );
 

--- a/src/app/api/study-agent/me/study-goals/route.ts
+++ b/src/app/api/study-agent/me/study-goals/route.ts
@@ -1,0 +1,146 @@
+import { NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { and, eq } from "drizzle-orm";
+
+import { db } from "~/server/db";
+import { studyAgentGoals } from "~/server/db/schema";
+
+function mapGoal(goal: typeof studyAgentGoals.$inferSelect) {
+    return {
+        ...goal,
+        id: goal.id.toString(),
+    };
+}
+
+export async function GET() {
+    try {
+        const { userId } = await auth();
+        if (!userId) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+
+        const goals = await db
+            .select()
+            .from(studyAgentGoals)
+            .where(eq(studyAgentGoals.userId, userId));
+
+        return NextResponse.json({ goals: goals.map(mapGoal) });
+    } catch (error) {
+        console.error("Error fetching study goals", error);
+        return NextResponse.json({ error: "Failed to load study goals" }, { status: 500 });
+    }
+}
+
+export async function POST(request: Request) {
+    try {
+        const { userId } = await auth();
+        if (!userId) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+
+        const body = await request.json();
+
+        // Bulk replace goals if items array provided
+        if (Array.isArray(body.items)) {
+            await db.delete(studyAgentGoals).where(eq(studyAgentGoals.userId, userId));
+
+            const inserted = await db
+                .insert(studyAgentGoals)
+                .values(
+                    body.items.map((item: any) => ({
+                        userId,
+                        title: item.title ?? "",
+                        description: item.description ?? null,
+                        materials: item.materials ?? [],
+                        completed: Boolean(item.completed),
+                    }))
+                )
+                .returning();
+
+            return NextResponse.json({ goals: inserted.map(mapGoal) }, { status: 201 });
+        }
+
+        const [created] = await db
+            .insert(studyAgentGoals)
+            .values({
+                userId,
+                title: body.title ?? "",
+                description: body.description ?? null,
+                materials: body.materials ?? [],
+                completed: Boolean(body.completed),
+            })
+            .returning();
+
+        return NextResponse.json({ goal: mapGoal(created) }, { status: 201 });
+    } catch (error) {
+        console.error("Error saving study goals", error);
+        return NextResponse.json({ error: "Failed to save study goals" }, { status: 500 });
+    }
+}
+
+export async function PUT(request: Request) {
+    try {
+        const { userId } = await auth();
+        if (!userId) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+
+        const body = await request.json();
+        if (!body.id) {
+            return NextResponse.json({ error: "Goal ID is required" }, { status: 400 });
+        }
+
+        const [updated] = await db
+            .update(studyAgentGoals)
+            .set({
+                title: body.title,
+                description: body.description,
+                materials: body.materials,
+                completed: body.completed,
+            })
+            .where(
+                and(
+                    eq(studyAgentGoals.id, Number(body.id)),
+                    eq(studyAgentGoals.userId, userId)
+                )
+            )
+            .returning();
+
+        if (!updated) {
+            return NextResponse.json({ error: "Goal not found" }, { status: 404 });
+        }
+
+        return NextResponse.json({ goal: mapGoal(updated) });
+    } catch (error) {
+        console.error("Error updating study goal", error);
+        return NextResponse.json({ error: "Failed to update study goal" }, { status: 500 });
+    }
+}
+
+export async function DELETE(request: Request) {
+    try {
+        const { userId } = await auth();
+        if (!userId) {
+            return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+        }
+
+        const body = await request.json();
+        if (!body.id) {
+            return NextResponse.json({ error: "Goal ID is required" }, { status: 400 });
+        }
+
+        await db
+            .delete(studyAgentGoals)
+            .where(
+                and(
+                    eq(studyAgentGoals.id, Number(body.id)),
+                    eq(studyAgentGoals.userId, userId)
+                )
+            );
+
+        return NextResponse.json({ success: true });
+    } catch (error) {
+        console.error("Error deleting study goal", error);
+        return NextResponse.json({ error: "Failed to delete study goal" }, { status: 500 });
+    }
+}

--- a/src/app/employer/studyAgent/_components/OnboardingScreen.tsx
+++ b/src/app/employer/studyAgent/_components/OnboardingScreen.tsx
@@ -10,9 +10,10 @@ interface OnboardingScreenProps {
   documents: Document[];
   onComplete: (preferences: UserPreferences) => void;
   onUploadDocument: (file: File) => void;
+  errorMessage?: string | null;
 }
 
-export function OnboardingScreen({ documents, onComplete, onUploadDocument }: OnboardingScreenProps) {
+export function OnboardingScreen({ documents, onComplete, onUploadDocument, errorMessage }: OnboardingScreenProps) {
   const [step, setStep] = useState(1);
   const [selectedDocuments, setSelectedDocuments] = useState<string[]>([]);
   const [name, setName] = useState("");
@@ -144,6 +145,11 @@ export function OnboardingScreen({ documents, onComplete, onUploadDocument }: On
           <p className="text-white/80">
             Let&apos;s set up your personalized learning experience
           </p>
+          {errorMessage && (
+            <p className="mt-4 text-red-100 text-sm bg-red-500/30 inline-block px-3 py-2 rounded-lg">
+              {errorMessage}
+            </p>
+          )}
         </div>
 
         {/* Progress Steps */}

--- a/src/app/employer/studyAgent/_components/StudyBuddyPanel.tsx
+++ b/src/app/employer/studyAgent/_components/StudyBuddyPanel.tsx
@@ -31,6 +31,7 @@ interface StudyBuddyPanelProps {
   onDeleteNote: (noteId: string) => void;
   onToggleSidebar?: () => void;
   isDark?: boolean;
+  errorMessage?: string | null;
 }
 
 export function StudyBuddyPanel({
@@ -51,6 +52,7 @@ export function StudyBuddyPanel({
   onDeleteNote,
   onToggleSidebar,
   isDark = false,
+  errorMessage,
 }: StudyBuddyPanelProps) {
   void _selectedDocument; // Unused but required by interface
   const [isCreating, setIsCreating] = useState(false);
@@ -225,6 +227,11 @@ export function StudyBuddyPanel({
             <p className={`text-sm mb-3 ${isDark ? 'text-gray-400' : 'text-gray-600'}`}>
               Customize your learning journey
             </p>
+            {errorMessage && (
+              <p className="mb-3 text-sm text-red-600 bg-red-50 border border-red-200 rounded-md p-2">
+                {errorMessage}
+              </p>
+            )}
             <Button
               onClick={handleStartCreate}
               className="w-full bg-blue-600 hover:bg-blue-700"

--- a/src/server/db/schema/study-agent.ts
+++ b/src/server/db/schema/study-agent.ts
@@ -1,0 +1,108 @@
+
+import { relations, sql } from "drizzle-orm";
+import type { InferSelectModel } from "drizzle-orm";
+import { boolean, index, integer, jsonb, serial, text, timestamp, varchar } from "drizzle-orm/pg-core";
+
+import { pgTable } from "./helpers";
+
+export const studyAgentProfile = pgTable(
+    "study_agent_profile",
+    {
+        id: serial("id").primaryKey(),
+        userId: varchar("user_id", { length: 256 }).notNull().unique(),
+        name: text("name"),
+        grade: text("grade"),
+        gender: text("gender"),
+        fieldOfStudy: text("field_of_study"),
+        createdAt: timestamp("created_at", { withTimezone: true })
+            .default(sql`CURRENT_TIMESTAMP`)
+            .notNull(),
+        updatedAt: timestamp("updated_at", { withTimezone: true }).$onUpdate(
+            () => new Date()
+        ),
+    },
+    (table) => ({
+        userIdx: index("study_agent_profile_user_idx").on(table.userId),
+    })
+);
+
+export const studyAgentPreferences = pgTable(
+    "study_agent_preferences",
+    {
+        id: serial("id").primaryKey(),
+        userId: varchar("user_id", { length: 256 }).notNull().unique(),
+        preferences: jsonb("preferences").notNull().default({}),
+        createdAt: timestamp("created_at", { withTimezone: true })
+            .default(sql`CURRENT_TIMESTAMP`)
+            .notNull(),
+        updatedAt: timestamp("updated_at", { withTimezone: true }).$onUpdate(
+            () => new Date()
+        ),
+    },
+    (table) => ({
+        preferencesUserIdx: index("study_agent_preferences_user_idx").on(table.userId),
+    })
+);
+
+export const studyAgentGoals = pgTable(
+    "study_agent_goals",
+    {
+        id: serial("id").primaryKey(),
+        userId: varchar("user_id", { length: 256 }).notNull(),
+        title: text("title").notNull(),
+        description: text("description"),
+        materials: text("materials").array().default([]),
+        completed: boolean("completed").notNull().default(false),
+        createdAt: timestamp("created_at", { withTimezone: true })
+            .default(sql`CURRENT_TIMESTAMP`)
+            .notNull(),
+        updatedAt: timestamp("updated_at", { withTimezone: true }).$onUpdate(
+            () => new Date()
+        ),
+    },
+    (table) => ({
+        goalsUserIdx: index("study_agent_goals_user_idx").on(table.userId),
+    })
+);
+
+export const studyAgentPomodoroSettings = pgTable(
+    "study_agent_pomodoro_settings",
+    {
+        id: serial("id").primaryKey(),
+        userId: varchar("user_id", { length: 256 }).notNull().unique(),
+        focusMinutes: integer("focus_minutes").notNull().default(25),
+        shortBreakMinutes: integer("short_break_minutes").notNull().default(5),
+        longBreakMinutes: integer("long_break_minutes").notNull().default(15),
+        sessionsBeforeLongBreak: integer("sessions_before_long_break")
+            .notNull()
+            .default(4),
+        autoStartBreaks: boolean("auto_start_breaks").notNull().default(false),
+        autoStartPomodoros: boolean("auto_start_pomodoros").notNull().default(false),
+        createdAt: timestamp("created_at", { withTimezone: true })
+            .default(sql`CURRENT_TIMESTAMP`)
+            .notNull(),
+        updatedAt: timestamp("updated_at", { withTimezone: true }).$onUpdate(
+            () => new Date()
+        ),
+    },
+    (table) => ({
+        pomodoroUserIdx: index("study_agent_pomodoro_settings_user_idx").on(table.userId),
+    })
+);
+
+export const studyAgentProfileRelations = relations(studyAgentProfile, ({ one, many }) => ({
+    preferences: one(studyAgentPreferences, {
+        fields: [studyAgentProfile.userId],
+        references: [studyAgentPreferences.userId],
+    }),
+    goals: many(studyAgentGoals),
+    pomodoroSettings: one(studyAgentPomodoroSettings, {
+        fields: [studyAgentProfile.userId],
+        references: [studyAgentPomodoroSettings.userId],
+    }),
+}));
+
+export type StudyAgentGoal = InferSelectModel<typeof studyAgentGoals>;
+export type StudyAgentProfile = InferSelectModel<typeof studyAgentProfile>;
+export type StudyAgentPreferences = InferSelectModel<typeof studyAgentPreferences>;
+export type StudyAgentPomodoroSettings = InferSelectModel<typeof studyAgentPomodoroSettings>;

--- a/src/server/study-agent/session.ts
+++ b/src/server/study-agent/session.ts
@@ -1,0 +1,40 @@
+import { and, asc, eq } from "drizzle-orm";
+
+import { db } from "../db";
+import { studyAgentSessions } from "../db/schema";
+
+export async function resolveSessionForUser(
+    userId: string,
+    sessionId?: number | null
+) {
+    if (sessionId) {
+        const [session] = await db
+            .select()
+            .from(studyAgentSessions)
+            .where(
+                and(
+                    eq(studyAgentSessions.id, sessionId),
+                    eq(studyAgentSessions.userId, userId)
+                )
+            );
+
+        return session ?? null;
+    }
+
+    const [existing] = await db
+        .select()
+        .from(studyAgentSessions)
+        .where(eq(studyAgentSessions.userId, userId))
+        .orderBy(asc(studyAgentSessions.id));
+
+    if (existing) {
+        return existing;
+    }
+
+    const [created] = await db
+        .insert(studyAgentSessions)
+        .values({ userId, name: "Default Session" })
+        .returning();
+
+    return created;
+}


### PR DESCRIPTION
## Summary
- add Clerk-scoped API routes for study agent profile, preferences, goals, and pomodoro settings with database persistence
- define study agent schema tables to store user profile details, preferences, study goals, and timer settings
- connect the study agent frontend flows to the new endpoints, persisting onboarding data, study plan edits, and pomodoro settings with error handling

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6945b9c8957883328ce2d73d9089de1b)