### PR TITLE
Align pomodoro timer with session links

### DIFF
--- a/src/app/api/study-agent/agentic/tools/pomodoro-timer.ts
+++ b/src/app/api/study-agent/agentic/tools/pomodoro-timer.ts
@@ -111,7 +111,9 @@ function formatTimeRemaining(endsAt: Date): string {
 /**
  * Manage Pomodoro timer
  */
-export async function managePomodoro(input: PomodoroInput & { userId: string }): Promise<{
+export async function managePomodoro(
+    input: PomodoroInput & { userId: string; sessionId?: string | number }
+): Promise<{
     success: boolean;
     session?: PomodoroSession;
     message: string;
@@ -119,8 +121,12 @@ export async function managePomodoro(input: PomodoroInput & { userId: string }):
     timeRemaining?: string;
     encouragement?: string;
 }> {
+    const parsedSessionId = input.sessionId ? Number(input.sessionId) : undefined;
     const now = new Date();
-    const session = await resolveSessionForUser(input.userId);
+    const session = await resolveSessionForUser(
+        input.userId,
+        Number.isNaN(parsedSessionId) ? undefined : parsedSessionId
+    );
     if (!session) {
         return {
             success: false,
@@ -514,6 +520,7 @@ export const pomodoroTool = tool(
                 action: input.action,
                 userId: input.userId,
                 settings: input.settings,
+                sessionId: input.sessionId,
             });
 
             return JSON.stringify(result);

--- a/src/app/employer/studyAgent/_components/StudyBuddyPanel.tsx
+++ b/src/app/employer/studyAgent/_components/StudyBuddyPanel.tsx
@@ -18,6 +18,7 @@ interface StudyBuddyPanelProps {
   studyPlan: StudyPlanItem[];
   documents: Document[];
   notes: Note[];
+  sessionId?: number | null;
   selectedDocument: Document | null;
   onSendMessage: (content: string) => void;
   onEndCall?: () => void;
@@ -53,6 +54,7 @@ export function StudyBuddyPanel({
   onToggleSidebar,
   isDark = false,
   errorMessage,
+  sessionId,
 }: StudyBuddyPanelProps) {
   void _selectedDocument; // Unused but required by interface
   const [isCreating, setIsCreating] = useState(false);
@@ -427,7 +429,7 @@ export function StudyBuddyPanel({
               </p>
             </div>
             
-            <PomodoroTimer isDark={isDark} />
+            <PomodoroTimer isDark={isDark} sessionId={sessionId} />
           </div>
         </TabsContent>
 


### PR DESCRIPTION
## Summary
- thread pomodoro timer API calls through the active study session so timers persist with deep-linked sessions
- allow pomodoro sync and configuration routes to accept explicit session identifiers from the client
- pass session IDs from the study buddy panel to the timer component when rendering

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6946f80989308332bb53327ae08134a7)