### PR TITLE
read-only evidence collector command + tests, example snapshot, and handoff doc

### DIFF
--- a/apps/web/__tests__/founderWeeklyReview/collect-evidence.integration.test.ts
+++ b/apps/web/__tests__/founderWeeklyReview/collect-evidence.integration.test.ts
@@ -1,0 +1,200 @@
+import { sql } from "drizzle-orm";
+
+import { FounderWeeklyReviewEvidenceService } from "@launchstack/features/founder-weekly-review";
+
+import { createFounderWeeklyReviewTestDatabase } from "./testDb";
+
+// skip if no test db url provided
+const describeIfDatabase =
+    process.env.LAUNCHSTACK_TEST_DATABASE_URL ?? process.env.DATABASE_URL
+        ? describe
+        : describe.skip;
+
+type TestDatabase = Awaited<
+    ReturnType<typeof createFounderWeeklyReviewTestDatabase>
+>;
+type TestDb = TestDatabase["db"];
+
+const REPORTING_PERIOD = { start: "2026-02-16", end: "2026-02-22" } as const;
+
+function firstInsertedId(rows: unknown): bigint {
+    const [row] = rows as Array<{ id: number | string | bigint }>;
+    if (!row) {
+        throw new Error("Expected an inserted row with an id");
+    }
+    return BigInt(row.id);
+}
+
+async function insertCompany(db: TestDb, name: string): Promise<bigint> {
+    const rows = await db.execute(sql`
+        INSERT INTO "pdr_ai_v2_company" ("name", "numberOfEmployees")
+        VALUES (${name}, '5')
+        RETURNING "id"
+    `);
+    return firstInsertedId(rows);
+}
+
+async function insertDocument(
+    db: TestDb,
+    companyId: bigint,
+    category: string,
+    title: string
+): Promise<bigint> {
+    const rows = await db.execute(sql`
+        INSERT INTO "pdr_ai_v2_document" ("company_id", "url", "category", "title")
+        VALUES (${companyId}, ${"/api/files/1"}, ${category}, ${title})
+        RETURNING "id"
+    `);
+    return firstInsertedId(rows);
+}
+
+async function insertVersion(
+    db: TestDb,
+    documentId: bigint,
+    versionNumber: number,
+    createdAtIso: string,
+    changelog: string | null = null
+): Promise<bigint> {
+    const rows = await db.execute(sql`
+        INSERT INTO "pdr_ai_v2_document_versions"
+            ("document_id", "version_number", "url", "mime_type", "changelog", "created_at")
+        VALUES (${documentId}, ${versionNumber}, ${"/api/files/1"}, ${"application/pdf"}, ${changelog}, ${createdAtIso})
+        RETURNING "id"
+    `);
+    return firstInsertedId(rows);
+}
+
+async function insertChunk(
+    db: TestDb,
+    documentId: bigint,
+    versionId: bigint,
+    content: string
+): Promise<void> {
+    await db.execute(sql`
+        INSERT INTO "pdr_ai_v2_document_context_chunks"
+            ("document_id", "version_id", "content")
+        VALUES (${documentId}, ${versionId}, ${content})
+    `);
+}
+
+describeIfDatabase("FounderWeeklyReviewEvidenceService", () => {
+    let testDb: TestDatabase;
+    let service: FounderWeeklyReviewEvidenceService;
+
+    let companyA: bigint;
+    let companyB: bigint;
+    let emptyCompany: bigint;
+    let productDocA: bigint;
+    let feedbackDocA: bigint;
+    let docB: bigint;
+
+    let productV1: bigint;
+    let productV2: bigint;
+    let productV3: bigint;
+
+    let feedbackV1: bigint;
+    // company B's in-window doc version to check for company evidence isolation
+    let docBV1: bigint;
+
+    beforeAll(async () => {
+        testDb = await createFounderWeeklyReviewTestDatabase();
+        service = new FounderWeeklyReviewEvidenceService(testDb.db);
+
+        companyA = await insertCompany(testDb.db, "Alpha");
+        companyB = await insertCompany(testDb.db, "Beta");
+        emptyCompany = await insertCompany(testDb.db, "Empty");
+
+        productDocA = await insertDocument(testDb.db, companyA, "Product", "Alpha Product");
+        feedbackDocA = await insertDocument(testDb.db, companyA, "Customer Feedback", "Alpha Feedback");
+        docB = await insertDocument(testDb.db, companyB, "Product", "Beta Product");
+
+        productV1 = await insertVersion(testDb.db, productDocA, 1, "2026-02-17T10:00:00.000Z");
+        productV2 = await insertVersion(testDb.db, productDocA, 2, "2026-02-20T10:00:00.000Z", "Updated pricing");
+        productV3 = await insertVersion(testDb.db, productDocA, 3, "2026-02-25T10:00:00.000Z"); // outside of review window
+
+        // Company A customer-feedback doc: one in-window version with two citeable chunks.
+        feedbackV1 = await insertVersion(testDb.db, feedbackDocA, 1, "2026-02-18T10:00:00.000Z");
+        await insertChunk(testDb.db, feedbackDocA, feedbackV1, "Customers love the new pricing.");
+        await insertChunk(testDb.db, feedbackDocA, feedbackV1, "They want SSO next.");
+
+        // Company B: one in-window version that must never appear in Company A's snapshot.
+        docBV1 = await insertVersion(testDb.db, docB, 1, "2026-02-18T12:00:00.000Z");
+    });
+
+    afterAll(async () => {
+        await testDb?.close();
+    });
+
+    it("collects in-window evidence for the company and excludes out-of-window versions", async () => {
+        const snapshot = await service.collectFounderWeeklyReviewEvidence({
+            companyId: companyA,
+            reportingPeriod: REPORTING_PERIOD,
+            workspaceTimezone: "UTC",
+        });
+
+        const ids = snapshot.items.map((item) => item.sourceId);
+
+        // in-window product versions are present as document_change
+        expect(ids).toContain(`document_change:doc:${productDocA}:version:${productV1}`);
+        expect(ids).toContain(`document_change:doc:${productDocA}:version:${productV2}`);
+        expect(ids).not.toContain(`document_change:doc:${productDocA}:version:${productV3}`);
+    });
+
+    it("creates customer_feedback evidence from document-context chunks", async () => {
+        const snapshot = await service.collectFounderWeeklyReviewEvidence({
+            companyId: companyA,
+            reportingPeriod: REPORTING_PERIOD,
+            workspaceTimezone: "UTC",
+        });
+
+        const feedback = snapshot.items.filter((item) => item.sourceType === "customer_feedback");
+        expect(feedback).toHaveLength(2);
+        expect(feedback.every((item) =>
+            item.sourceId.startsWith(`customer_feedback:doc:${feedbackDocA}:version:${feedbackV1}:section:`)
+        )).toBe(true);
+        expect(feedback.map((item) => item.excerpt).sort()).toEqual([
+            "Customers love the new pricing.",
+            "They want SSO next.",
+        ]);
+    });
+
+    it("never leaks another company's evidence", async () => {
+        const snapshot = await service.collectFounderWeeklyReviewEvidence({
+            companyId: companyA,
+            reportingPeriod: REPORTING_PERIOD,
+            workspaceTimezone: "UTC",
+        });
+
+        const ids = snapshot.items.map((item) => item.sourceId);
+        expect(ids.some((id) => id.includes(`doc:${docB}:`))).toBe(false);
+        expect(ids.some((id) => id.includes(`version:${docBV1}`))).toBe(false);
+    });
+
+    it("returns a valid empty snapshot for a company with no evidence", async () => {
+        const snapshot = await service.collectFounderWeeklyReviewEvidence({
+            companyId: emptyCompany,
+            reportingPeriod: REPORTING_PERIOD,
+            workspaceTimezone: "UTC",
+        });
+
+        expect(snapshot.items).toEqual([]);
+        expect(snapshot.schemaVersion).toBeTruthy();
+    });
+
+    it("never mislabels founder_context as customer_feedback", async () => {
+        const snapshot = await service.collectFounderWeeklyReviewEvidence({
+            companyId: emptyCompany,
+            reportingPeriod: REPORTING_PERIOD,
+            workspaceTimezone: "UTC",
+            founderContext: "We are blocked on the payments migration.",
+            actor: { externalUserId: "user_founder" },
+            contextEntryId: "cli:test:2026-02-16:2026-02-22",
+        });
+
+        const founder = snapshot.items.filter((item) => item.sourceType === "founder_context");
+        expect(founder).toHaveLength(1);
+        expect(founder[0]?.excerpt).toBe("We are blocked on the payments migration.");
+
+        expect(snapshot.items.some((item) => item.sourceType === "customer_feedback")).toBe(false);
+    });
+});

--- a/apps/web/__tests__/founderWeeklyReview/collect-evidence.unit.test.ts
+++ b/apps/web/__tests__/founderWeeklyReview/collect-evidence.unit.test.ts
@@ -1,0 +1,132 @@
+import { assertLocalDatabaseUrl, parseCollectEvidenceArgs } from "../../scripts/collect-founder-weekly-review-evidence.lib";
+
+const BASE_ARGS = [
+    "--company",
+    "5",
+    "--start",
+    "2026-02-16",
+    "--end",
+    "2026-02-22",
+    "--tz",
+    "UTC",
+];
+
+describe("parseCollectEvidenceArgs", () => {
+    it("parses the minimal required flags", () => {
+        const input = parseCollectEvidenceArgs(BASE_ARGS);
+        expect(input.companyId).toBe(5n);
+        expect(input.reportingPeriod).toEqual({ start: "2026-02-16", end: "2026-02-22" });
+        expect(input.workspaceTimezone).toBe("UTC");
+        expect(input.founderContext).toBeUndefined();
+        expect(input.actor).toBeUndefined();
+        expect(input.contextEntryId).toBeUndefined();
+        expect(input.out).toBeUndefined();
+    });
+
+    it("attaches founder context, actor, and a stable contextEntryId together", () => {
+        const input = parseCollectEvidenceArgs([
+            ...BASE_ARGS,
+            "--founder-context",
+            "Shipped billing v2",
+            "--actor",
+            "user_123",
+            "--out",
+            "snap.json",
+        ]);
+        expect(input.founderContext).toBe("Shipped billing v2");
+        expect(input.actor).toEqual({ externalUserId: "user_123" });
+        expect(input.contextEntryId).toBe("cli:5:2026-02-16:2026-02-22");
+        expect(input.out).toBe("snap.json");
+    });
+
+    it("throws when --founder-context is given without --actor", () => {
+        expect(() =>
+            parseCollectEvidenceArgs([...BASE_ARGS, "--founder-context", "note"])
+        ).toThrow(/--founder-context requires --actor/);
+    });
+
+    it.each([
+        ["company", ["--start", "2026-02-16", "--end", "2026-02-22", "--tz", "UTC"]],
+        ["start", ["--company", "5", "--end", "2026-02-22", "--tz", "UTC"]],
+        ["end", ["--company", "5", "--start", "2026-02-16", "--tz", "UTC"]],
+        ["tz", ["--company", "5", "--start", "2026-02-16", "--end", "2026-02-22"]],
+    ])("throws when required flag --%s is missing", (flag, args) => {
+        expect(() => parseCollectEvidenceArgs(args)).toThrow(
+            new RegExp(`Missing required flag --${flag}`)
+        );
+    });
+
+    it("rejects a non-integer company id", () => {
+        expect(() =>
+            parseCollectEvidenceArgs(["--company", "abc", "--start", "2026-02-16", "--end", "2026-02-22", "--tz", "UTC"])
+        ).toThrow(/must be an integer company id/);
+    });
+
+    it("rejects a non-positive company id", () => {
+        expect(() =>
+            parseCollectEvidenceArgs(["--company", "0", "--start", "2026-02-16", "--end", "2026-02-22", "--tz", "UTC"])
+        ).toThrow(/must be a positive company id/);
+    });
+
+    it("rejects a malformed date shape", () => {
+        expect(() =>
+            parseCollectEvidenceArgs(["--company", "5", "--start", "2026/02/16", "--end", "2026-02-22", "--tz", "UTC"])
+        ).toThrow(/must be a YYYY-MM-DD date/);
+    });
+
+    it("rejects a shaped-but-impossible calendar date", () => {
+        expect(() =>
+            parseCollectEvidenceArgs(["--company", "5", "--start", "2026-02-30", "--end", "2026-03-05", "--tz", "UTC"])
+        ).toThrow(/must be a real calendar date/);
+    });
+
+    it("allows start equal to end (single-day period)", () => {
+        const input = parseCollectEvidenceArgs([
+            "--company", "5", "--start", "2026-02-16", "--end", "2026-02-16", "--tz", "UTC",
+        ]);
+        expect(input.reportingPeriod).toEqual({ start: "2026-02-16", end: "2026-02-16" });
+    });
+
+    it("throws when start is after end", () => {
+        expect(() =>
+            parseCollectEvidenceArgs(["--company", "5", "--start", "2026-02-22", "--end", "2026-02-16", "--tz", "UTC"])
+        ).toThrow(/must be before or the same as/);
+    });
+});
+
+describe("assertLocalDatabaseUrl", () => {
+    it("accepts a localhost url", () => {
+        expect(() =>
+            assertLocalDatabaseUrl("postgresql://user:pass@localhost:5433/launchstack")
+        ).not.toThrow();
+    });
+
+    it("accepts a 127.0.0.1 url", () => {
+        expect(() =>
+            assertLocalDatabaseUrl("postgres://127.0.0.1:5432/db")
+        ).not.toThrow();
+    });
+
+    it("rejects a remote (non-local) url", () => {
+        expect(() =>
+            assertLocalDatabaseUrl("postgresql://user:pass@ep-fake.neon.tech/db")
+        ).toThrow(/non-local database/);
+    });
+
+    it("rejects when NODE_ENV is production, even for a local db url", () => {
+        const env = process.env as Record<string, string | undefined>;
+        const previous = env.NODE_ENV;
+        env.NODE_ENV = "production";
+        try {
+            expect(() =>
+                assertLocalDatabaseUrl("postgresql://localhost:5433/db")
+            ).toThrow(/NODE_ENV=production/);
+        } finally {
+            if (previous === undefined) {
+                delete env.NODE_ENV;
+            } else {
+                env.NODE_ENV = previous;
+            }
+        }
+    });
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,6 +14,7 @@
     "db:backfill:note-embeddings": "tsx ./scripts/backfill-note-embeddings.ts",
     "db:backfill:embedding-credentials": "tsx ./scripts/backfill-embedding-credentials.ts",
     "db:studio": "drizzle-kit studio",
+    "fwr:collect-evidence": "tsx ./scripts/collect-founder-weekly-review-evidence.ts",
     "dev": "concurrently --names next,inngest --prefix-colors blue,magenta \"next dev --turbo\" \"pnpm dlx inngest-cli@latest dev -u http://localhost:3000/api/inngest\"",
     "dev:next": "next dev --turbo",
     "lint": "eslint .",

--- a/apps/web/scripts/collect-founder-weekly-review-evidence.lib.ts
+++ b/apps/web/scripts/collect-founder-weekly-review-evidence.lib.ts
@@ -1,0 +1,112 @@
+import { parseArgs } from "node:util";
+
+export interface CollectEvidenceInput {
+    companyId: bigint;
+    reportingPeriod: { start: string; end: string };
+    workspaceTimezone: string;
+    // optional founder-entered context, if included then actor is required
+    founderContext?: string;
+    actor?: { externalUserId: string };
+    contextEntryId?: string;
+    // optional path to write the snapshot to
+    out?: string;
+}
+
+// only accepts local db url
+const LOCAL_DATABASE_URL_PATTERN =
+    /^postgres(?:ql)?:\/\/(?:[^@]+@)?(?:127\.0\.0\.1|localhost)(?::\d+)?\//i;
+
+// exclude the invalid url from error message as it contains credentials
+export function assertLocalDatabaseUrl(url: string): void {
+    if (process.env.NODE_ENV === "production") {
+        throw new Error("Refusing to run the evidence collector command with NODE_ENV=production.");
+    }
+    if (!LOCAL_DATABASE_URL_PATTERN.test(url)) {
+        throw new Error("Refusing non-local database. Use local instance to run this read-only command.");
+    }
+}
+
+function requireFlag(value: string | undefined, name: string): string {
+    if (value === undefined || value === "") {
+        throw new Error(`Missing required flag --${name}.`);
+    }
+    return value;
+}
+
+function assertIsoDate(value: string, name: string): void {
+    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+    if (!match) {
+        throw new Error(`--${name} must be a YYYY-MM-DD date, received "${value}".`);
+    }
+
+    // check shape of inputted date and whether or not is actually valid date
+    const year = Number(match[1]);
+    const month = Number(match[2]);
+    const day = Number(match[3]);
+    const date = new Date(Date.UTC(year, month - 1, day));
+    if (date.getUTCFullYear() !== year || date.getUTCMonth() !== month - 1 || date.getUTCDate() !== day) {
+        throw new Error(`--${name} must be a real calendar date, received "${value}".`);
+    }
+}
+
+export function parseCollectEvidenceArgs(argv: string[]): CollectEvidenceInput {
+    const { values } = parseArgs({
+        args: argv,
+        allowPositionals: false,
+        options: {
+            company: { type: "string" },
+            start: { type: "string" },
+            end: { type: "string" },
+            tz: { type: "string" },
+            "founder-context": { type: "string" },
+            actor: { type: "string" },
+            out: { type: "string" },
+        },
+    });
+
+    const company = requireFlag(values.company, "company");
+    const start = requireFlag(values.start, "start");
+    const end = requireFlag(values.end, "end");
+    const tz = requireFlag(values.tz, "tz");
+
+    let companyId: bigint;
+    try {
+        companyId = BigInt(company);
+    } catch {
+        throw new Error(`--company must be an integer company id, received "${company}".`);
+    }
+    if (companyId <= 0n) {
+        throw new Error(`--company must be a positive company id, received "${company}".`);
+    }
+
+    assertIsoDate(start, "start");
+    assertIsoDate(end, "end");
+
+    if (start > end) {
+        throw new Error(`--start (${start}) must be before or the same as --end (${end}).`);
+    }
+
+    const founderContext = values["founder-context"];
+    const actorId = values.actor;
+    if (founderContext !== undefined && actorId === undefined) {
+        throw new Error("--founder-context requires --actor <externalUserId>.");
+    }
+
+    const input: CollectEvidenceInput = {
+        companyId,
+        reportingPeriod: { start, end },
+        workspaceTimezone: tz,
+    };
+
+    if (values.out !== undefined) {
+        input.out = values.out;
+    }
+
+    if (founderContext !== undefined && actorId !== undefined) {
+        input.founderContext = founderContext;
+        input.actor = { externalUserId: actorId };
+        input.contextEntryId = `cli:${companyId}:${start}:${end}`;
+    }
+
+    return input;
+}

--- a/apps/web/scripts/collect-founder-weekly-review-evidence.ts
+++ b/apps/web/scripts/collect-founder-weekly-review-evidence.ts
@@ -1,0 +1,113 @@
+import { parseArgs } from "node:util";
+
+export interface CollectEvidenceInput {
+    companyId: bigint;
+    reportingPeriod: { start: string; end: string };
+    workspaceTimezone: string;
+    // optional founder-entered context, if included then actor is required
+    founderContext?: string;
+    actor?: { externalUserId: string };
+    contextEntryId?: string;
+    // optional path to write the snapshot to
+    out?: string;
+}
+
+// only accepts local db url
+const LOCAL_DATABASE_URL_PATTERN =
+    /^postgres(?:ql)?:\/\/(?:[^@]+@)?(?:127\.0\.0\.1|localhost)(?::\d+)?\//i;
+
+
+// exclude the invalid url from error message as it contains credentials
+export function assertLocalDatabaseUrl(url: string): void {
+    if (process.env.NODE_ENV === "production") {
+        throw new Error("Refusing to run the evidence collector command with NODE_ENV=production.");
+    }
+    if (!LOCAL_DATABASE_URL_PATTERN.test(url)) {
+        throw new Error("Refusing non-local database. Use local instance to run this read-only command.");
+    }
+}
+
+function requireFlag(value: string | undefined, name: string): string {
+    if (value === undefined || value === "") {
+        throw new Error(`Missing required flag --${name}.`);
+    }
+    return value;
+}
+
+function assertIsoDate(value: string, name: string): void {
+    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+    if (!match) {
+        throw new Error(`--${name} must be a YYYY-MM-DD date, received "${value}".`);
+    }
+
+    // check shape of inputted date and whether or not is actually valid date
+    const year = Number(match[1]);
+    const month = Number(match[2]);
+    const day = Number(match[3]);
+    const date = new Date(Date.UTC(year, month - 1, day));
+    if (date.getUTCFullYear() !== year || date.getUTCMonth() !== month - 1 || date.getUTCDate() !== day) {
+        throw new Error(`--${name} must be a real calendar date, received "${value}".`);
+    }
+}
+
+export function parseCollectEvidenceArgs(argv: string[]): CollectEvidenceInput {
+    const { values } = parseArgs({
+        args: argv,
+        allowPositionals: false,
+        options: {
+            company: { type: "string" },
+            start: { type: "string" },
+            end: { type: "string" },
+            tz: { type: "string" },
+            "founder-context": { type: "string" },
+            actor: { type: "string" },
+            out: { type: "string" },
+        },
+    });
+
+    const company = requireFlag(values.company, "company");
+    const start = requireFlag(values.start, "start");
+    const end = requireFlag(values.end, "end");
+    const tz = requireFlag(values.tz, "tz");
+
+    let companyId: bigint;
+    try {
+        companyId = BigInt(company);
+    } catch {
+        throw new Error(`--company must be an integer company id, received "${company}".`);
+    }
+    if (companyId <= 0n) {
+        throw new Error(`--company must be a positive company id, received "${company}".`);
+    }
+
+    assertIsoDate(start, "start");
+    assertIsoDate(end, "end");
+
+    if (start > end) {
+        throw new Error(`--start (${start}) must be before or the same as --end (${end}).`);
+    }
+
+    const founderContext = values["founder-context"];
+    const actorId = values.actor;
+    if (founderContext !== undefined && actorId === undefined) {
+        throw new Error("--founder-context requires --actor <externalUserId>.");
+    }
+
+    const input: CollectEvidenceInput = {
+        companyId,
+        reportingPeriod: { start, end },
+        workspaceTimezone: tz,
+    };
+
+    if (values.out !== undefined) {
+        input.out = values.out;
+    }
+    
+    if (founderContext !== undefined && actorId !== undefined) {
+        input.founderContext = founderContext;
+        input.actor = { externalUserId: actorId };
+        input.contextEntryId = `cli:${companyId}:${start}:${end}`;
+    }
+    
+    return input;
+}

--- a/apps/web/scripts/collect-founder-weekly-review-evidence.ts
+++ b/apps/web/scripts/collect-founder-weekly-review-evidence.ts
@@ -1,4 +1,15 @@
+// Loads .env into process.env before anything reads DATABASE_URL. Must be first.
+import "dotenv/config";
+
+import { writeFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
 import { parseArgs } from "node:util";
+
+import postgres from "postgres";
+import { drizzle } from "drizzle-orm/postgres-js";
+
+import * as coreSchema from "@launchstack/core/db/schema";
+import { FounderWeeklyReviewEvidenceService } from "@launchstack/features/founder-weekly-review";
 
 export interface CollectEvidenceInput {
     companyId: bigint;
@@ -108,6 +119,49 @@ export function parseCollectEvidenceArgs(argv: string[]): CollectEvidenceInput {
         input.actor = { externalUserId: actorId };
         input.contextEntryId = `cli:${companyId}:${start}:${end}`;
     }
-    
+
     return input;
+}
+
+async function main(): Promise<void> {
+    const input = parseCollectEvidenceArgs(process.argv.slice(2));
+
+    const url = process.env.LAUNCHSTACK_TEST_DATABASE_URL ?? process.env.DATABASE_URL ?? "";
+    assertLocalDatabaseUrl(url);
+
+    const client = postgres(url, { max: 1 });
+
+    try {
+        const db = drizzle(client, { schema: coreSchema });
+        const service = new FounderWeeklyReviewEvidenceService(db);
+
+        const snapshot = await service.collectFounderWeeklyReviewEvidence({
+            companyId: input.companyId,
+            reportingPeriod: input.reportingPeriod,
+            workspaceTimezone: input.workspaceTimezone,
+            founderContext: input.founderContext,
+            actor: input.actor,
+            contextEntryId: input.contextEntryId,
+        });
+
+        const json = JSON.stringify(snapshot, null, 2);
+        console.log(json);
+
+        if (input.out) {
+            await writeFile(input.out, json, "utf8");
+
+            // write to stderror to isolate from stdout json output
+            console.error(`Wrote snapshot to ${input.out}`);
+        }
+    } finally {
+        await client.end({ timeout: 5 });
+    }
+}
+
+// only execute main when running directly through command, avoid running if just being imported
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    main().catch((error: unknown) => {
+        console.error(error instanceof Error ? error.message : error);
+        process.exitCode = 1;
+    });
 }

--- a/apps/web/scripts/collect-founder-weekly-review-evidence.ts
+++ b/apps/web/scripts/collect-founder-weekly-review-evidence.ts
@@ -2,8 +2,6 @@
 import "dotenv/config";
 
 import { writeFile } from "node:fs/promises";
-import { pathToFileURL } from "node:url";
-import { parseArgs } from "node:util";
 
 import postgres from "postgres";
 import { drizzle } from "drizzle-orm/postgres-js";
@@ -11,117 +9,7 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import * as coreSchema from "@launchstack/core/db/schema";
 import { FounderWeeklyReviewEvidenceService } from "@launchstack/features/founder-weekly-review";
 
-export interface CollectEvidenceInput {
-    companyId: bigint;
-    reportingPeriod: { start: string; end: string };
-    workspaceTimezone: string;
-    // optional founder-entered context, if included then actor is required
-    founderContext?: string;
-    actor?: { externalUserId: string };
-    contextEntryId?: string;
-    // optional path to write the snapshot to
-    out?: string;
-}
-
-// only accepts local db url
-const LOCAL_DATABASE_URL_PATTERN =
-    /^postgres(?:ql)?:\/\/(?:[^@]+@)?(?:127\.0\.0\.1|localhost)(?::\d+)?\//i;
-
-
-// exclude the invalid url from error message as it contains credentials
-export function assertLocalDatabaseUrl(url: string): void {
-    if (process.env.NODE_ENV === "production") {
-        throw new Error("Refusing to run the evidence collector command with NODE_ENV=production.");
-    }
-    if (!LOCAL_DATABASE_URL_PATTERN.test(url)) {
-        throw new Error("Refusing non-local database. Use local instance to run this read-only command.");
-    }
-}
-
-function requireFlag(value: string | undefined, name: string): string {
-    if (value === undefined || value === "") {
-        throw new Error(`Missing required flag --${name}.`);
-    }
-    return value;
-}
-
-function assertIsoDate(value: string, name: string): void {
-    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
-    if (!match) {
-        throw new Error(`--${name} must be a YYYY-MM-DD date, received "${value}".`);
-    }
-
-    // check shape of inputted date and whether or not is actually valid date
-    const year = Number(match[1]);
-    const month = Number(match[2]);
-    const day = Number(match[3]);
-    const date = new Date(Date.UTC(year, month - 1, day));
-    if (date.getUTCFullYear() !== year || date.getUTCMonth() !== month - 1 || date.getUTCDate() !== day) {
-        throw new Error(`--${name} must be a real calendar date, received "${value}".`);
-    }
-}
-
-export function parseCollectEvidenceArgs(argv: string[]): CollectEvidenceInput {
-    const { values } = parseArgs({
-        args: argv,
-        allowPositionals: false,
-        options: {
-            company: { type: "string" },
-            start: { type: "string" },
-            end: { type: "string" },
-            tz: { type: "string" },
-            "founder-context": { type: "string" },
-            actor: { type: "string" },
-            out: { type: "string" },
-        },
-    });
-
-    const company = requireFlag(values.company, "company");
-    const start = requireFlag(values.start, "start");
-    const end = requireFlag(values.end, "end");
-    const tz = requireFlag(values.tz, "tz");
-
-    let companyId: bigint;
-    try {
-        companyId = BigInt(company);
-    } catch {
-        throw new Error(`--company must be an integer company id, received "${company}".`);
-    }
-    if (companyId <= 0n) {
-        throw new Error(`--company must be a positive company id, received "${company}".`);
-    }
-
-    assertIsoDate(start, "start");
-    assertIsoDate(end, "end");
-
-    if (start > end) {
-        throw new Error(`--start (${start}) must be before or the same as --end (${end}).`);
-    }
-
-    const founderContext = values["founder-context"];
-    const actorId = values.actor;
-    if (founderContext !== undefined && actorId === undefined) {
-        throw new Error("--founder-context requires --actor <externalUserId>.");
-    }
-
-    const input: CollectEvidenceInput = {
-        companyId,
-        reportingPeriod: { start, end },
-        workspaceTimezone: tz,
-    };
-
-    if (values.out !== undefined) {
-        input.out = values.out;
-    }
-    
-    if (founderContext !== undefined && actorId !== undefined) {
-        input.founderContext = founderContext;
-        input.actor = { externalUserId: actorId };
-        input.contextEntryId = `cli:${companyId}:${start}:${end}`;
-    }
-
-    return input;
-}
+import { assertLocalDatabaseUrl, parseCollectEvidenceArgs } from "./collect-founder-weekly-review-evidence.lib";
 
 async function main(): Promise<void> {
     const input = parseCollectEvidenceArgs(process.argv.slice(2));
@@ -150,7 +38,7 @@ async function main(): Promise<void> {
         if (input.out) {
             await writeFile(input.out, json, "utf8");
 
-            // write to stderror to isolate from stdout json output
+            // write to stderr to isolate from stdout json output
             console.error(`Wrote snapshot to ${input.out}`);
         }
     } finally {
@@ -158,10 +46,7 @@ async function main(): Promise<void> {
     }
 }
 
-// only execute main when running directly through command, avoid running if just being imported
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-    main().catch((error: unknown) => {
-        console.error(error instanceof Error ? error.message : error);
-        process.exitCode = 1;
-    });
-}
+main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+});

--- a/apps/web/scripts/examples/founder-weekly-review-evidence.example.json
+++ b/apps/web/scripts/examples/founder-weekly-review-evidence.example.json
@@ -1,0 +1,142 @@
+{
+  "schemaVersion": "founder-weekly-review-evidence/v1",
+  "capturedAt": "2026-08-01T22:34:54.816Z",
+  "reportingPeriod": {
+    "start": "2026-07-20",
+    "end": "2026-07-26"
+  },
+  "workspaceTimezone": "America/New_York",
+  "items": [
+    {
+      "sourceType": "founder_context",
+      "sourceId": "founder_context:entry:cli:2:2026-07-20:2026-07-26",
+      "title": "Founder context",
+      "excerpt": "This week focused on pricing clarity and onboarding. Main blocker: choosing an SSO vendor before we can ship SAML.",
+      "metadata": {
+        "enteredBy": "demo-founder",
+        "provenance": "request_time_founder_input",
+        "excerptTruncated": false
+      }
+    },
+    {
+      "sourceType": "document_change",
+      "sourceId": "document_change:doc:2:version:2",
+      "title": "Pricing Page",
+      "sourceTimestamp": "2026-07-21T14:00:00.000Z",
+      "excerpt": "Reworked pricing tiers; added an annual billing option.",
+      "workspaceDeepLink": "/employer/documents/viewer?docId=2",
+      "metadata": {
+        "documentId": "2",
+        "documentVersionId": 2,
+        "versionNumber": 1,
+        "documentCategory": "Product",
+        "uploadedBy": "demo-user",
+        "hasChangelog": true,
+        "changelogTruncated": false
+      }
+    },
+    {
+      "sourceType": "document_change",
+      "sourceId": "document_change:doc:3:version:5",
+      "title": "Onboarding Guide",
+      "sourceTimestamp": "2026-07-22T09:15:00.000Z",
+      "excerpt": "Added an SSO / SAML setup walkthrough.",
+      "workspaceDeepLink": "/employer/documents/viewer?docId=3",
+      "metadata": {
+        "documentId": "3",
+        "documentVersionId": 5,
+        "versionNumber": 1,
+        "documentCategory": "Product",
+        "uploadedBy": "demo-user",
+        "hasChangelog": true,
+        "changelogTruncated": false
+      }
+    },
+    {
+      "sourceType": "customer_feedback",
+      "sourceId": "customer_feedback:doc:4:version:6:section:1",
+      "title": "Customer Feedback - July",
+      "sourceTimestamp": "2026-07-22T11:00:00.000Z",
+      "excerpt": "Several customers asked for annual billing instead of monthly-only.",
+      "workspaceDeepLink": "/employer/documents/viewer?docId=4",
+      "metadata": {
+        "documentId": "4",
+        "documentVersionId": 6,
+        "sectionId": 1,
+        "versionNumber": 1,
+        "documentCategory": "Customer Feedback",
+        "pageNumber": 1,
+        "excerptTruncated": false
+      }
+    },
+    {
+      "sourceType": "customer_feedback",
+      "sourceId": "customer_feedback:doc:4:version:6:section:2",
+      "title": "Customer Feedback - July",
+      "sourceTimestamp": "2026-07-22T11:00:00.000Z",
+      "excerpt": "A user said the enterprise tier pricing felt confusing to compare.",
+      "workspaceDeepLink": "/employer/documents/viewer?docId=4",
+      "metadata": {
+        "documentId": "4",
+        "documentVersionId": 6,
+        "sectionId": 2,
+        "versionNumber": 1,
+        "documentCategory": "Customer Feedback",
+        "pageNumber": 1,
+        "excerptTruncated": false
+      }
+    },
+    {
+      "sourceType": "customer_feedback",
+      "sourceId": "customer_feedback:doc:4:version:6:section:3",
+      "title": "Customer Feedback - July",
+      "sourceTimestamp": "2026-07-22T11:00:00.000Z",
+      "excerpt": "Multiple requests for SSO / SAML so larger teams can roll out access.",
+      "workspaceDeepLink": "/employer/documents/viewer?docId=4",
+      "metadata": {
+        "documentId": "4",
+        "documentVersionId": 6,
+        "sectionId": 3,
+        "versionNumber": 1,
+        "documentCategory": "Customer Feedback",
+        "pageNumber": 2,
+        "excerptTruncated": false
+      }
+    },
+    {
+      "sourceType": "document_change",
+      "sourceId": "document_change:doc:4:version:6",
+      "title": "Customer Feedback - July",
+      "sourceTimestamp": "2026-07-22T11:00:00.000Z",
+      "excerpt": "Version 1 uploaded",
+      "workspaceDeepLink": "/employer/documents/viewer?docId=4",
+      "metadata": {
+        "documentId": "4",
+        "documentVersionId": 6,
+        "versionNumber": 1,
+        "documentCategory": "Customer Feedback",
+        "uploadedBy": "demo-user",
+        "hasChangelog": false,
+        "changelogTruncated": false
+      }
+    },
+    {
+      "sourceType": "document_change",
+      "sourceId": "document_change:doc:2:version:3",
+      "title": "Pricing Page",
+      "sourceTimestamp": "2026-07-23T15:30:00.000Z",
+      "excerpt": "Clarified enterprise tier copy after customer confusion.",
+      "workspaceDeepLink": "/employer/documents/viewer?docId=2",
+      "metadata": {
+        "documentId": "2",
+        "documentVersionId": 3,
+        "versionNumber": 2,
+        "documentCategory": "Product",
+        "uploadedBy": "demo-user",
+        "hasChangelog": true,
+        "changelogTruncated": false
+      }
+    }
+  ],
+  "sourceWarnings": []
+}

--- a/apps/web/scripts/founder-weekly-review-evidence-collector.md
+++ b/apps/web/scripts/founder-weekly-review-evidence-collector.md
@@ -1,0 +1,161 @@
+# Founder Weekly Review - Evidence Collector Handoff
+
+Read-only tooling that produces a canonical FounderWeeklyReviewEvidenceSnapshot
+for a company + reporting week. The collector command only reads and normalizes:
+it never calls an LLM, writes to the database, or touches embeddings. The
+optional seed script writes local fixture data only so the example snapshot can
+be regenerated.
+
+## Entry point
+
+```ts
+import { FounderWeeklyReviewEvidenceService } from "@launchstack/features/founder-weekly-review";
+
+const service = new FounderWeeklyReviewEvidenceService(db); // db: DbClient
+const snapshot = await service.collectFounderWeeklyReviewEvidence({
+  companyId,            // bigint
+  reportingPeriod,      // { start: "YYYY-MM-DD", end: "YYYY-MM-DD" }  (end is inclusive)
+  workspaceTimezone,    // IANA zone, e.g. "America/New_York"
+  founderContext,       // optional string (request-time founder input)
+  actor,                // optional { externalUserId }; required if founderContext is set
+  contextEntryId,       // optional stable id for founder context
+  requestKey,           // optional fallback stable id for founder context
+  capturedAt,           // optional Date override, mainly for deterministic tests
+  maxItems,             // optional snapshot item cap, bounded by the service maximum
+});
+```
+
+Returned type: `FounderWeeklyReviewEvidenceSnapshot` - the canonical snapshot the LAU-9
+generation pipeline consumes directly. **No adapter is needed** between this output and
+the downstream generation step.
+
+## Local developer command
+
+Runs the collector without starting generation and prints the snapshot as JSON.
+
+```bash
+pnpm --filter @launchstack/web fwr:collect-evidence \
+  --company 2 \
+  --start 2026-07-20 --end 2026-07-26 \
+  --tz America/New_York \
+  --founder-context "This week we shipped X; blocked on Y." \
+  --actor demo-founder \
+  --out scripts/examples/founder-weekly-review-evidence.example.json
+```
+
+- `--company --start --end --tz` are required. `--founder-context` (with `--actor`),
+  and `--out` are optional. Using `--out` also writes the JSON to a file; without it the
+  snapshot only prints to stdout.
+- Source: `apps/web/scripts/collect-founder-weekly-review-evidence.ts` (actual entrypoint)
+  + `.lib.ts` (arg-parsing / URL-guard helpers).
+
+### Required environment
+
+The command resolves one URL: `LAUNCHSTACK_TEST_DATABASE_URL ?? DATABASE_URL`,
+refuses to run unless the URL is `localhost`/`127.0.0.1`, and
+refuses when `NODE_ENV=production`. Point it at a local DB only:
+
+```bash
+LAUNCHSTACK_TEST_DATABASE_URL="postgresql://postgres:password@localhost:5433/pdr_ai_v2" \
+  pnpm --filter @launchstack/web fwr:collect-evidence <...>
+```
+
+## Example snapshot + how to regenerate
+
+A committed example lives at
+`apps/web/scripts/examples/founder-weekly-review-evidence.example.json`.
+To regenerate an example snapshot against a local DB:
+
+```bash
+# 1. seed the local fixture data; this prints the companyId to use below
+LAUNCHSTACK_TEST_DATABASE_URL="postgresql://postgres:password@localhost:5433/pdr_ai_v2" \
+  pnpm --filter @launchstack/web tsx scripts/seed-founder-weekly-review-evidence-example.ts
+
+# 2. run the read-only collector command with --company <that id>
+LAUNCHSTACK_TEST_DATABASE_URL="postgresql://postgres:password@localhost:5433/pdr_ai_v2" \
+  pnpm --filter @launchstack/web fwr:collect-evidence \
+    --company <that id> \
+    --start 2026-07-20 --end 2026-07-26 \
+    --tz America/New_York \
+    --founder-context "This week focused on pricing clarity and onboarding. Main blocker: choosing an SSO vendor before we can ship SAML." \
+    --actor demo-founder \
+    --out scripts/examples/founder-weekly-review-evidence.example.json
+```
+
+The example intentionally shows all three source types, deterministic ordering, and
+reporting-window filter (an out-of-window version is seeded and correctly excluded).
+
+## Tests
+
+```bash
+# unit (no DB): arg parsing + local-URL guard
+pnpm --filter @launchstack/web exec jest founderWeeklyReview/collect-evidence.unit.test.ts
+
+# integration (needs a local db url)
+LAUNCHSTACK_TEST_DATABASE_URL="postgresql://postgres:password@localhost:5433/pdr_ai_v2" \
+  pnpm --filter @launchstack/web exec jest founderWeeklyReview/collect-evidence.integration.test.ts
+```
+
+Integration coverage: company isolation / no cross-company leakage, in-window vs
+out-of-window boundaries, chunk-based customer feedback, empty snapshot, and
+`founder_context` never classified as `customer_feedback`.
+
+## Sources
+
+| Source | sourceType | Status | Origin |
+| --- | --- | --- | --- |
+| Document changes | `document_change` | **Supported** | `document_versions` joined to `document`, scoped by company and reporting window |
+| Customer feedback | `customer_feedback` | **Supported** | processed `document_context_chunks` from documents whose category is exactly `Customer Feedback` |
+| Founder context | `founder_context` | **Supported** | request-time input from `--founder-context` or API collection input; no DB source |
+| GitHub activity | `github_activity` | **Not emitted by this collector** | separate LAU-8 adapter work |
+| `workspace_document` / `manual_note` / `other` | - | **Reserved / not used** | accepted by the contract enum but not emitted by the current collector |
+
+## Stable source IDs
+
+- `document_change:doc:<documentId>:version:<documentVersionId>`
+- `customer_feedback:doc:<documentId>:version:<documentVersionId>:section:<chunkId>`
+- `founder_context:entry:<entryId>` - where `entryId` is the caller-supplied
+  `contextEntryId` (falling back to `requestKey`). The developer command builds that
+  value as `cli:<companyId>:<start>:<end>`, so a snapshot produced by the command looks
+  like `founder_context:entry:cli:2:2026-07-20:2026-07-26`.
+
+IDs derive from stable DB primary keys (document/version/chunk) or the supplied stable
+request identity, so re-running against unchanged data yields identical IDs.
+
+## Reporting period & timezone
+
+Calendar dates are interpreted in the **workspace timezone** and converted to a
+half-open UTC interval `[start 00:00 local, (end + 1 day) 00:00 local)`, so `end` is
+the **last included day**. Conversion is DST-aware (dayjs + IANA data). Invalid zones
+throw. `start == end` is a valid single-day period.
+
+## Dedup & ordering
+
+- **Dedup:** by `sourceId`. Two items with the same `sourceId` but different content
+  throw `FounderWeeklyReviewEvidenceConflictError` (fail-loud on an ID collision).
+- **Ordering:** by `sourceTimestamp` ascending (items without a timestamp, currently
+  founder context, sort first), then `sourceType`, then `sourceId`, using ordinal
+  (locale-independent) comparison. Deterministic across machines.
+
+## Safety / limits
+
+- Per-source cap `250`, snapshot cap `500`, excerpt cap `4000` chars; overflow emits a
+  warning (`document_change_truncated`, `customer_feedback_truncated`,
+  `evidence_snapshot_truncated`) rather than dropping data silently.
+- Non-critical gaps emit safe warnings, not raw errors:
+  `customer_feedback_unavailable` (no feedback docs in the window),
+  `customer_feedback_missing_sections` (feedback doc had no citeable chunks).
+- The immutable snapshot carries no credentials/tokens/signed URLs; `canonicalUrl` is
+  omitted (source `document.url` is inconsistent); `workspaceDeepLink` is a host-less
+  relative path.
+- No LLM calls, no embedding/reindex writes; the collector command is read-only.
+
+## Known limitations / open questions
+
+1. **Customer-feedback documents also appear as `document_change`.** The
+   `document_change` query has no category filter, so a `"Customer Feedback"` document's
+   version is emitted **both** as `document_change` **and** as `customer_feedback` chunks.
+   Visible in the example snapshot. Should feedback-category documents be
+   excluded from `document_change`?
+2. **Formatting-only / near-duplicate versions** are not de-noised; every in-window
+   version becomes a `document_change` item.

--- a/apps/web/scripts/seed-founder-weekly-review-evidence-example.ts
+++ b/apps/web/scripts/seed-founder-weekly-review-evidence-example.ts
@@ -1,0 +1,117 @@
+// seeds local-only Founder Weekly Review data for producing example
+// evidence snapshot. Re-running removes previous data first
+// founder context must be manually entered through --founder-context flag
+//
+// pnpm --filter @launchstack/web tsx scripts/seed-founder-weekly-review-evidence-example.ts
+
+import "dotenv/config";
+
+import { sql } from "drizzle-orm";
+import postgres from "postgres";
+import { drizzle } from "drizzle-orm/postgres-js";
+
+import type { DbClient } from "@launchstack/core/db";
+import * as coreSchema from "@launchstack/core/db/schema";
+
+import { assertLocalDatabaseUrl } from "./collect-founder-weekly-review-evidence.lib";
+
+const FIXTURE_COMPANY_NAME = "Founder Weekly Review Example Co";
+
+// example snapshot is generated for (America/New_York) timezone.
+export const EXAMPLE_REPORTING_PERIOD = { start: "2026-07-20", end: "2026-07-26" } as const;
+export const EXAMPLE_WORKSPACE_TIMEZONE = "America/New_York";
+
+function firstInsertedId(rows: unknown): bigint {
+    const [row] = rows as Array<{ id: number | string | bigint }>;
+    if (!row) {
+        throw new Error("Expected an inserted row with an id");
+    }
+    return BigInt(row.id);
+}
+
+async function insertDocument(db: DbClient, companyId: bigint, category: string, title: string): Promise<bigint> {
+    const rows = await db.execute(sql`
+        INSERT INTO "pdr_ai_v2_document" ("company_id", "url", "category", "title")
+        VALUES (${companyId}, ${"/api/files/example"}, ${category}, ${title})
+        RETURNING "id"
+    `);
+    return firstInsertedId(rows);
+}
+
+async function insertVersion(
+    db: DbClient,
+    documentId: bigint,
+    versionNumber: number,
+    createdAtIso: string,
+    changelog: string | null,
+    uploadedBy: string | null
+): Promise<bigint> {
+    const rows = await db.execute(sql`
+        INSERT INTO "pdr_ai_v2_document_versions"
+            ("document_id", "version_number", "url", "mime_type", "changelog", "uploaded_by", "created_at")
+        VALUES (${documentId}, ${versionNumber}, ${"/api/files/example"}, ${"application/pdf"}, ${changelog}, ${uploadedBy}, ${createdAtIso})
+        RETURNING "id"
+    `);
+    return firstInsertedId(rows);
+}
+
+async function insertChunk(db: DbClient, documentId: bigint, versionId: bigint, content: string, pageNumber: number): Promise<void> {
+    await db.execute(sql`
+        INSERT INTO "pdr_ai_v2_document_context_chunks" ("document_id", "version_id", "content", "page_number")
+        VALUES (${documentId}, ${versionId}, ${content}, ${pageNumber})
+    `);
+}
+
+async function removeExistingFixture(db: DbClient): Promise<void> {
+    await db.execute(sql`DELETE FROM "pdr_ai_v2_document_context_chunks" WHERE "document_id" IN (SELECT id FROM "pdr_ai_v2_document" WHERE "company_id" IN (SELECT id FROM "pdr_ai_v2_company" WHERE "name" = ${FIXTURE_COMPANY_NAME}))`);
+    await db.execute(sql`DELETE FROM "pdr_ai_v2_document_versions" WHERE "document_id" IN (SELECT id FROM "pdr_ai_v2_document" WHERE "company_id" IN (SELECT id FROM "pdr_ai_v2_company" WHERE "name" = ${FIXTURE_COMPANY_NAME}))`);
+    await db.execute(sql`DELETE FROM "pdr_ai_v2_document" WHERE "company_id" IN (SELECT id FROM "pdr_ai_v2_company" WHERE "name" = ${FIXTURE_COMPANY_NAME})`);
+    await db.execute(sql`DELETE FROM "pdr_ai_v2_company" WHERE "name" = ${FIXTURE_COMPANY_NAME}`);
+}
+
+async function main(): Promise<void> {
+    const url = process.env.LAUNCHSTACK_TEST_DATABASE_URL ?? process.env.DATABASE_URL ?? "";
+    assertLocalDatabaseUrl(url);
+
+    const client = postgres(url, { max: 1 });
+    try {
+        const db = drizzle(client, { schema: coreSchema });
+
+        await removeExistingFixture(db);
+
+        const companyRows = await db.execute(sql`
+            INSERT INTO "pdr_ai_v2_company" ("name", "numberOfEmployees")
+            VALUES (${FIXTURE_COMPANY_NAME}, ${"12"})
+            RETURNING "id"
+        `);
+        const companyId = firstInsertedId(companyRows);
+
+        // product doc with two in-window versions and one out-of-window version.
+        const pricing = await insertDocument(db, companyId, "Product", "Pricing Page");
+        await insertVersion(db, pricing, 1, "2026-07-21T14:00:00.000Z", "Reworked pricing tiers; added an annual billing option.", "demo-user");
+        await insertVersion(db, pricing, 2, "2026-07-23T15:30:00.000Z", "Clarified enterprise tier copy after customer confusion.", "demo-user");
+        await insertVersion(db, pricing, 3, "2026-07-28T14:00:00.000Z", "Post-window tweak (should NOT appear in the 07-20..07-26 pack).", "demo-user");
+
+        // second product doc with no extra versions
+        const onboarding = await insertDocument(db, companyId, "Product", "Onboarding Guide");
+        await insertVersion(db, onboarding, 1, "2026-07-22T09:15:00.000Z", "Added an SSO / SAML setup walkthrough.", "demo-user");
+
+        // customer-feedback doc with three citeable chunks.
+        const feedback = await insertDocument(db, companyId, "Customer Feedback", "Customer Feedback - July");
+        const feedbackV1 = await insertVersion(db, feedback, 1, "2026-07-22T11:00:00.000Z", null, "demo-user");
+        await insertChunk(db, feedback, feedbackV1, "Several customers asked for annual billing instead of monthly-only.", 1);
+        await insertChunk(db, feedback, feedbackV1, "A user said the enterprise tier pricing felt confusing to compare.", 1);
+        await insertChunk(db, feedback, feedbackV1, "Multiple requests for SSO / SAML so larger teams can roll out access.", 2);
+
+        console.log(`Seeded fixture "${FIXTURE_COMPANY_NAME}" with companyId=${companyId}`);
+        console.log(`Reporting period: ${EXAMPLE_REPORTING_PERIOD.start} .. ${EXAMPLE_REPORTING_PERIOD.end} (${EXAMPLE_WORKSPACE_TIMEZONE})`);
+        console.log(`Next: run the collector with --company ${companyId} to produce the example snapshot.`);
+    } finally {
+        await client.end({ timeout: 5 });
+    }
+}
+
+main().catch((error: unknown) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary

- Added a read-only developer command for collecting Founder Weekly Review evidence without triggering generation.
- Added local fixture seeding and an example evidence snapshot.
- Added unit/integration coverage and a short handoff doc for the collector workflow.

## What Changed

- `fwr:collect-evidence` runs the canonical evidence collector and prints a JSON snapshot.
- The command is local-only and refuses non-local database URLs or `NODE_ENV=production`.
- The seed script creates local example data for document changes, customer feedback, and founder context.
- The integration test verifies collection against real DB tables through the isolated schema helper.

## Testing

- Added unit tests for CLI argument parsing and local database URL guarding.
- Added integration tests for real DB-backed collection behavior using the isolated test schema helper.