### PR TITLE
Reproduce storage owner FK integrity hole (LAU-20 polymorphic vs exclusive FKs)

### DIFF
--- a/docs/issues/storage-owner-fk-integrity.md
+++ b/docs/issues/storage-owner-fk-integrity.md
@@ -1,0 +1,79 @@
+# Storage owner FK integrity — why polymorphic ownership breaks deletion
+
+**Related:** [LAU-20](https://linear.app/launchstack/issue/LAU-20), [GitHub #313](https://github.com/Deodat-Lawson/LaunchStack/issues/313)
+
+**Reproduction:** `scripts/repro/storage-owner-fk/run.sh`
+
+## What we reproduced
+
+Kareem’s schema question for the LAU-20 storage manifest (`storage_objects`): an object is owned by **exactly one** of several parent tables (`document`, `document_version`, `artifact_group`). Two patterns look plausible:
+
+| Pattern | Shape | DB referential integrity |
+| --- | --- | --- |
+| 1. Polymorphic FK | `owner_type` + `owner_id` | **None.** Postgres cannot attach one FK to three tables. |
+| 2. Exclusive nullable FKs | `document_id` / `document_version_id` / `artifact_group_id` + `CHECK` that exactly one is non-null | **Full.** Each column is a real FK; owner delete can `RESTRICT` / `CASCADE` deliberately. |
+
+Running the repro against Postgres 16 shows:
+
+1. **Pattern 1:** delete the owning `document_versions` row → the polymorphic manifest row **survives with a dangling `owner_id`**. The database cannot stop this.
+2. **Pattern 2:** the same owner delete is **rejected by FK** while the manifest row exists; zero-owner and multi-owner inserts are rejected by `CHECK`.
+
+Transcript: `/tmp/cursor/artifacts/storage-owner-fk-repro.log` (produced by `run.sh`).
+
+## Why we had this issue in the first place
+
+This is not an abstract modeling preference. It is the schema consequence of today’s storage deletion failure.
+
+### 1. Upload captures object identity, then discards it
+
+S3/Blob/DB uploads already know provider + key/pathname at write time, but document registration persists **URLs only**. `storageProvider` / `storagePathname` are accepted on the upload API and dropped before the document row is created. `file_uploads` has provider metadata but **no FK ownership** back to a document/version.
+
+So there is no durable “these bytes belong to this owner” row the deleter can trust.
+
+### 2. Normal delete is DB-only
+
+`DELETE /api/deleteDocument` and batch delete call ordered SQL deletes (see `document-delete.ts` / `deleteDocument/route.ts`) and return success after the Postgres transaction. They never:
+
+- snapshot version/artifact URLs or opaque refs,
+- call `StoragePort` / `deleteFileByUrl`,
+- distinguish “SQL gone” from “bytes gone”.
+
+`document_versions` cascade off `document`, so even the URL evidence disappears while S3/Blob/`file_uploads` bytes remain. That is the P0 orphan class in #313.
+
+### 3. The partial paths that *do* touch storage are still unsafe
+
+Version delete calls `deleteFileByUrl`, but:
+
+- S3 key recovery strips only the endpoint and leaves the bucket in `Key`,
+- Vercel Blob has no delete wiring (falls through to a no-op database branch),
+- `/api/files/{id}` returns early without deleting the `file_uploads` row.
+
+Those bugs amplify the same root omission: **no owned, provider-opaque manifest**.
+
+### 4. LAU-20 therefore needs exclusive ownership on `storage_objects`
+
+The deletion lifecycle design requires:
+
+1. register an opaque `ObjectRef` under an exclusive owner before the document/version becomes active,
+2. snapshot owned refs into a deletion outbox **before** relational cascade,
+3. hard-delete SQL only after storage is `DELETED` / `NOT_FOUND`.
+
+That lifecycle is only sound if the database itself refuses dangling or ambiguous ownership. Polymorphic `(owner_type, owner_id)` cannot do that — the repro’s dangling row after owner delete is exactly the integrity hole a deletion coordinator must not have. Exclusive nullable FK columns + an exactly-one `CHECK` (Pattern 2) are the Postgres-native fit for a closed set of three owner kinds.
+
+## Recommendation
+
+Use **Pattern 2** for `storage_objects` ownership:
+
+- real FKs to `document` / `document_versions` / artifact-group table,
+- `CHECK` that exactly one owner column is non-null,
+- `ON DELETE RESTRICT` (or equivalent) so relational purge cannot race ahead of the storage worker,
+- app helpers that set exactly one owner column from a typed owner union.
+
+Accept the two NULL columns per row. For this table, nullability is cheaper than unverifiable ownership during delete/retry/quarantine.
+
+## How to re-run
+
+```bash
+# requires local Postgres (psql) with a role that can CREATE DATABASE
+./scripts/repro/storage-owner-fk/run.sh
+```

--- a/scripts/repro/storage-owner-fk/01_polymorphic_vs_exclusive_fks.sql
+++ b/scripts/repro/storage-owner-fk/01_polymorphic_vs_exclusive_fks.sql
@@ -1,0 +1,169 @@
+-- Reproduce: polymorphic owner FK vs exclusive nullable FK columns
+-- Context: LAU-20 / GitHub #313 storage deletion lifecycle (Dev B schema)
+--
+-- storage_objects must exclusively own bytes for exactly one of:
+--   document | document_version | artifact_group
+--
+-- Pattern 1 (polymorphic owner_type + owner_id) looks clean in app code, but
+-- Postgres cannot attach a real FOREIGN KEY to "whichever table owner_type
+-- names". Deleting an owner therefore leaves dangling manifest rows — fatal
+-- for a deletion lifecycle that must snapshot owned refs before cascade.
+--
+-- Pattern 2 (document_id / document_version_id / artifact_group_id + CHECK
+-- that exactly one is non-null) trades two NULL columns per row for real
+-- referential integrity and ON DELETE behavior the worker can rely on.
+
+\set ON_ERROR_STOP on
+
+DROP SCHEMA IF EXISTS storage_owner_fk_repro CASCADE;
+CREATE SCHEMA storage_owner_fk_repro;
+SET search_path TO storage_owner_fk_repro;
+
+CREATE TABLE documents (
+  id bigserial PRIMARY KEY,
+  title text NOT NULL
+);
+
+CREATE TABLE document_versions (
+  id bigserial PRIMARY KEY,
+  document_id bigint NOT NULL REFERENCES documents(id) ON DELETE CASCADE,
+  version_number integer NOT NULL
+);
+
+CREATE TABLE artifact_groups (
+  id bigserial PRIMARY KEY,
+  label text NOT NULL
+);
+
+---------------------------------------------------------------------------
+-- Pattern 1: polymorphic FK (NOT enforceable as a real FK)
+---------------------------------------------------------------------------
+
+CREATE TABLE storage_objects_polymorphic (
+  id bigserial PRIMARY KEY,
+  adapter text NOT NULL,
+  storage_location_id text NOT NULL,
+  object_key text NOT NULL,
+  owner_type text NOT NULL CHECK (owner_type IN ('document', 'document_version', 'artifact_group')),
+  owner_id bigint NOT NULL
+  -- Intentionally no FOREIGN KEY: Postgres cannot target three tables
+  -- conditionally from (owner_type, owner_id).
+);
+
+INSERT INTO documents (title) VALUES ('pitch-deck.pdf') RETURNING id \gset doc_
+INSERT INTO document_versions (document_id, version_number)
+  VALUES (:doc_id, 1) RETURNING id \gset ver_
+INSERT INTO artifact_groups (label) VALUES ('zip-extract-children') RETURNING id \gset art_
+
+INSERT INTO storage_objects_polymorphic
+  (adapter, storage_location_id, object_key, owner_type, owner_id)
+VALUES
+  ('s3', 's3:http://localhost:8333@pdr-documents', 'documents/pitch-v1.pdf', 'document_version', :ver_id),
+  ('s3', 's3:http://localhost:8333@pdr-documents', 'artifacts/child-a.pdf', 'artifact_group', :art_id);
+
+\echo ''
+\echo '=== Pattern 1: delete the owning document_version ==='
+DELETE FROM document_versions WHERE id = :ver_id;
+
+\echo 'Polymorphic manifest AFTER owner delete (dangling ref expected):'
+SELECT id, owner_type, owner_id, object_key
+FROM storage_objects_polymorphic
+WHERE owner_type = 'document_version';
+
+\echo 'Owner row still exists? (should be 0):'
+SELECT count(*) AS surviving_versions FROM document_versions WHERE id = :ver_id;
+
+---------------------------------------------------------------------------
+-- Pattern 2: exclusive nullable FK columns + exactly-one CHECK
+---------------------------------------------------------------------------
+
+CREATE TABLE storage_objects_exclusive (
+  id bigserial PRIMARY KEY,
+  adapter text NOT NULL,
+  storage_location_id text NOT NULL,
+  object_key text NOT NULL,
+  document_id bigint REFERENCES documents(id) ON DELETE RESTRICT,
+  document_version_id bigint REFERENCES document_versions(id) ON DELETE RESTRICT,
+  artifact_group_id bigint REFERENCES artifact_groups(id) ON DELETE RESTRICT,
+  CONSTRAINT storage_objects_exclusive_one_owner CHECK (
+    ((document_id IS NOT NULL)::int
+     + (document_version_id IS NOT NULL)::int
+     + (artifact_group_id IS NOT NULL)::int) = 1
+  )
+);
+
+-- Fresh owners for pattern 2
+INSERT INTO documents (title) VALUES ('roadmap.pdf') RETURNING id \gset doc2_
+INSERT INTO document_versions (document_id, version_number)
+  VALUES (:doc2_id, 1) RETURNING id \gset ver2_
+INSERT INTO artifact_groups (label) VALUES ('audio-transcript-pair') RETURNING id \gset art2_
+
+INSERT INTO storage_objects_exclusive
+  (adapter, storage_location_id, object_key, document_version_id)
+VALUES
+  ('s3', 's3:http://localhost:8333@pdr-documents', 'documents/roadmap-v1.pdf', :ver2_id);
+
+INSERT INTO storage_objects_exclusive
+  (adapter, storage_location_id, object_key, artifact_group_id)
+VALUES
+  ('vercel-blob', 'vercel-blob:store_demo', 'transcripts/roadmap.txt', :art2_id);
+
+\echo ''
+\echo '=== Pattern 2: CHECK rejects zero / multi-owner rows ==='
+\echo 'Expect failure: zero owners'
+DO $$
+BEGIN
+  BEGIN
+    INSERT INTO storage_objects_exclusive
+      (adapter, storage_location_id, object_key)
+    VALUES ('s3', 's3:loc', 'orphan-key');
+    RAISE EXCEPTION 'UNEXPECTED: zero-owner insert succeeded';
+  EXCEPTION WHEN check_violation THEN
+    RAISE NOTICE 'OK: zero-owner insert rejected by CHECK';
+  END;
+END $$;
+
+\echo 'Expect failure: two owners'
+DO $$
+BEGIN
+  BEGIN
+    INSERT INTO storage_objects_exclusive
+      (adapter, storage_location_id, object_key, document_id, artifact_group_id)
+    VALUES ('s3', 's3:loc', 'two-owners', 1, 1);
+    RAISE EXCEPTION 'UNEXPECTED: multi-owner insert succeeded';
+  EXCEPTION WHEN check_violation THEN
+    RAISE NOTICE 'OK: multi-owner insert rejected by CHECK';
+  END;
+END $$;
+
+\echo ''
+\echo '=== Pattern 2: deleting an owned version is blocked while manifest exists ==='
+\echo 'Expect FK violation (RESTRICT) — deletion coordinator must snapshot + clear first:'
+DO $$
+DECLARE
+  ver_id bigint;
+BEGIN
+  SELECT document_version_id INTO ver_id
+  FROM storage_objects_exclusive
+  WHERE object_key = 'documents/roadmap-v1.pdf';
+
+  BEGIN
+    DELETE FROM document_versions WHERE id = ver_id;
+    RAISE EXCEPTION 'UNEXPECTED: owner delete succeeded while exclusive FK remained';
+  EXCEPTION WHEN foreign_key_violation THEN
+    RAISE NOTICE 'OK: owner delete blocked by real FK (no dangling manifest possible)';
+  END;
+END $$;
+
+\echo ''
+\echo '=== Pattern 2: after coordinator removes manifest refs, owner delete succeeds ==='
+DELETE FROM storage_objects_exclusive WHERE object_key = 'documents/roadmap-v1.pdf';
+DELETE FROM document_versions WHERE id = :ver2_id;
+SELECT count(*) AS remaining_version_manifest_rows
+FROM storage_objects_exclusive
+WHERE document_version_id = :ver2_id;
+
+\echo ''
+\echo '=== Summary ==='
+\echo 'Pattern 1 leaves dangling owner_id after owner delete — DB cannot prevent it.'
+\echo 'Pattern 2 enforces exactly-one owner + real FKs — required for LAU-20 integrity.'

--- a/scripts/repro/storage-owner-fk/02_current_orphan_delete_path.mjs
+++ b/scripts/repro/storage-owner-fk/02_current_orphan_delete_path.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/**
+ * Static reproduction of today's P0 orphan path (GitHub #313 / LAU-20).
+ *
+ * Proves, from source, that full-document delete never touches storage and that
+ * upload registration does not persist provider-owned object identity — which
+ * is why the storage_objects ownership schema (and the polymorphic-vs-exclusive
+ * FK question) exists at all.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+
+function read(rel) {
+  return fs.readFileSync(path.join(root, rel), "utf8");
+}
+
+const checks = [];
+
+function assert(name, condition, detail) {
+  checks.push({ name, ok: Boolean(condition), detail });
+}
+
+const deleteRoute = read("apps/web/src/app/api/deleteDocument/route.ts");
+const deleteCore = read("apps/web/src/server/services/document-delete.ts");
+const batchDelete = read("apps/web/src/app/api/documents/batchDelete/route.ts");
+const storageLib = read("apps/web/src/lib/storage.ts");
+const uploadRoute = read("apps/web/src/app/api/uploadDocument/route.ts");
+const documentSchema = read("packages/core/src/db/schema/base.ts");
+
+assert(
+  "deleteDocument route has no storage import",
+  !/deleteFile|StoragePort|storage\//.test(deleteRoute),
+  "DELETE /api/deleteDocument only performs SQL deletes",
+);
+
+assert(
+  "deleteDocumentCore has no storage import",
+  !/deleteFile|StoragePort|storage\//.test(deleteCore),
+  "shared helper is ordered tx.delete(...) only",
+);
+
+assert(
+  "batchDelete reuses DB-only core",
+  /deleteDocumentCore/.test(batchDelete) && !/deleteFileByUrl/.test(batchDelete),
+  "batch path can orphan up to 100 docs of objects at once",
+);
+
+assert(
+  "deleteFileByUrl early-returns for /api/files/",
+  /if \(url\.startsWith\("\/api\/files\/"\)\) return;/.test(storageLib),
+  "database-backed canonical URLs never delete file_uploads rows",
+);
+
+assert(
+  "deleteFileByUrl strips only S3 endpoint (bucket remains in key)",
+  /url\.slice\(s3Endpoint\.replace/.test(storageLib) &&
+    /pdr-documents\/documents\/abc-file\.pdf/.test(storageLib),
+  "commented example shows Key becoming bucket/key",
+);
+
+assert(
+  "uploadDocument schema accepts storageProvider/storagePathname",
+  /storageProvider/.test(uploadRoute) && /storagePathname/.test(uploadRoute),
+  "identity is available at the API boundary",
+);
+
+const uploadHandlerUsesProvider =
+  /storageProvider/.test(uploadRoute.split("export async function")[1] ?? "") &&
+  /createDocument|uploadDocument|storagePathname/.test(
+    uploadRoute.split("export async function")[1] ?? "",
+  );
+
+// The Zod schema lists the fields, but the destructure/pass-through must not
+// forward them into the upload service for this assertion to hold.
+const afterSchema = uploadRoute.slice(uploadRoute.indexOf("export async function"));
+assert(
+  "upload handler does not forward storageProvider into persistence",
+  !/storageProvider\s*,/.test(afterSchema.replace(/storageProvider:\s*z[\s\S]*?optional\(\),/, "")),
+  "accepted provider identity is dropped before document registration",
+);
+
+assert(
+  "document / document_versions persist url, not ObjectRef columns",
+  /url: varchar\("url"/.test(documentSchema) &&
+    !/storage_location_id|object_ref|owner_type/.test(documentSchema),
+  "no durable owned manifest in the engine schema today",
+);
+
+const failed = checks.filter((c) => !c.ok);
+for (const c of checks) {
+  console.log(`${c.ok ? "PASS" : "FAIL"}  ${c.name}`);
+  console.log(`       ${c.detail}`);
+}
+
+console.log("");
+if (failed.length) {
+  console.error(`Orphan-path reproduction incomplete: ${failed.length} assertion(s) failed.`);
+  process.exit(1);
+}
+
+console.log(
+  [
+    "Reproduced root cause of the ownership-schema question:",
+    "  1. Full/batch document delete is SQL-only → storage bytes orphaned.",
+    "  2. Object identity is not persisted as an owned manifest row.",
+    "  3. LAU-20 therefore adds storage_objects with exclusive owners;",
+    "     polymorphic (owner_type, owner_id) cannot enforce that in Postgres",
+    "     (see 01_polymorphic_vs_exclusive_fks.sql).",
+  ].join("\n"),
+);

--- a/scripts/repro/storage-owner-fk/run.sh
+++ b/scripts/repro/storage-owner-fk/run.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Run the storage-owner FK integrity reproduction against local Postgres.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+SQL="$ROOT/scripts/repro/storage-owner-fk/01_polymorphic_vs_exclusive_fks.sql"
+DB_NAME="${STORAGE_OWNER_FK_REPRO_DB:-storage_owner_fk_repro}"
+OUT_DIR="${STORAGE_OWNER_FK_REPRO_OUT:-/tmp/cursor/artifacts}"
+OUT_FILE="$OUT_DIR/storage-owner-fk-repro.log"
+
+mkdir -p "$OUT_DIR"
+
+if ! command -v psql >/dev/null 2>&1; then
+  echo "psql is required" >&2
+  exit 1
+fi
+
+if [[ "$(id -u)" -eq 0 ]]; then
+  PSQL=(psql -v ON_ERROR_STOP=1)
+elif command -v sudo >/dev/null 2>&1 && id postgres >/dev/null 2>&1; then
+  PSQL=(sudo -u postgres psql -v ON_ERROR_STOP=1)
+else
+  PSQL=(psql -v ON_ERROR_STOP=1)
+fi
+
+echo "Creating database $DB_NAME (if needed)..."
+"${PSQL[@]}" -tc "SELECT 1 FROM pg_database WHERE datname = '$DB_NAME'" | grep -q 1 \
+  || "${PSQL[@]}" -c "CREATE DATABASE $DB_NAME"
+
+echo "Running reproduction SQL..."
+"${PSQL[@]}" -d "$DB_NAME" -f "$SQL" | tee "$OUT_FILE"
+
+echo
+echo "Running static orphan-path checks..."
+ORPHAN_OUT="$OUT_DIR/current-orphan-delete-path.log"
+node "$ROOT/scripts/repro/storage-owner-fk/02_current_orphan_delete_path.mjs" | tee "$ORPHAN_OUT"
+
+echo
+echo "Wrote FK transcript to $OUT_FILE"
+echo "Wrote orphan-path transcript to $ORPHAN_OUT"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Reproduces Kareem’s LAU-20 / #313 schema question: **polymorphic `(owner_type, owner_id)` cannot enforce ownership for `storage_objects` in Postgres**, while exclusive nullable FK columns + an exactly-one `CHECK` can.

Also shows *why* this question exists: today’s full/batch document delete is SQL-only and never persists opaque object ownership, so the deletion lifecycle must introduce a real owned manifest.

## Reproduction

```bash
./scripts/repro/storage-owner-fk/run.sh
```

**Pattern 1 (polymorphic):** deleting the owning `document_versions` row leaves a dangling `storage_objects` row (`owner_type=document_version`, `owner_id=1`, owner count `0`).

**Pattern 2 (exclusive FKs):** owner delete is blocked by `ON DELETE RESTRICT` while the manifest exists; zero/multi-owner inserts fail the `CHECK`.

Static orphan-path check confirms `deleteDocument` / `deleteDocumentCore` / batch delete never call storage, and upload drops `storageProvider`/`storagePathname` before persistence.

## Why we had it

1. Uploads know provider + key, but documents store **URLs only**.
2. Normal delete purges Postgres (and cascades version URLs) without deleting bytes.
3. LAU-20 therefore needs exclusive `storage_objects` ownership before cascade — and polymorphic FKs cannot provide the integrity that lifecycle requires.

Write-up: `docs/issues/storage-owner-fk-integrity.md`

## Recommendation

Prefer **Pattern 2** (exclusive nullable FKs + exactly-one `CHECK`, `ON DELETE RESTRICT`) for the Dev B manifest schema.

## Artifacts

- FK SQL transcript: `/opt/cursor/artifacts/storage-owner-fk-repro.log`
- Orphan-path transcript: `/opt/cursor/artifacts/current-orphan-delete-path.log`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fdf36-33e6-7157-a57d-db94727d9fb2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fdf36-33e6-7157-a57d-db94727d9fb2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

