### PR TITLE
docs: add Call Notes architecture wayfinder

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,41 @@
+# LaunchStack
+
+LaunchStack organizes company knowledge and the user-authored context that steers AI assistance. Call Notes adds provider-captured call evidence without collapsing it into the user's own notes.
+
+## Call Notes Language
+
+**Call**:
+One real provider-hosted conversation occurrence scoped to one LaunchStack company. Repeated use of the same provider meeting identifier creates separate Calls.
+_Avoid_: Meeting (reserved for agent collaboration), call series, recurring call
+
+**Capture**:
+The single company-scoped acquisition of live call evidence for a Call, shared by that company's attending users.
+_Avoid_: User recording, personal capture
+
+**Capture Attempt**:
+One continuous provider stream interval within a Capture, anchored to one Capture User. The attempt ends when that provider stream stops.
+_Avoid_: New capture, retry job
+
+**Capture User**:
+An authorized conferencing-provider user whose active app session enables and exclusively controls a Capture Attempt. The Capture User anchors provider authorization and lifecycle but does not own the company Transcript; leaving ends the attempt, and the same user can start a later attempt after returning.
+_Avoid_: Transcript owner, recorder, bot
+
+**Participant**:
+A person represented in a Call by the name and call-local identity supplied by the conferencing provider. Repeated names or reconnects are not assumed to be the same Participant.
+_Avoid_: User, contact
+
+**Transcript**:
+The immutable, speaker-attributed textual evidence received for a Call and visible to every authorized user in that Call's LaunchStack company. It is not a user-editable note.
+_Avoid_: Note, recording
+
+**Bookmark**:
+A company-visible marker that the Call Note owner attaches to an immutable Transcript segment, optionally with freeform guidance. Bookmarks do not alter transcript evidence and can guide generated outputs and Call Note enrichment.
+_Avoid_: Private highlight, transcript edit
+
+**Call Note**:
+The one canonical editable note for a Call, owned by the first LaunchStack user whose capture start succeeds. It is company-visible by default but the owner can make it private; other users then see the Transcript without a note and cannot create another. Ownership does not transfer in the initial product.
+_Avoid_: User Note, collaborative note, multiple notes per Call
+
+**Enriched Note**:
+An AI-proposed revision grounded in the Call's Transcript. It preserves existing owner steering and emphasis, may propose a complete Call Note when blank, and becomes the next canonical revision only after the owner accepts it.
+_Avoid_: Call summary, transcript summary

--- a/docs/issues/call-notes-wayfinder/001-verify-zoom-rtms-operating-contract.md
+++ b/docs/issues/call-notes-wayfinder/001-verify-zoom-rtms-operating-contract.md
@@ -1,0 +1,31 @@
+---
+id: MN-WF-001
+title: Verify the Zoom RTMS Operating Contract
+parent: MN-WF-000
+status: closed
+assignee: ZoomRtmsContract
+labels:
+  - wayfinder:research
+blocked_by: []
+research_context: agent://ZoomRtmsContract
+---
+
+# Verify the Zoom RTMS Operating Contract
+
+## Question
+
+What current, source-verifiable Zoom RTMS contract constrains a self-hosted, multi-user LaunchStack deployment: General App ownership and distribution, Developer Pack billing, OAuth authorization scope, intra-account and external-meeting use, start and stop controls, host and administrator approval, participant disclosure, transcript packet semantics, webhook verification, reconnect and buffering behavior, concurrency limits, and the supported Node SDK/runtime path?
+
+## Resolution comment
+
+Resolved from official Zoom documentation and repositories checked on 2026-08-14. Full research context: [Zoom RTMS contract research](agent://ZoomRtmsContract).
+
+- RTMS requires a user-managed Zoom General App, RTMS event subscriptions and scopes, and Developer Pack credits. A private app serves users in its owning Zoom account; durable external distribution requires reviewed unlisted or public publication. Approved beta authorization is temporary and capped.
+- Account and group settings enable RTMS; hosts can approve or deny it; Zoom shows every participant that meeting content is being sent to one or more apps. Zoom documents host approval plus disclosure, not an all-participant click-to-consent flow.
+- A REST start targets an invited participant who has joined while the host or designated alternate is present. RTMS can also auto-start or be controlled through supported in-client APIs.
+- Transcript packets are continuous, speaker-attributed `msg_type: 17` messages carrying participant identity, timestamps, language, and text. Zoom documents no finality flag, total-order guarantee, deduplication key, or transcript replay guarantee; application finalization and post-processing are therefore required.
+- The runtime contract is signed webhook → signaling WebSocket → media WebSocket → client-ready acknowledgement, with keepalives and bounded reconnection behavior. Audio has documented buffering; transcript replay during interruption is unspecified.
+- The current official Node package targets a long-running Node runtime and its package metadata requires Node 22, despite older examples mentioning Node 20. A public HTTPS webhook and outbound WSS connectivity are required.
+- Zoom's live pricing UI showed $0.02 per meeting streaming minute with transcription and $0.01 without on 2026-08-14. Public documentation does not unambiguously specify cross-account billing attribution for a reviewed app, universal concurrency, transcript replay/finality, or several timeout and stop-reason details; those remain support/account-verification questions rather than safe assumptions.
+
+Primary sources: [RTMS setup](https://developers.zoom.us/docs/rtms/meetings/add-features/), [stream lifecycle](https://developers.zoom.us/docs/rtms/meetings/work-with-streams/), [media and transcripts](https://developers.zoom.us/docs/rtms/meetings/media/), [event reference](https://developers.zoom.us/docs/rtms/event-reference/), [reconnection](https://developers.zoom.us/docs/rtms/meetings/failover-reconnection/), [participant UX](https://developers.zoom.us/docs/rtms/meetings/ux-participant/), [distribution](https://developers.zoom.us/docs/distribute/), [webhooks](https://developers.zoom.us/docs/api/webhooks/), [official Node SDK](https://github.com/zoom/rtms), and [Developer Pack pricing](https://zoom.us/pricing/developer).

--- a/docs/issues/call-notes-wayfinder/002-define-call-notes-domain-model.md
+++ b/docs/issues/call-notes-wayfinder/002-define-call-notes-domain-model.md
@@ -1,0 +1,30 @@
+---
+id: MN-WF-002
+title: Define the Call Notes Domain Model
+parent: MN-WF-000
+status: closed
+assignee: Main
+labels:
+  - wayfinder:grilling
+blocked_by: []
+---
+
+# Define the Call Notes Domain Model
+
+## Question
+
+What are the canonical concepts, ownership rules, identities, and lifecycle boundaries for a Call, Capture, Capture Attempt, Capture User, Participant, Transcript, Call Note, Enriched Note, and generated outputs—especially when several LaunchStack users attend the same Zoom meeting, view company evidence, or authorize competing capture attempts?
+
+## Resolution comment
+
+The Call Notes domain uses these boundaries:
+
+- A **Call** is one real Zoom meeting occurrence inside one LaunchStack company. Recurring provider identifiers do not merge occurrences, and separate LaunchStack companies never share a Call or Capture.
+- A company owns the Call, its single logical **Capture**, Participants, immutable Transcript, and transcript **Bookmarks**. Every authorized company user can view the Transcript and Bookmarks; only the Call Note owner creates Bookmarks. The Capture can contain multiple **Capture Attempts** when provider streaming stops and later resumes.
+- Zoom anchors each RTMS session to one authorized **Capture User** who is present in the Zoom meeting and exclusively controls that Capture Attempt. LaunchStack's worker is not a meeting participant, and Zoom exposes no company-level service identity. Cross-user continuation is deferred.
+- The first LaunchStack user whose capture start succeeds owns the Call's one canonical **Call Note**. It is shared read-only with the company by default, but the owner can make it private during or after the Call; other users then see the Transcript without a note and cannot create another. Ownership transfer is deferred.
+- An **Enriched Note** is an AI-proposed revision grounded in the Transcript. It preserves existing owner steering, may propose a complete Call Note when blank, and becomes canonical only after side-by-side owner approval; revision history preserves the prior note.
+- The Transcript remains immutable and speaker-attributed. Transcript editing is deferred. A Participant keeps provider-supplied call-local identity and name; no LaunchStack-user/contact linking or name-based reconnect merging is required.
+- Capture outcome is `complete`, `partial`, or `failed`. If the Capture User leaves, or capture starts late, ends early, or has a known gap, LaunchStack retains the evidence received and marks the Transcript partial. The same Capture User can continue the logical Capture through a new Capture Attempt after returning; the initial release does not hand it to another user.
+
+Canonical terminology is recorded in [`CONTEXT.md`](../../../CONTEXT.md). Target-account access remains assigned to [Confirm RTMS Access in the Target Zoom Account](./013-confirm-target-zoom-rtms-access.md); cross-user continuity is a later effort.

--- a/docs/issues/call-notes-wayfinder/003-prototype-call-notes-interaction-shape.md
+++ b/docs/issues/call-notes-wayfinder/003-prototype-call-notes-interaction-shape.md
@@ -1,0 +1,51 @@
+---
+id: MN-WF-003
+title: Prototype the Call Notes Interaction Shape
+parent: MN-WF-000
+status: open
+assignee: Main
+labels:
+  - wayfinder:prototype
+blocked_by: []
+---
+
+# Prototype the Call Notes Interaction Shape
+
+## Question
+
+What minimal interaction shape makes live attributed transcript, a contemporaneous Call Note, capture state, and post-call AI enrichment feel like one LaunchStack feature without turning it into a live copilot—and what concrete rough prototype best exposes the architecture-affecting states, controls, and failure cases for human review?
+
+## Decisions so far
+
+- Capture starts manually. While any LaunchStack tab is open, LaunchStack offers a global best-effort suggestion when Zoom exposes an eligible call, without promising universal detection or background push.
+- If Zoom does not expose a candidate, the user can paste a Zoom join URL or meeting ID and explicitly start capture.
+- The long-running worker owns capture. Closing the Calls page does not stop it; capture ends only through Zoom/provider lifecycle, while Pause and Resume remain available in the web UI.
+- The live workspace is notes-first: a large owner-editable Call Note beside a narrower company-visible Transcript.
+- The transcript follows new attributed segments until the user scrolls away, then offers **Jump to live**.
+- The first release exposes Start, Pause, and Resume through Zoom's participant RTMS status API, but deliberately omits Stop. Pause preserves the Capture Attempt and records a known `user_paused` gap that makes the Transcript `partial`; nothing resumes automatically.
+- Review and enrichment remain on the same Call page after capture.
+- The Calls library initially shows Live and Recent Calls only.
+- A global **Call live** pill remains visible across the workspace and opens the active Call; Pause and Resume remain on the Call page.
+- Calls is a first-class workspace feature at `?feature=calls`.
+- The Calls page uses one compact **Start capture** dialog for a detected candidate or pasted Zoom link/meeting ID. A detected-call notification is an additional Start surface, but both entry points use the same validation and start action.
+- After Start, LaunchStack immediately opens the Call in `Connecting` state so note-taking can begin before RTMS is ready.
+- A detected-call notification is a persistent actionable ping showing the Zoom topic plus **Start** and **Dismiss**. It remains until acted on or the occurrence ends; dismissing suppresses only that occurrence.
+- The Call Note continuously autosaves through LaunchStack's existing rich-note model and displays Saving/Saved state without a Save button.
+- If RTMS fails to start, the Call workspace and Call Note remain available, the exact failure is shown, and the user can Retry through the same capture flow.
+- The Call Note is shared read-only with the company by default. Only its initiating owner can edit or accept AI revisions, and a **Shared with company** toggle can make it private during or after the Call; other users then see Transcript only.
+- Transcript segments are immutable and visible to all authorized company users. Only the Call Note owner can add a company-visible Bookmark with an optional freeform comment; AI infers whether that comment requests verbatim reuse or thematic focus.
+- The live editor is a blank rich Call Note using existing formatting and autosave, without templates or live-AI prompts.
+- After transcript finalization, AI automatically prepares an owner-only enrichment proposal and shows the owner a Ready badge and same-page banner without interrupting or navigating them. If the Call Note is blank, the proposal may generate a complete note from Transcript evidence. Review is side by side: the current note remains read-only beside an editable proposal; Accept creates the next canonical revision with the Call Note's current visibility and Reject preserves the current note.
+- Failed Calls remain in Recent even when empty. Empty failed attempts expose an explicit Delete action so the user can clean them up.
+- Calls uses a list/detail split: a compact Live/Recent rail remains beside the selected Call and collapses on narrow screens.
+- Enrichment review gives the current note and editable proposal two columns; citations open the relevant immutable Transcript segment in a collapsible evidence drawer.
+- Every known missing interval, including a user pause, appears as an immutable inline gap marker at the correct timeline position and in the Call's `partial` status with reason and duration.
+- Enrichment shows visible speaker-and-timestamp citations only for passages derived from Bookmarks; other AI-added prose has no visible inline citation.
+- Concurrent starts for the same company and Zoom occurrence converge on one Call and Capture. The first successful starter owns the Call Note; later users see **Call already live** and open it without creating another RTMS stream.
+- Call Note ownership does not transfer in the first release.
+- A Call defaults to its Zoom topic or **Untitled call**; the Call Note owner can rename the LaunchStack title without altering provider evidence.
+- Only the Call Note owner can delete an empty failed Call from Recent.
+- The global **Call live** pill appears only for the current user's active capture; other company Calls remain discoverable in the Calls rail.
+- Only the Capture User who started the current Attempt can Pause or Resume it; company viewers have no RTMS controls.
+- When the Call Note is shared, authorized company viewers see owner edits update during the live Call and afterward, but remain read-only.
+- Authorized company users can watch the immutable Transcript stream live, regardless of Call Note visibility.

--- a/docs/issues/call-notes-wayfinder/004-decide-transcript-note-rag-model.md
+++ b/docs/issues/call-notes-wayfinder/004-decide-transcript-note-rag-model.md
@@ -1,0 +1,18 @@
+---
+id: MN-WF-004
+title: Decide the Transcript, Note, and RAG Knowledge Model
+parent: MN-WF-000
+status: open
+assignee: null
+labels:
+  - wayfinder:grilling
+blocked_by:
+  - MN-WF-002
+  - MN-WF-003
+---
+
+# Decide the Transcript, Note, and RAG Knowledge Model
+
+## Question
+
+How should LaunchStack preserve a call transcript and its Call Note as equally significant but distinct knowledge: dedicated Call records, transcript segments, an ingested transcript Document, an editable `document_notes` record, embeddings, citations, and links—while reusing the existing document and notes retrieval paths instead of creating a third knowledge system?

--- a/docs/issues/call-notes-wayfinder/005-decide-ai-enrichment-provenance-contract.md
+++ b/docs/issues/call-notes-wayfinder/005-decide-ai-enrichment-provenance-contract.md
@@ -1,0 +1,19 @@
+---
+id: MN-WF-005
+title: Decide the AI Enrichment and Provenance Contract
+parent: MN-WF-000
+status: open
+assignee: null
+labels:
+  - wayfinder:grilling
+blocked_by:
+  - MN-WF-002
+  - MN-WF-003
+  - MN-WF-004
+---
+
+# Decide the AI Enrichment and Provenance Contract
+
+## Question
+
+How should post-call AI combine the user's steering notes with transcript evidence: precedence, omissions, contradictions, proposed edits versus automatic overwrite, citations to speakers and timestamps, repeat enrichment, model routing, structured outputs, and the boundary between an editable note and generated summary, decisions, and action items?

--- a/docs/issues/call-notes-wayfinder/006-decide-module-runtime-boundaries.md
+++ b/docs/issues/call-notes-wayfinder/006-decide-module-runtime-boundaries.md
@@ -1,0 +1,19 @@
+---
+id: MN-WF-006
+title: Decide the LaunchStack Module and Runtime Boundaries
+parent: MN-WF-000
+status: open
+assignee: null
+labels:
+  - wayfinder:grilling
+blocked_by:
+  - MN-WF-001
+  - MN-WF-002
+  - MN-WF-004
+---
+
+# Decide the LaunchStack Module and Runtime Boundaries
+
+## Question
+
+Which responsibilities belong in `apps/web`, a long-running workspace application such as `apps/call-worker`, `packages/features`, `packages/core`, PostgreSQL, object storage, Inngest, and the existing batch transcription sidecar—and what dependency and process boundaries keep Zoom lifecycle code, product policy, knowledge integration, and portable infrastructure from leaking into one another?

--- a/docs/issues/call-notes-wayfinder/007-decide-self-hosted-docker-topology.md
+++ b/docs/issues/call-notes-wayfinder/007-decide-self-hosted-docker-topology.md
@@ -1,0 +1,18 @@
+---
+id: MN-WF-007
+title: Decide the Self-Hosted Docker Topology
+parent: MN-WF-000
+status: open
+assignee: null
+labels:
+  - wayfinder:grilling
+blocked_by:
+  - MN-WF-001
+  - MN-WF-006
+---
+
+# Decide the Self-Hosted Docker Topology
+
+## Question
+
+What is the authoritative operator-owned deployment topology for web UI, RTMS worker, public HTTPS webhook and callback ingress, PostgreSQL, secrets, migrations, health checks, and optional existing services—and how should local development, a public Docker Compose host, and the current Vercel-plus-external-worker mode differ without becoming three architectures?

--- a/docs/issues/call-notes-wayfinder/008-decide-identity-consent-retention.md
+++ b/docs/issues/call-notes-wayfinder/008-decide-identity-consent-retention.md
@@ -1,0 +1,19 @@
+---
+id: MN-WF-008
+title: Decide Identity, Consent, Tenancy, and Retention Boundaries
+parent: MN-WF-000
+status: open
+assignee: null
+labels:
+  - wayfinder:grilling
+blocked_by:
+  - MN-WF-001
+  - MN-WF-002
+  - MN-WF-007
+---
+
+# Decide Identity, Consent, Tenancy, and Retention Boundaries
+
+## Question
+
+How do Clerk identity and company tenancy relate to Zoom app ownership, Zoom users, meeting hosts, participants, and stored OAuth tokens; who may start, view, enrich, share, export, or delete a Call; what consent evidence is retained; and what transcript, note, token, and derived-artifact retention defaults make an OSS deployment safe without inventing a compliance platform?

--- a/docs/issues/call-notes-wayfinder/009-decide-rtms-session-reliability.md
+++ b/docs/issues/call-notes-wayfinder/009-decide-rtms-session-reliability.md
@@ -1,0 +1,20 @@
+---
+id: MN-WF-009
+title: Decide the RTMS Session Reliability Model
+parent: MN-WF-000
+status: open
+assignee: null
+labels:
+  - wayfinder:grilling
+blocked_by:
+  - MN-WF-001
+  - MN-WF-002
+  - MN-WF-006
+  - MN-WF-007
+---
+
+# Decide the RTMS Session Reliability Model
+
+## Question
+
+What state machine and persistence guarantees govern a single-user RTMS capture from authorization through start, buffering, transcript ingestion, duplicate or out-of-order packets, worker restart, transport reconnect, the Capture User leaving and returning, stop, finalization, and partial failure—and which guarantees are required for the internal pilot versus deferred until measured concurrency demands them? Same-user continuation through a new Capture Attempt is in scope; cross-user handoff is not.

--- a/docs/issues/call-notes-wayfinder/010-define-future-capture-adapter-seam.md
+++ b/docs/issues/call-notes-wayfinder/010-define-future-capture-adapter-seam.md
@@ -1,0 +1,20 @@
+---
+id: MN-WF-010
+title: Define the Future Capture Adapter Seam
+parent: MN-WF-000
+status: open
+assignee: null
+labels:
+  - wayfinder:grilling
+blocked_by:
+  - MN-WF-002
+  - MN-WF-004
+  - MN-WF-006
+  - MN-WF-009
+---
+
+# Define the Future Capture Adapter Seam
+
+## Question
+
+What is the minimum platform-neutral boundary that lets a later Google Meet Media API or native capture source feed the settled Call model without weakening Zoom attribution or introducing a speculative provider framework—covering identities, finalized segments, timestamps, capabilities, lifecycle events, and explicitly unsupported raw-media or transcript-revision behavior?

--- a/docs/issues/call-notes-wayfinder/011-decide-downstream-knowledge-integrations.md
+++ b/docs/issues/call-notes-wayfinder/011-decide-downstream-knowledge-integrations.md
@@ -1,0 +1,20 @@
+---
+id: MN-WF-011
+title: Decide Post-Call Outputs and Downstream Integrations
+parent: MN-WF-000
+status: open
+assignee: null
+labels:
+  - wayfinder:grilling
+blocked_by:
+  - MN-WF-002
+  - MN-WF-003
+  - MN-WF-004
+  - MN-WF-005
+---
+
+# Decide Post-Call Outputs and Downstream Integrations
+
+## Question
+
+Which durable outputs should a completed Call expose to LaunchStack—enriched note, full transcript, summary, decisions, action items, participants, citations, embeddings, RAG retrieval, wiki links, Founder Weekly Review, or document workflows—and which system owns each output so Call Notes plugs into existing capabilities without coupling every downstream consumer to RTMS internals?

--- a/docs/issues/call-notes-wayfinder/012-decide-verification-rollout-gates.md
+++ b/docs/issues/call-notes-wayfinder/012-decide-verification-rollout-gates.md
@@ -1,0 +1,23 @@
+---
+id: MN-WF-012
+title: Decide Architecture Verification and Rollout Gates
+parent: MN-WF-000
+status: open
+assignee: null
+labels:
+  - wayfinder:grilling
+blocked_by:
+  - MN-WF-005
+  - MN-WF-007
+  - MN-WF-008
+  - MN-WF-009
+  - MN-WF-010
+  - MN-WF-011
+  - MN-WF-013
+---
+
+# Decide Architecture Verification and Rollout Gates
+
+## Question
+
+What observable scenarios, cost limits, security checks, failure drills, migration checks, and operator acceptance criteria must the eventual implementation satisfy before an internal pilot and before a supported OSS release—and which constraints are architectural gates rather than implementation-task details beyond this map's destination?

--- a/docs/issues/call-notes-wayfinder/013-confirm-target-zoom-rtms-access.md
+++ b/docs/issues/call-notes-wayfinder/013-confirm-target-zoom-rtms-access.md
@@ -1,0 +1,16 @@
+---
+id: MN-WF-013
+title: Confirm RTMS Access in the Target Zoom Account
+parent: MN-WF-000
+status: open
+assignee: null
+labels:
+  - wayfinder:task
+blocked_by: []
+---
+
+# Confirm RTMS Access in the Target Zoom Account
+
+## Question
+
+Can the actual Zoom account intended for the internal pilot create a user-managed General App, purchase or activate Developer Pack credits, expose the required RTMS scopes and events, add the private app to an intended user, show the current transcript-enabled rate and concurrency entitlement, and complete one disclosed single-user test stream without undocumented support enablement? The test must include native Pause and Resume, observe whether the media connection and RTMS billing continue while paused, then have the user leave and return and verify that LaunchStack can append the restarted RTMS session as a new Capture Attempt under the same logical Capture while accurately preserving every gap.

--- a/docs/issues/call-notes-wayfinder/014-resolve-calls-agent-meetings-boundary.md
+++ b/docs/issues/call-notes-wayfinder/014-resolve-calls-agent-meetings-boundary.md
@@ -1,0 +1,20 @@
+---
+id: MN-WF-014
+title: Resolve the Human Calls and Agent Meetings Boundary
+parent: MN-WF-000
+status: closed
+assignee: Main
+labels:
+  - wayfinder:grilling
+blocked_by: []
+---
+
+# Resolve the Human Calls and Agent Meetings Boundary
+
+## Question
+
+LaunchStack already uses `Meeting` for a Slack-shaped channel where agents work an objective, with its own Meeting state, participants, messages, and minutes. What distinct product and domain language should the Zoom human-conversation feature use; should the two surfaces remain separate, replace one another, or share a higher-level concept; and what navigation boundary prevents users and code from confusing agent Meetings with captured human calls?
+
+## Resolution comment
+
+The existing agent collaboration feature remains **Meetings** and is not modified. The Zoom-first human-conversation feature is **Call Notes**, appears in navigation as **Calls**, and uses **Call** as its aggregate name. Calls and agent Meetings keep separate routes, tables, lifecycle states, participant models, and product surfaces; they meet only through existing knowledge outputs such as notes, documents, decisions, and action items. `Meeting` remains reserved for the existing agent collaboration domain, while provider-specific prose may still refer to a Zoom or Google meeting.

--- a/docs/issues/call-notes-wayfinder/map.md
+++ b/docs/issues/call-notes-wayfinder/map.md
@@ -1,0 +1,52 @@
+---
+id: MN-WF-000
+title: Plan LaunchStack Call Notes Architecture
+status: open
+assignee: null
+labels:
+  - wayfinder:map
+tracker: local-markdown
+---
+
+# Plan LaunchStack Call Notes Architecture
+
+## Destination
+
+An architecture decision set for a Zoom-first, self-hosted LaunchStack Call Notes feature. The map is complete when the product and domain boundaries, Zoom capture lifecycle, knowledge model, module and runtime topology, deployment, security, operations, and future adapter seams are settled; implementation remains a separate handoff.
+
+## Notes
+
+- Domain: Founder OS call capture and AI-assisted notes integrated into LaunchStack.
+- Every decision session should consult the `grilling`, `domain-modeling`, and `ponytail` skills and the current LaunchStack architecture documentation.
+- Fully decide Zoom RTMS; use Google Meet and native capture only to pressure-test future seams.
+- Make self-hosted Docker the authoritative deployment. A hosted LaunchStack OAuth application is not part of this effort.
+- The operator owns the Zoom General app, Developer Pack billing, OAuth credentials, and public deployment endpoint.
+- During a call, LaunchStack must provide a live Zoom-attributed transcript and a place for the user to write notes. AI enrichment happens after the call, not as a live copilot.
+- Each Capture Attempt is anchored to one authorized Capture User. If that user leaves, the attempt ends and any retained Transcript is partial; the same user can continue the logical Capture in a new attempt after returning, while cross-user handoff is deferred.
+- Zoom's attributed transcript is the initial transcription source. Custom streaming ASR and raw-audio retention are not launch requirements.
+- Transcript evidence and the owner-authored Call Note are both first-class inputs. The architecture must preserve transcript thoroughness, owner steering, visibility, and provenance when AI enriches the note.
+- Existing code distinguishes editable, embedded `document_notes` from versioned, ingested `document` knowledge sources. The map must decide how a Call links or materializes both rather than assuming they are interchangeable.
+- Local-markdown tracker convention: ticket frontmatter records parent, label, status, assignee, and blocking relationships. An open ticket with `assignee: null` is unclaimed; a ticket is on the frontier when every `blocked_by` ticket is closed.
+
+## Decisions so far
+
+- [Verify the Zoom RTMS Operating Contract](./001-verify-zoom-rtms-operating-contract.md) — RTMS is viable for an operator-owned private app, but requires a long-running signed webhook/WebSocket runtime and application-owned transcript finalization; several commercial and replay guarantees remain undocumented.
+- [Define the Call Notes Domain Model](./002-define-call-notes-domain-model.md) — A company-scoped Call occurrence owns one logical Capture and immutable Transcript; its initiating user owns one revisioned Call Note, shared read-only with the company by default but optionally private, and each initial Capture Attempt stays anchored to one authorized Capture User.
+- [Resolve the Human Calls and Agent Meetings Boundary](./014-resolve-calls-agent-meetings-boundary.md) — The existing agent Meetings feature remains untouched; the new human-conversation feature is Call Notes, uses Calls in navigation and Call in the domain, and shares only downstream knowledge outputs with agent Meetings.
+
+## Not yet specified
+
+- The final ADR/document split and execution handoff shape will become clear only after the substantive architecture decisions close.
+- Operator upgrade, migration, and backward-compatibility obligations depend on the selected deployment and persistence boundaries.
+- Whether future providers need transcript revision semantics, raw-media capabilities, or only finalized attributed segments depends on the Call aggregate and Zoom operating contract.
+
+## Out of scope
+
+- Implementing the feature or producing a build-task backlog.
+- A complete Google Meet, native recorder, browser recorder, or meeting-bot implementation.
+- A centrally hosted LaunchStack OAuth app, Marketplace publication, centralized RTMS billing, or SaaS pricing.
+- Custom streaming ASR and raw-audio recording for the Zoom-first release.
+- Pixel-level visual design beyond prototypes needed to resolve architecture-affecting behavior.
+- User-editable transcript correction tooling; the Zoom-first model keeps transcript evidence immutable.
+- Participant-to-LaunchStack-user or contact identity matching; the first release keeps provider-supplied participant names and call-local identities only.
+- Cross-user Capture handoff, overlapping RTMS user sessions, and continuity billing. Same-user continuation through a new Capture Attempt remains in scope.


### PR DESCRIPTION
## Summary

- Add the Call Notes architecture wayfinder and its decision tickets.
- Define canonical Call, Capture, Transcript, Call Note, and enrichment terminology in `CONTEXT.md`.
- Record resolved Zoom RTMS, domain-model, and Calls-versus-Meetings boundaries alongside the remaining architecture decisions.

## Related

No linked issue.

## Checklist

- [ ] `pnpm check` passes (lint + typecheck)
- [ ] `pnpm --filter @launchstack/web test` passes
- [ ] Changeset added (if `packages/core/` changed — `pnpm changeset`)
- [ ] New env vars documented in `.env.example` and `apps/web/src/env.ts`
- [ ] UI changes exercised in a browser (not just a green build)
- [x] Docs updated if behavior changed

## Testing

- `pnpm exec prettier --check CONTEXT.md docs/issues/call-notes-wayfinder/*.md`
- `git diff --cached --check`

## Notes for reviewers

Documentation-only change. No runtime code, package, environment, or UI behavior changed.