### PR TITLE
Right-click context menus for the documents workspace

### DIFF
--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -1,0 +1,3 @@
+
+# clerk configuration (can include secrets)
+/.clerk/

--- a/apps/web/src/app/dev/source-rail/SourceRailPreview.tsx
+++ b/apps/web/src/app/dev/source-rail/SourceRailPreview.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { ConfirmActionDialog } from "~/app/employer/documents/_workspace/ConfirmActionDialog";
+import { RenameSourceDialog } from "~/app/employer/documents/_workspace/RenameSourceDialog";
+import { SourceRail } from "~/app/employer/documents/_workspace/SourceRail";
+import type {
+  WorkspaceFolder,
+  WorkspaceSource,
+} from "~/app/employer/documents/_workspace/types";
+
+const FIXTURE_SOURCES: WorkspaceSource[] = [
+  {
+    id: "d1",
+    documentId: 1,
+    title:
+      "Claude Code (global) — projects/-Users-aurea-Pensieve-new-frontend/memory/reference_design_bundles.md",
+    type: "doc",
+    size: "",
+    added: "2h ago",
+    folder: "Launchstack Future Plans 2",
+    tags: ["memory"],
+    domain: "Technical",
+  },
+  {
+    id: "d2",
+    documentId: 2,
+    title:
+      "Claude Code (global) — projects/-Users-aurea-AI-coworker/memory/feedback_parallel_worktree_scopes.md",
+    type: "doc",
+    size: "",
+    added: "Yesterday",
+    folder: "Launchstack Future Plans 2",
+    tags: ["memory"],
+    domain: "Technical",
+  },
+];
+
+const FIXTURE_FOLDERS: WorkspaceFolder[] = [
+  { id: "cat-1", name: "Launchstack Future Plans 2", color: "oklch(0.6 0.17 285)" },
+  { id: "cat-2", name: "Unfiled", color: "oklch(0.5 0.02 280)" },
+];
+
+/**
+ * Local harness for the source-rail context menu. Production auth is skipped so
+ * the menu can be exercised without a Clerk session. Gated by the server page.
+ */
+export function SourceRailPreview() {
+  const [sources, setSources] = useState(FIXTURE_SOURCES);
+  const [selected, setSelected] = useState<string[]>([]);
+  const [activeFolder, setActiveFolder] = useState<string | null>(null);
+  const [activeTag, setActiveTag] = useState<string | null>(null);
+  const [renameSource, setRenameSource] = useState<WorkspaceSource | null>(null);
+  const [deleteSource, setDeleteSource] = useState<WorkspaceSource | null>(null);
+  const [opened, setOpened] = useState<string | null>(null);
+
+  const folders = useMemo(() => FIXTURE_FOLDERS, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (new URLSearchParams(window.location.search).get("openMenu") !== "1") return;
+    const timer = window.setTimeout(() => {
+      const row = document.querySelector("[data-testid='source-row-d1']");
+      row?.dispatchEvent(
+        new MouseEvent("contextmenu", {
+          bubbles: true,
+          cancelable: true,
+          clientX: 120,
+          clientY: 220,
+        }),
+      );
+    }, 50);
+    return () => window.clearTimeout(timer);
+  }, []);
+
+  return (
+    <div
+      className="lsw-root"
+      style={{
+        height: "100vh",
+        background: "var(--bg)",
+        color: "var(--ink)",
+      }}
+    >
+      <SourceRail
+        sources={sources}
+        folders={folders}
+        selected={selected}
+        setSelected={setSelected}
+        onOpenAdd={() => setOpened("add")}
+        onOpenSource={(source) => setOpened(`open:${source.title}`)}
+        onNewFolder={() => setOpened("new-folder")}
+        onRenameFolder={(folder) => setOpened(`rename-folder:${folder.name}`)}
+        onMoveToFolder={(id, name) => {
+          setSources((prev) =>
+            prev.map((source) => (source.id === id ? { ...source, folder: name } : source)),
+          );
+        }}
+        onRenameSource={setRenameSource}
+        onDeleteSource={setDeleteSource}
+        activeFolder={activeFolder}
+        setActiveFolder={setActiveFolder}
+        activeTag={activeTag}
+        setActiveTag={setActiveTag}
+      />
+      {opened && (
+        <div
+          data-testid="preview-last-action"
+          style={{
+            position: "fixed",
+            right: 16,
+            bottom: 16,
+            padding: "8px 12px",
+            borderRadius: 8,
+            background: "var(--panel)",
+            border: "1px solid var(--line)",
+            fontSize: 12,
+            maxWidth: 360,
+          }}
+        >
+          {opened}
+        </div>
+      )}
+      <RenameSourceDialog
+        open={!!renameSource}
+        source={renameSource}
+        onClose={() => setRenameSource(null)}
+        onRename={async (documentId, title) => {
+          setSources((prev) =>
+            prev.map((source) =>
+              source.documentId === documentId ? { ...source, title } : source,
+            ),
+          );
+          return true;
+        }}
+      />
+      <ConfirmActionDialog
+        open={!!deleteSource}
+        title="Delete this source?"
+        body={
+          deleteSource
+            ? `"${deleteSource.title}" will be removed from this workspace. This cannot be undone.`
+            : ""
+        }
+        confirmLabel="Delete"
+        onConfirm={() => {
+          if (!deleteSource) return;
+          setSources((prev) => prev.filter((source) => source.id !== deleteSource.id));
+          setDeleteSource(null);
+        }}
+        onClose={() => setDeleteSource(null)}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/app/dev/source-rail/page.tsx
+++ b/apps/web/src/app/dev/source-rail/page.tsx
@@ -1,0 +1,7 @@
+import { notFound } from "next/navigation";
+import { SourceRailPreview } from "./SourceRailPreview";
+
+export default function SourceRailPreviewPage() {
+  if (process.env.NODE_ENV === "production") notFound();
+  return <SourceRailPreview />;
+}

--- a/apps/web/src/app/employer/documents/_workspace/ConfirmActionDialog.tsx
+++ b/apps/web/src/app/employer/documents/_workspace/ConfirmActionDialog.tsx
@@ -1,0 +1,143 @@
+"use client";
+
+import { useEffect } from "react";
+
+export interface ConfirmActionDialogProps {
+  open: boolean;
+  title: string;
+  body: string;
+  confirmLabel: string;
+  busy?: boolean;
+  error?: string | null;
+  danger?: boolean;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+export function ConfirmActionDialog({
+  open,
+  title,
+  body,
+  confirmLabel,
+  busy = false,
+  error,
+  danger = true,
+  onConfirm,
+  onClose,
+}: ConfirmActionDialogProps) {
+  useEffect(() => {
+    if (!open) return;
+    const onEsc = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !busy) onClose();
+    };
+    window.addEventListener("keydown", onEsc);
+    return () => window.removeEventListener("keydown", onEsc);
+  }, [open, onClose, busy]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      data-testid="confirm-action-dialog"
+      onClick={() => {
+        if (!busy) onClose();
+      }}
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 210,
+        background: "var(--scrim)",
+        backdropFilter: "blur(4px)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        animation: "lsw-fadeIn 140ms",
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="confirm-action-title"
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          width: 420,
+          maxWidth: "92vw",
+          background: "var(--panel)",
+          borderRadius: 14,
+          boxShadow: "0 30px 80px var(--scrim-shadow), 0 0 0 1px var(--line)",
+          overflow: "hidden",
+          animation: "lsw-modalIn 180ms",
+        }}
+      >
+        <div style={{ padding: "18px 20px 14px" }}>
+          <div
+            id="confirm-action-title"
+            style={{ fontSize: 15, fontWeight: 700, marginBottom: 8 }}
+          >
+            {title}
+          </div>
+          <p
+            style={{
+              margin: 0,
+              fontSize: 13,
+              lineHeight: 1.55,
+              color: "var(--ink-2)",
+            }}
+          >
+            {body}
+          </p>
+          {error && (
+            <div style={{ fontSize: 11, color: "var(--danger)", marginTop: 8 }}>
+              {error}
+            </div>
+          )}
+        </div>
+        <div
+          style={{
+            padding: "12px 20px",
+            borderTop: "1px solid var(--line)",
+            background: "var(--line-2)",
+            display: "flex",
+            gap: 8,
+            justifyContent: "flex-end",
+          }}
+        >
+          <button
+            onClick={onClose}
+            disabled={busy}
+            style={{
+              fontSize: 13,
+              padding: "7px 14px",
+              borderRadius: 7,
+              color: "var(--ink-2)",
+              border: "1px solid var(--line)",
+              background: "var(--panel)",
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={busy}
+            data-testid="confirm-action-confirm"
+            style={{
+              fontSize: 13,
+              fontWeight: 600,
+              padding: "7px 14px",
+              borderRadius: 7,
+              background: busy
+                ? "var(--line)"
+                : danger
+                  ? "var(--danger, oklch(0.5 0.18 25))"
+                  : "var(--accent)",
+              color: busy ? "var(--ink-3)" : "white",
+              cursor: busy ? "not-allowed" : "pointer",
+            }}
+          >
+            {busy ? "Working…" : confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/employer/documents/_workspace/ContextMenu.module.css
+++ b/apps/web/src/app/employer/documents/_workspace/ContextMenu.module.css
@@ -1,0 +1,142 @@
+/**
+ * Same surface language as StudioMenu / CommandPalette: token colors only,
+ * inherited from the `.lsw-root` the menu is portaled into.
+ */
+
+.layer {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  background: transparent;
+}
+
+.menu {
+  position: fixed;
+  z-index: 201;
+  box-sizing: border-box;
+  min-width: 228px;
+  max-width: 280px;
+  max-height: min(420px, calc(100vh - 16px));
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding: 5px;
+  border-radius: 12px;
+  isolation: isolate;
+  font-family: inherit;
+  color: var(--ink);
+  background: var(--panel);
+  border: 1px solid var(--line);
+  box-shadow: 0 18px 42px var(--scrim-shadow), 0 2px 6px rgba(0, 0, 0, 0.06);
+  outline: none;
+  transform-origin: top left;
+  animation: menuIn 120ms ease-out;
+}
+
+.label {
+  padding: 7px 10px 8px;
+  margin: 0 2px 3px;
+  border-bottom: 1px solid var(--line);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  line-height: 1.35;
+  color: var(--ink-3);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.separator {
+  height: 1px;
+  margin: 4px 8px;
+  background: var(--line);
+}
+
+.item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 10px;
+  border-radius: 8px;
+  font-size: 12.5px;
+  font-weight: 500;
+  line-height: 1.3;
+  cursor: pointer;
+  user-select: none;
+  color: var(--ink);
+  background: transparent;
+  transition: background 120ms;
+}
+
+.itemIcon {
+  width: 16px;
+  height: 16px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  color: var(--ink-3);
+}
+
+.itemLabel {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  text-align: left;
+}
+
+.itemShortcut {
+  margin-left: 8px;
+  font-size: 10px;
+  color: var(--ink-3);
+}
+
+.itemChevron {
+  color: var(--ink-3);
+  flex-shrink: 0;
+}
+
+.itemActive {
+  background: var(--line-2);
+}
+
+.itemActive .itemIcon,
+.itemActive .itemChevron,
+.itemActive .itemShortcut {
+  color: var(--ink-2);
+}
+
+.itemDanger {
+  color: var(--danger);
+}
+
+.itemDanger .itemIcon {
+  color: var(--danger);
+}
+
+.itemDanger.itemActive {
+  background: var(--line-2);
+  color: var(--danger);
+}
+
+.itemDisabled {
+  cursor: not-allowed;
+  color: var(--ink-4);
+  background: transparent;
+}
+
+.itemDisabled .itemIcon,
+.itemDisabled .itemChevron {
+  color: var(--ink-4);
+}
+
+@keyframes menuIn {
+  from {
+    transform: translateY(4px);
+  }
+  to {
+    transform: translateY(0);
+  }
+}

--- a/apps/web/src/app/employer/documents/_workspace/ContextMenu.tsx
+++ b/apps/web/src/app/employer/documents/_workspace/ContextMenu.tsx
@@ -1,0 +1,448 @@
+"use client";
+
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type MouseEvent as ReactMouseEvent,
+  type ReactNode,
+} from "react";
+import { createPortal } from "react-dom";
+import {
+  IconCheck,
+  IconChevronRight,
+  IconCopy,
+  IconEye,
+  IconFolder,
+  IconPen,
+  IconPlus,
+  IconSparkle,
+  IconTrash,
+} from "./icons";
+import { placeMenu, placeSubmenu } from "./placeMenu";
+import type { SourceContextMenuItem } from "./sourceContextMenu";
+import styles from "./ContextMenu.module.css";
+
+export type { SourceContextMenuItem };
+
+export interface ContextMenuProps {
+  open: boolean;
+  x: number;
+  y: number;
+  items: SourceContextMenuItem[];
+  onClose: () => void;
+  ariaLabel?: string;
+}
+
+type MenuIconName = NonNullable<
+  Extract<SourceContextMenuItem, { type: "item" | "submenu" }>["icon"]
+>;
+
+/** Mirrors `min-width` in ContextMenu.module.css; used for submenu placement math. */
+const MENU_MIN_WIDTH = 228;
+const SUBMENU_OPEN_DELAY_MS = 120;
+
+function iconFor(name: MenuIconName | undefined): ReactNode {
+  switch (name) {
+    case "open":
+      return <IconEye size={13} />;
+    case "ask":
+      return <IconSparkle size={13} />;
+    case "rename":
+      return <IconPen size={13} />;
+    case "copy":
+      return <IconCopy size={13} />;
+    case "delete":
+      return <IconTrash size={13} />;
+    case "folder":
+      return <IconFolder size={13} />;
+    case "plus":
+      return <IconPlus size={13} />;
+    case "check":
+      return <IconCheck size={13} />;
+    default:
+      return null;
+  }
+}
+
+function actionableItems(items: SourceContextMenuItem[]): SourceContextMenuItem[] {
+  return items.filter((item) => item.type === "item" || item.type === "submenu");
+}
+
+function portalRoot(): HTMLElement {
+  return document.querySelector(".lsw-root") ?? document.body;
+}
+
+export function ContextMenu({
+  open,
+  x,
+  y,
+  items,
+  onClose,
+  ariaLabel = "Actions",
+}: ContextMenuProps) {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+  if (!mounted || !open || items.length === 0) return null;
+  return createPortal(
+    <ContextMenuLayer
+      x={x}
+      y={y}
+      items={items}
+      onClose={onClose}
+      ariaLabel={ariaLabel}
+    />,
+    portalRoot(),
+  );
+}
+
+function ContextMenuLayer({
+  x,
+  y,
+  items,
+  onClose,
+  ariaLabel,
+}: Omit<ContextMenuProps, "open">) {
+  const menuRef = useRef<HTMLDivElement>(null);
+  const [pos, setPos] = useState({ left: x, top: y });
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [openSubmenuId, setOpenSubmenuId] = useState<string | null>(null);
+  const labelId = useId();
+  const actionables = useMemo(() => actionableItems(items), [items]);
+
+  useLayoutEffect(() => {
+    const el = menuRef.current;
+    if (!el) return;
+    const next = placeMenu({
+      x,
+      y,
+      width: el.offsetWidth,
+      height: el.offsetHeight,
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+    });
+    setPos(next);
+  }, [x, y, items]);
+
+  useEffect(() => {
+    menuRef.current?.focus();
+  }, []);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        if (openSubmenuId) {
+          setOpenSubmenuId(null);
+          return;
+        }
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose, openSubmenuId]);
+
+  const moveActive = useCallback(
+    (delta: number) => {
+      if (actionables.length === 0) return;
+      const current = actionables.findIndex((item) => item.id === activeId);
+      const start = current === -1 ? (delta > 0 ? -1 : 0) : current;
+      const next = (start + delta + actionables.length) % actionables.length;
+      setActiveId(actionables[next]!.id);
+      const item = actionables[next]!;
+      setOpenSubmenuId(item.type === "submenu" ? item.id : null);
+    },
+    [actionables, activeId],
+  );
+
+  const activate = useCallback(
+    (item: SourceContextMenuItem) => {
+      if (item.type === "item") {
+        if (item.disabled) return;
+        item.onSelect();
+        onClose();
+        return;
+      }
+      if (item.type === "submenu" && !item.disabled) {
+        setOpenSubmenuId(item.id);
+        setActiveId(item.id);
+      }
+    },
+    [onClose],
+  );
+
+  const onKeyDown = (e: ReactKeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      moveActive(1);
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      moveActive(-1);
+    } else if (e.key === "Home") {
+      e.preventDefault();
+      setActiveId(actionables[0]?.id ?? null);
+    } else if (e.key === "End") {
+      e.preventDefault();
+      setActiveId(actionables[actionables.length - 1]?.id ?? null);
+    } else if (e.key === "ArrowRight") {
+      const current = actionables.find((item) => item.id === activeId);
+      if (current?.type === "submenu" && !current.disabled) {
+        e.preventDefault();
+        setOpenSubmenuId(current.id);
+      }
+    } else if (e.key === "ArrowLeft") {
+      if (openSubmenuId) {
+        e.preventDefault();
+        setOpenSubmenuId(null);
+      }
+    } else if (e.key === "Enter" || e.key === " ") {
+      const current = actionables.find((item) => item.id === activeId);
+      if (current) {
+        e.preventDefault();
+        activate(current);
+      }
+    }
+  };
+
+  return (
+    <div
+      className={styles.layer}
+      data-testid="context-menu-backdrop"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+      onContextMenu={(e) => {
+        e.preventDefault();
+        onClose();
+      }}
+    >
+      <MenuPanel
+        ref={menuRef}
+        labelledBy={labelId}
+        ariaLabel={ariaLabel}
+        items={items}
+        left={pos.left}
+        top={pos.top}
+        activeId={activeId}
+        openSubmenuId={openSubmenuId}
+        onHover={(id, item) => {
+          setActiveId(id);
+          if (item?.type === "submenu" && !item.disabled) {
+            setOpenSubmenuId(item.id);
+          } else if (item?.type === "item") {
+            setOpenSubmenuId(null);
+          }
+        }}
+        onActivate={activate}
+        onKeyDown={onKeyDown}
+        parentPos={pos}
+      />
+    </div>
+  );
+}
+
+interface MenuPanelProps {
+  items: SourceContextMenuItem[];
+  left: number;
+  top: number;
+  activeId: string | null;
+  openSubmenuId: string | null;
+  labelledBy?: string;
+  ariaLabel?: string;
+  onHover: (id: string | null, item: SourceContextMenuItem | null) => void;
+  onActivate: (item: SourceContextMenuItem) => void;
+  onKeyDown?: (e: ReactKeyboardEvent<HTMLDivElement>) => void;
+  parentPos: { left: number; top: number };
+  nested?: boolean;
+}
+
+// Named MenuPanelImpl, not MenuPanel: a named function expression binds its own
+// name inside its body, so the recursive <MenuPanel> below would resolve to this
+// raw (props, ref) render function instead of the forwardRef component.
+const MenuPanel = forwardRef<HTMLDivElement, MenuPanelProps>(function MenuPanelImpl(
+  {
+    items,
+    left,
+    top,
+    activeId,
+    openSubmenuId,
+    labelledBy,
+    ariaLabel,
+    onHover,
+    onActivate,
+    onKeyDown,
+    parentPos,
+    nested,
+  },
+  ref,
+) {
+  const submenuTimer = useRef<number | null>(null);
+  const itemRefs = useRef<Record<string, HTMLDivElement | null>>({});
+
+  useEffect(() => {
+    return () => {
+      if (submenuTimer.current != null) window.clearTimeout(submenuTimer.current);
+    };
+  }, []);
+
+  const openSubmenu = items.find(
+    (item): item is Extract<SourceContextMenuItem, { type: "submenu" }> =>
+      item.type === "submenu" && item.id === openSubmenuId && !item.disabled,
+  );
+
+  let submenuPos = { left: left + MENU_MIN_WIDTH, top };
+  if (openSubmenu) {
+    const trigger = itemRefs.current[openSubmenu.id];
+    const offsetTop = trigger ? trigger.offsetTop : 0;
+    submenuPos = placeSubmenu({
+      parentLeft: parentPos.left,
+      parentTop: parentPos.top,
+      parentWidth: trigger?.offsetWidth ?? MENU_MIN_WIDTH,
+      itemOffsetTop: offsetTop,
+      width: MENU_MIN_WIDTH,
+      height: Math.min(openSubmenu.items.length * 32 + 8, 320),
+      viewportWidth: typeof window === "undefined" ? 1280 : window.innerWidth,
+      viewportHeight: typeof window === "undefined" ? 800 : window.innerHeight,
+    });
+  }
+
+  return (
+    <>
+      <div
+        ref={ref}
+        role="menu"
+        tabIndex={nested ? -1 : 0}
+        aria-label={ariaLabel}
+        aria-labelledby={labelledBy}
+        data-testid={nested ? "context-submenu" : "context-menu"}
+        onKeyDown={onKeyDown}
+        onContextMenu={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+        }}
+        className={styles.menu}
+        style={{
+          left,
+          top,
+          zIndex: nested ? 202 : 201,
+        }}
+      >
+        {items.map((item) => {
+          if (item.type === "separator") {
+            return (
+              <div
+                key={item.id}
+                role="separator"
+                data-testid={`context-menu-sep-${item.id}`}
+                className={styles.separator}
+              />
+            );
+          }
+          if (item.type === "label") {
+            return (
+              <div
+                key={item.id}
+                id={labelledBy}
+                data-testid={`context-menu-label-${item.id}`}
+                title={item.label}
+                className={styles.label}
+              >
+                {item.label}
+              </div>
+            );
+          }
+
+          const disabled = Boolean(item.disabled);
+          const danger = item.type === "item" && item.danger;
+          const active = item.id === activeId && !disabled;
+          const icon = iconFor(item.icon);
+          const itemClass = [
+            styles.item,
+            active ? styles.itemActive : "",
+            danger ? styles.itemDanger : "",
+            disabled ? styles.itemDisabled : "",
+          ]
+            .filter(Boolean)
+            .join(" ");
+
+          return (
+            <div
+              key={item.id}
+              ref={(node) => {
+                itemRefs.current[item.id] = node;
+              }}
+              role="menuitem"
+              aria-disabled={disabled || undefined}
+              aria-haspopup={item.type === "submenu" ? "menu" : undefined}
+              aria-expanded={
+                item.type === "submenu" ? item.id === openSubmenuId : undefined
+              }
+              data-testid={`context-menu-item-${item.id}`}
+              title={
+                disabled && "disabledReason" in item
+                  ? item.disabledReason
+                  : item.label
+              }
+              onMouseEnter={() => {
+                if (submenuTimer.current != null) {
+                  window.clearTimeout(submenuTimer.current);
+                }
+                submenuTimer.current = window.setTimeout(() => {
+                  onHover(item.id, item);
+                }, SUBMENU_OPEN_DELAY_MS);
+              }}
+              onMouseLeave={() => {
+                if (submenuTimer.current != null) {
+                  window.clearTimeout(submenuTimer.current);
+                  submenuTimer.current = null;
+                }
+              }}
+              onMouseDown={(e: ReactMouseEvent) => {
+                e.preventDefault();
+                e.stopPropagation();
+              }}
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                onActivate(item);
+              }}
+              className={itemClass}
+            >
+              <span className={styles.itemIcon}>{icon}</span>
+              <span className={styles.itemLabel}>{item.label}</span>
+              {item.type === "item" && item.shortcut && (
+                <span className={`mono ${styles.itemShortcut}`}>{item.shortcut}</span>
+              )}
+              {item.type === "submenu" && (
+                <IconChevronRight size={12} className={styles.itemChevron} />
+              )}
+            </div>
+          );
+        })}
+      </div>
+      {openSubmenu && (
+        <MenuPanel
+          nested
+          items={openSubmenu.items}
+          left={submenuPos.left}
+          top={submenuPos.top}
+          activeId={null}
+          openSubmenuId={null}
+          ariaLabel={openSubmenu.label}
+          onHover={() => undefined}
+          onActivate={onActivate}
+          parentPos={submenuPos}
+        />
+      )}
+    </>
+  );
+});
+
+MenuPanel.displayName = "MenuPanel";

--- a/apps/web/src/app/employer/documents/_workspace/KnowledgePane.tsx
+++ b/apps/web/src/app/employer/documents/_workspace/KnowledgePane.tsx
@@ -21,6 +21,8 @@ import {
   IconSearch,
   IconX,
 } from "./icons";
+import { ContextMenu } from "./ContextMenu";
+import { buildSourceMenuItems } from "./sourceContextMenu";
 import { ADD_TABS, DOC_DOMAINS, SOURCE_META } from "./types";
 import type { SourceTypeId, WorkspaceFolder, WorkspaceSource } from "./types";
 
@@ -38,6 +40,9 @@ export interface KnowledgePaneProps {
   onOpenSource: (source: WorkspaceSource) => void;
   onOpenAdd: (tabId?: string) => void;
   onAskAbout: (sourceIds: string[]) => void;
+  onRenameSource?: (source: WorkspaceSource) => void;
+  onDeleteSource?: (source: WorkspaceSource) => void;
+  onMoveToFolder?: (sourceId: string, folderName: string) => void;
 }
 
 type Layout = "grid" | "list";
@@ -51,11 +56,56 @@ export function KnowledgePane({
   onOpenSource,
   onOpenAdd,
   onAskAbout,
+  onRenameSource,
+  onDeleteSource,
+  onMoveToFolder,
 }: KnowledgePaneProps) {
   const [query, setQuery] = useState("");
   const [folder, setFolder] = useState<string | null>(null);
   const [type, setType] = useState<SourceTypeId | null>(null);
   const [layout, setLayout] = useState<Layout>("grid");
+  const [menu, setMenu] = useState<{
+    x: number;
+    y: number;
+    source: WorkspaceSource;
+  } | null>(null);
+
+  const openSourceMenu = (source: WorkspaceSource, point: { clientX: number; clientY: number }) => {
+    setMenu({ source, x: point.clientX, y: point.clientY });
+  };
+
+  const menuItems = useMemo(
+    () =>
+      menu
+        ? buildSourceMenuItems(menu.source, folders, selected, {
+            onOpen: onOpenSource,
+            onToggleContext: (source) => {
+              if (selected.includes(source.id)) {
+                setSelected((prev) => prev.filter((id) => id !== source.id));
+                return;
+              }
+              onAskAbout([source.id]);
+            },
+            onRename: onRenameSource,
+            onMoveToFolder,
+            onCopyTitle: (source) => {
+              void navigator.clipboard?.writeText(source.title).catch(() => undefined);
+            },
+            onDelete: onDeleteSource,
+          })
+        : [],
+    [
+      menu,
+      folders,
+      selected,
+      onOpenSource,
+      onAskAbout,
+      onRenameSource,
+      onMoveToFolder,
+      onDeleteSource,
+      setSelected,
+    ],
+  );
 
   const counts = useMemo(() => {
     const byType = new Map<SourceTypeId, number>();
@@ -277,6 +327,7 @@ export function KnowledgePane({
                 selected={selected.includes(source.id)}
                 onToggle={() => toggle(source.id)}
                 onOpen={() => onOpenSource(source)}
+                onOpenMenu={openSourceMenu}
               />
             ))}
           </div>
@@ -286,11 +337,22 @@ export function KnowledgePane({
             selected={selected}
             onToggle={toggle}
             onOpen={onOpenSource}
+            onOpenMenu={openSourceMenu}
           />
         )}
 
         <ConnectorStrip onOpenAdd={onOpenAdd} />
       </div>
+      {menu && (
+        <ContextMenu
+          open
+          x={menu.x}
+          y={menu.y}
+          items={menuItems}
+          ariaLabel={`Actions for ${menu.source.title}`}
+          onClose={() => setMenu(null)}
+        />
+      )}
     </div>
   );
 }
@@ -483,11 +545,13 @@ function SourceCard({
   selected,
   onToggle,
   onOpen,
+  onOpenMenu,
 }: {
   source: WorkspaceSource;
   selected: boolean;
   onToggle: () => void;
   onOpen: () => void;
+  onOpenMenu?: (source: WorkspaceSource, point: { clientX: number; clientY: number }) => void;
 }) {
   const meta = SOURCE_META[source.type];
   const domain = DOC_DOMAINS[source.domain] ?? DOC_DOMAINS.General;
@@ -495,13 +559,26 @@ function SourceCard({
   return (
     <div
       onClick={onOpen}
+      onContextMenu={(e) => {
+        if (!onOpenMenu) return;
+        e.preventDefault();
+        e.stopPropagation();
+        onOpenMenu(source, { clientX: e.clientX, clientY: e.clientY });
+      }}
       role="button"
       tabIndex={0}
+      data-testid={`knowledge-card-${source.id}`}
       onKeyDown={(e) => {
         if (e.key === "Enter" || e.key === " ") {
           e.preventDefault();
           onOpen();
+          return;
         }
+        if (!onOpenMenu) return;
+        if (e.key !== "ContextMenu" && !(e.shiftKey && e.key === "F10")) return;
+        e.preventDefault();
+        const rect = e.currentTarget.getBoundingClientRect();
+        onOpenMenu(source, { clientX: rect.left + 16, clientY: rect.bottom });
       }}
       style={{
         position: "relative",
@@ -633,11 +710,13 @@ function SourceTable({
   selected,
   onToggle,
   onOpen,
+  onOpenMenu,
 }: {
   sources: WorkspaceSource[];
   selected: string[];
   onToggle: (id: string) => void;
   onOpen: (source: WorkspaceSource) => void;
+  onOpenMenu?: (source: WorkspaceSource, point: { clientX: number; clientY: number }) => void;
 }) {
   return (
     <div
@@ -668,7 +747,14 @@ function SourceTable({
               return (
                 <tr
                   key={source.id}
+                  data-testid={`knowledge-row-${source.id}`}
                   onClick={() => onOpen(source)}
+                  onContextMenu={(e) => {
+                    if (!onOpenMenu) return;
+                    e.preventDefault();
+                    e.stopPropagation();
+                    onOpenMenu(source, { clientX: e.clientX, clientY: e.clientY });
+                  }}
                   style={{
                     borderTop: "1px solid var(--line)",
                     cursor: "pointer",

--- a/apps/web/src/app/employer/documents/_workspace/RenameSourceDialog.tsx
+++ b/apps/web/src/app/employer/documents/_workspace/RenameSourceDialog.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { IconFile } from "./icons";
+import type { WorkspaceSource } from "./types";
+
+export interface RenameSourceDialogProps {
+  open: boolean;
+  source: WorkspaceSource | null;
+  onClose: () => void;
+  onRename: (documentId: number, title: string) => Promise<boolean>;
+}
+
+export function RenameSourceDialog({
+  open,
+  source,
+  onClose,
+  onRename,
+}: RenameSourceDialogProps) {
+  const [name, setName] = useState(source?.title ?? "");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (open && source) {
+      setName(source.title);
+      setError(null);
+      setSubmitting(false);
+    }
+  }, [open, source]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onEsc = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && !submitting) onClose();
+    };
+    window.addEventListener("keydown", onEsc);
+    return () => window.removeEventListener("keydown", onEsc);
+  }, [open, onClose, submitting]);
+
+  if (!open || !source) return null;
+
+  const trimmed = name.trim();
+  const unchanged = trimmed === source.title;
+  const ok = trimmed.length > 0 && !unchanged && Boolean(source.documentId);
+
+  const submit = async () => {
+    if (!ok || submitting || !source.documentId) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const success = await onRename(source.documentId, trimmed);
+      if (!success) {
+        setError("Couldn't rename this source. Try again.");
+        return;
+      }
+      onClose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to rename");
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      data-testid="rename-source-dialog"
+      onClick={() => {
+        if (!submitting) onClose();
+      }}
+      style={{
+        position: "fixed",
+        inset: 0,
+        zIndex: 210,
+        background: "var(--scrim)",
+        backdropFilter: "blur(4px)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        animation: "lsw-fadeIn 140ms",
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="rename-source-title"
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          width: 440,
+          maxWidth: "92vw",
+          background: "var(--panel)",
+          borderRadius: 14,
+          boxShadow: "0 30px 80px var(--scrim-shadow), 0 0 0 1px var(--line)",
+          overflow: "hidden",
+          animation: "lsw-modalIn 180ms",
+        }}
+      >
+        <div style={{ padding: "18px 20px 14px" }}>
+          <div
+            style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 14 }}
+          >
+            <div
+              style={{
+                width: 28,
+                height: 28,
+                borderRadius: 7,
+                background: "var(--accent-soft)",
+                color: "var(--accent)",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
+              <IconFile size={14} />
+            </div>
+            <div id="rename-source-title" style={{ fontSize: 15, fontWeight: 700 }}>
+              Rename source
+            </div>
+          </div>
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            autoFocus
+            disabled={submitting}
+            maxLength={256}
+            aria-label="Source title"
+            data-testid="rename-source-input"
+            onKeyDown={(e) => {
+              if (e.key === "Enter") void submit();
+            }}
+            style={{
+              width: "100%",
+              padding: "10px 14px",
+              borderRadius: 9,
+              fontSize: 14,
+              border: `1px solid ${trimmed.length === 0 ? "var(--danger)" : "var(--line)"}`,
+              background: "var(--panel)",
+              color: "var(--ink)",
+              outline: "none",
+            }}
+          />
+          {trimmed.length === 0 && (
+            <div style={{ fontSize: 11, color: "var(--danger)", marginTop: 6 }}>
+              Title cannot be empty.
+            </div>
+          )}
+          {error && (
+            <div style={{ fontSize: 11, color: "var(--danger)", marginTop: 6 }}>
+              {error}
+            </div>
+          )}
+        </div>
+        <div
+          style={{
+            padding: "12px 20px",
+            borderTop: "1px solid var(--line)",
+            background: "var(--line-2)",
+            display: "flex",
+            gap: 8,
+            justifyContent: "flex-end",
+          }}
+        >
+          <button
+            onClick={onClose}
+            disabled={submitting}
+            style={{
+              fontSize: 13,
+              padding: "7px 14px",
+              borderRadius: 7,
+              color: "var(--ink-2)",
+              border: "1px solid var(--line)",
+              background: "var(--panel)",
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            disabled={!ok || submitting}
+            onClick={() => void submit()}
+            data-testid="rename-source-save"
+            style={{
+              fontSize: 13,
+              fontWeight: 600,
+              padding: "7px 14px",
+              borderRadius: 7,
+              background: ok && !submitting ? "var(--accent)" : "var(--line)",
+              color: ok && !submitting ? "white" : "var(--ink-3)",
+              cursor: ok && !submitting ? "pointer" : "not-allowed",
+            }}
+          >
+            {submitting ? "Saving…" : "Save"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/employer/documents/_workspace/SourceRail.tsx
+++ b/apps/web/src/app/employer/documents/_workspace/SourceRail.tsx
@@ -21,7 +21,27 @@ import {
   IconX,
 } from "./icons";
 import { LaunchstackMark } from "~/app/_components/LaunchstackLogo";
+import { ContextMenu } from "./ContextMenu";
+import {
+  buildBlankRailMenuItems,
+  buildFolderMenuItems,
+  buildSourceMenuItems,
+  type SourceContextMenuItem,
+} from "./sourceContextMenu";
 import { SOURCE_META, type WorkspaceFolder, type WorkspaceSource } from "./types";
+
+type RailMenu =
+  | { kind: "source"; x: number; y: number; source: WorkspaceSource }
+  | { kind: "folder"; x: number; y: number; folderName: string; itemIds: string[] }
+  | { kind: "blank"; x: number; y: number };
+
+async function copyText(value: string): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(value);
+  } catch {
+    // Private mode / missing permission — the action still closes the menu.
+  }
+}
 
 interface TagChipProps {
   tag: string;
@@ -123,20 +143,43 @@ interface SourceRowProps {
   selected: boolean;
   toggleSelected: (id: string) => void;
   onOpen?: (source: WorkspaceSource) => void;
+  onOpenMenu?: (point: { clientX: number; clientY: number }, source: WorkspaceSource) => void;
 }
 
-function SourceRow({ source, selected, toggleSelected, onOpen }: SourceRowProps) {
+function SourceRow({
+  source,
+  selected,
+  toggleSelected,
+  onOpen,
+  onOpenMenu,
+}: SourceRowProps) {
   const meta = SOURCE_META[source.type] ?? SOURCE_META.doc;
   const Icon = meta.Icon;
   const [hover, setHover] = useState(false);
+  const [menuFocus, setMenuFocus] = useState(false);
   const tags = source.tags ?? [];
   const visibleTags = tags.slice(0, 2);
   const extra = tags.length - visibleTags.length;
+  const showActions = hover || menuFocus;
 
   return (
     <div
+      data-testid={`source-row-${source.id}`}
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
+      onContextMenu={(e) => {
+        if (!onOpenMenu) return;
+        e.preventDefault();
+        e.stopPropagation();
+        onOpenMenu({ clientX: e.clientX, clientY: e.clientY }, source);
+      }}
+      onKeyDown={(e) => {
+        if (!onOpenMenu) return;
+        if (e.key !== "ContextMenu" && !(e.shiftKey && e.key === "F10")) return;
+        e.preventDefault();
+        const rect = e.currentTarget.getBoundingClientRect();
+        onOpenMenu({ clientX: rect.left + 16, clientY: rect.bottom }, source);
+      }}
       style={{
         display: "flex",
         alignItems: "center",
@@ -234,6 +277,44 @@ function SourceRow({ source, selected, toggleSelected, onOpen }: SourceRowProps)
           )}
         </div>
       </div>
+      {onOpenMenu && (
+        <button
+          type="button"
+          data-testid={`source-row-menu-${source.id}`}
+          aria-label={`Actions for ${source.title}`}
+          aria-haspopup="menu"
+          title="Actions"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            const rect = e.currentTarget.getBoundingClientRect();
+            onOpenMenu({ clientX: rect.right, clientY: rect.bottom }, source);
+          }}
+          onFocus={() => setMenuFocus(true)}
+          onBlur={() => setMenuFocus(false)}
+          style={{
+            width: 18,
+            height: 18,
+            borderRadius: 4,
+            color: "var(--ink-3)",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            flexShrink: 0,
+            opacity: showActions ? 1 : 0,
+          }}
+          onMouseEnter={(e) => {
+            e.currentTarget.style.color = "var(--ink)";
+            e.currentTarget.style.background = "var(--panel)";
+          }}
+          onMouseLeave={(e) => {
+            e.currentTarget.style.color = "var(--ink-3)";
+            e.currentTarget.style.background = "transparent";
+          }}
+        >
+          <IconMore size={12} />
+        </button>
+      )}
     </div>
   );
 }
@@ -246,6 +327,7 @@ interface FolderHeaderProps {
   onToggle: () => void;
   onSelectAll: (ids: string[], add: boolean) => void;
   onRename?: () => void;
+  onOpenMenu?: (point: { clientX: number; clientY: number }) => void;
   selected: string[];
   dragOver: boolean;
 }
@@ -258,6 +340,7 @@ function FolderHeader({
   onToggle,
   onSelectAll,
   onRename,
+  onOpenMenu,
   selected,
   dragOver,
 }: FolderHeaderProps) {
@@ -269,6 +352,12 @@ function FolderHeader({
     <div
       onMouseEnter={() => setHover(true)}
       onMouseLeave={() => setHover(false)}
+      onContextMenu={(e) => {
+        if (!onOpenMenu) return;
+        e.preventDefault();
+        e.stopPropagation();
+        onOpenMenu({ clientX: e.clientX, clientY: e.clientY });
+      }}
       style={{
         display: "flex",
         alignItems: "center",
@@ -369,6 +458,8 @@ export interface SourceRailProps {
   onNewFolder?: () => void;
   onRenameFolder?: (folder: WorkspaceFolder) => void;
   onMoveToFolder?: (sourceId: string, folderName: string) => void;
+  onRenameSource?: (source: WorkspaceSource) => void;
+  onDeleteSource?: (source: WorkspaceSource) => void;
   activeFolder: string | null;
   setActiveFolder: Dispatch<SetStateAction<string | null>>;
   activeTag: string | null;
@@ -401,6 +492,8 @@ export function SourceRail({
   onNewFolder,
   onRenameFolder,
   onMoveToFolder,
+  onRenameSource,
+  onDeleteSource,
   activeFolder,
   setActiveFolder,
   activeTag,
@@ -414,6 +507,70 @@ export function SourceRail({
   const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
   const [dragOverFolder, setDragOverFolder] = useState<string | null>(null);
   const [draggingId, setDraggingId] = useState<string | null>(null);
+  const [menu, setMenu] = useState<RailMenu | null>(null);
+
+  const closeMenu = () => setMenu(null);
+
+  const menuItems = useMemo<SourceContextMenuItem[]>(() => {
+    if (!menu) return [];
+    if (menu.kind === "source") {
+      return buildSourceMenuItems(menu.source, folders, selected, {
+        onOpen: onOpenSource,
+        onToggleContext: (source) => {
+          setSelected((prev) =>
+            prev.includes(source.id)
+              ? prev.filter((id) => id !== source.id)
+              : [...prev, source.id],
+          );
+        },
+        onRename: onRenameSource,
+        onMoveToFolder,
+        onCopyTitle: (source) => {
+          void copyText(source.title);
+        },
+        onDelete: onDeleteSource,
+      });
+    }
+    if (menu.kind === "folder") {
+      const selCount = menu.itemIds.filter((id) => selected.includes(id)).length;
+      const selectState: "none" | "some" | "all" =
+        selCount === 0 ? "none" : selCount === menu.itemIds.length ? "all" : "some";
+      const match = folders.find((f) => f.name === menu.folderName);
+      return buildFolderMenuItems(menu.folderName, {
+        onRename:
+          onRenameFolder && match
+            ? () => onRenameFolder(match)
+            : undefined,
+        onSelectAll: (add) => {
+          setSelected((prev) => {
+            if (add) {
+              const set = new Set(prev);
+              menu.itemIds.forEach((id) => set.add(id));
+              return [...set];
+            }
+            return prev.filter((id) => !menu.itemIds.includes(id));
+          });
+        },
+        selectState,
+      });
+    }
+    return buildBlankRailMenuItems({
+      onAddKnowledge: onOpenAdd,
+      onNewFolder,
+    });
+  }, [
+    menu,
+    folders,
+    selected,
+    onOpenSource,
+    onRenameSource,
+    onMoveToFolder,
+    onDeleteSource,
+    onRenameFolder,
+    onOpenAdd,
+    onNewFolder,
+    setSelected,
+  ]);
 
   const toggleCollapsed = (name: string) =>
     setCollapsed((p) => ({ ...p, [name]: !p[name] }));
@@ -631,7 +788,14 @@ export function SourceRail({
         </div>
       )}
 
-      <div style={{ flex: 1, overflowY: "auto", padding: "2px 8px 8px" }}>
+      <div
+        data-testid="source-rail-list"
+        onContextMenu={(e) => {
+          e.preventDefault();
+          setMenu({ kind: "blank", x: e.clientX, y: e.clientY });
+        }}
+        style={{ flex: 1, overflowY: "auto", padding: "2px 8px 8px" }}
+      >
         {groups.map((group) => {
           const isCollapsed = group.name ? !!collapsed[group.name] : false;
           const hasHeader = !!group.name;
@@ -688,6 +852,15 @@ export function SourceRail({
                       return prev.filter((id) => !ids.includes(id));
                     });
                   }}
+                  onOpenMenu={(point) => {
+                    setMenu({
+                      kind: "folder",
+                      x: point.clientX,
+                      y: point.clientY,
+                      folderName: group.name!,
+                      itemIds: group.items.map((item) => item.id),
+                    });
+                  }}
                   dragOver={isDragOver}
                 />
               )}
@@ -708,6 +881,14 @@ export function SourceRail({
                         selected={selected.includes(s.id)}
                         toggleSelected={toggle}
                         onOpen={onOpenSource}
+                        onOpenMenu={(point, source) => {
+                          setMenu({
+                            kind: "source",
+                            x: point.clientX,
+                            y: point.clientY,
+                            source,
+                          });
+                        }}
                       />
                     </div>
                   ))}
@@ -799,6 +980,22 @@ export function SourceRail({
             clear
           </button>
         </div>
+      )}
+      {menu && (
+        <ContextMenu
+          open
+          x={menu.x}
+          y={menu.y}
+          items={menuItems}
+          ariaLabel={
+            menu.kind === "source"
+              ? `Actions for ${menu.source.title}`
+              : menu.kind === "folder"
+                ? `Actions for folder ${menu.folderName}`
+                : "Sidebar actions"
+          }
+          onClose={closeMenu}
+        />
       )}
     </aside>
   );

--- a/apps/web/src/app/employer/documents/_workspace/WorkspaceShell.tsx
+++ b/apps/web/src/app/employer/documents/_workspace/WorkspaceShell.tsx
@@ -13,10 +13,12 @@ import {
   workspaceMainHeaderBarStyle,
 } from "./AskPanel";
 import { CommandPalette } from "./CommandPalette";
+import { ConfirmActionDialog } from "./ConfirmActionDialog";
 import { DocumentViewer } from "./DocumentViewer";
 import { IconChevronRight } from "./icons";
 import { NewFolderDialog } from "./NewFolderDialog";
 import { RenameFolderDialog } from "./RenameFolderDialog";
+import { RenameSourceDialog } from "./RenameSourceDialog";
 import { SourceRail } from "./SourceRail";
 import { StudioDrawer } from "./StudioDrawer";
 import { StudioMenu } from "./StudioMenu";
@@ -135,6 +137,10 @@ export function WorkspaceShell() {
   const [newFolderOpen, setNewFolderOpen] = useState(false);
   const [renameFolder, setRenameFolder] = useState<WorkspaceFolder | null>(null);
   const [viewerSource, setViewerSource] = useState<WorkspaceSource | null>(null);
+  const [renameSource, setRenameSource] = useState<WorkspaceSource | null>(null);
+  const [deleteSource, setDeleteSource] = useState<WorkspaceSource | null>(null);
+  const [deleteBusy, setDeleteBusy] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   const [studioOpen, setStudioOpen] = useState(false);
   const [studioFeatureId, setStudioFeatureId] = useState<string | null>(null);
   /**
@@ -315,28 +321,48 @@ export function WorkspaceShell() {
     [refresh],
   );
 
+  const deleteDocumentById = useCallback(
+    async (docId: number) => {
+      const res = await fetch("/api/deleteDocument", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ docId: String(docId) }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error ?? "Failed to delete document");
+      }
+      setViewerSource(null);
+      setSelected((prev) => prev.filter((id) => !id.endsWith(String(docId))));
+      await refresh();
+    },
+    [refresh],
+  );
+
   const handleDeleteDoc = useCallback(
     async (docId: number) => {
       try {
-        const res = await fetch("/api/deleteDocument", {
-          method: "DELETE",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ docId: String(docId) }),
-        });
-        if (!res.ok) {
-          const body = (await res.json().catch(() => ({}))) as { error?: string };
-          alert(body.error ?? "Failed to delete document");
-          return;
-        }
-        setViewerSource(null);
-        setSelected((prev) => prev.filter((id) => !id.endsWith(String(docId))));
-        await refresh();
+        await deleteDocumentById(docId);
       } catch (err) {
         alert(err instanceof Error ? err.message : "Failed to delete document");
       }
     },
-    [refresh],
+    [deleteDocumentById],
   );
+
+  const confirmDeleteSource = useCallback(async () => {
+    if (!deleteSource?.documentId) return;
+    setDeleteBusy(true);
+    setDeleteError(null);
+    try {
+      await deleteDocumentById(deleteSource.documentId);
+      setDeleteSource(null);
+    } catch (err) {
+      setDeleteError(err instanceof Error ? err.message : "Failed to delete document");
+    } finally {
+      setDeleteBusy(false);
+    }
+  }, [deleteSource, deleteDocumentById]);
 
   const handleAskAbout = useCallback((source: WorkspaceSource) => {
     setSelected((prev) => (prev.includes(source.id) ? prev : [source.id, ...prev]));
@@ -472,6 +498,11 @@ export function WorkspaceShell() {
           onOpenSource={handleOpenSource}
           onNewFolder={() => setNewFolderOpen(true)}
           onRenameFolder={(folder) => setRenameFolder(folder)}
+          onRenameSource={(source) => setRenameSource(source)}
+          onDeleteSource={(source) => {
+            setDeleteError(null);
+            setDeleteSource(source);
+          }}
           onMoveToFolder={(id, name) => void handleMoveToFolder(id, name)}
           activeFolder={activeFolder}
           setActiveFolder={setActiveFolder}
@@ -572,6 +603,12 @@ export function WorkspaceShell() {
                 setSelected(ids);
                 setActiveFeatureId("chat");
               },
+              onRenameSource: (source) => setRenameSource(source),
+              onDeleteSource: (source) => {
+                setDeleteError(null);
+                setDeleteSource(source);
+              },
+              onMoveToFolder: (id, name) => void handleMoveToFolder(id, name),
             },
           }}
         />
@@ -645,6 +682,32 @@ export function WorkspaceShell() {
         onDeleted={() => {
           if (activeFolder === renameFolder?.name) setActiveFolder(null);
           void refresh();
+        }}
+      />
+
+      <RenameSourceDialog
+        open={!!renameSource}
+        source={renameSource}
+        onClose={() => setRenameSource(null)}
+        onRename={handleRenameDoc}
+      />
+
+      <ConfirmActionDialog
+        open={!!deleteSource}
+        title="Delete this source?"
+        body={
+          deleteSource
+            ? `“${deleteSource.title}” will be removed from this workspace. This cannot be undone.`
+            : ""
+        }
+        confirmLabel="Delete"
+        busy={deleteBusy}
+        error={deleteError}
+        onConfirm={() => void confirmDeleteSource()}
+        onClose={() => {
+          if (deleteBusy) return;
+          setDeleteSource(null);
+          setDeleteError(null);
         }}
       />
 

--- a/apps/web/src/app/employer/documents/_workspace/__tests__/ContextMenu.test.tsx
+++ b/apps/web/src/app/employer/documents/_workspace/__tests__/ContextMenu.test.tsx
@@ -1,0 +1,110 @@
+/** @jest-environment jsdom */
+
+import React from "react";
+import { act, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { ContextMenu } from "../ContextMenu";
+import type { SourceContextMenuItem } from "../sourceContextMenu";
+
+function items(handlers: {
+  onOpen?: () => void;
+  onRename?: () => void;
+  onDelete?: () => void;
+}): SourceContextMenuItem[] {
+  return [
+    { type: "label", id: "title", label: "memory.md" },
+    {
+      type: "item",
+      id: "open",
+      label: "Open",
+      icon: "open",
+      onSelect: handlers.onOpen ?? jest.fn(),
+    },
+    {
+      type: "item",
+      id: "rename",
+      label: "Rename…",
+      icon: "rename",
+      onSelect: handlers.onRename ?? jest.fn(),
+    },
+    { type: "separator", id: "sep" },
+    {
+      type: "item",
+      id: "delete",
+      label: "Delete…",
+      icon: "delete",
+      danger: true,
+      onSelect: handlers.onDelete ?? jest.fn(),
+    },
+  ];
+}
+
+describe("ContextMenu", () => {
+  it("renders actions at the click point and runs the selected item", async () => {
+    const user = userEvent.setup();
+    const onRename = jest.fn();
+    const onClose = jest.fn();
+    render(
+      <ContextMenu
+        open
+        x={24}
+        y={48}
+        items={items({ onRename })}
+        onClose={onClose}
+      />,
+    );
+
+    expect(await screen.findByTestId("context-menu")).toBeInTheDocument();
+    expect(screen.getByTestId("context-menu-item-rename")).toHaveTextContent("Rename…");
+    await user.click(screen.getByTestId("context-menu-item-rename"));
+    expect(onRename).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes on Escape and on backdrop mousedown", async () => {
+    const user = userEvent.setup();
+    const onClose = jest.fn();
+    render(
+      <ContextMenu open x={10} y={10} items={items({})} onClose={onClose} />,
+    );
+    await screen.findByTestId("context-menu");
+    await user.keyboard("{Escape}");
+    expect(onClose).toHaveBeenCalled();
+
+    onClose.mockClear();
+    act(() => {
+      screen.getByTestId("context-menu-backdrop").dispatchEvent(
+        new MouseEvent("mousedown", { bubbles: true }),
+      );
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("does not fire a disabled item", async () => {
+    const user = userEvent.setup();
+    const onDelete = jest.fn();
+    const onClose = jest.fn();
+    render(
+      <ContextMenu
+        open
+        x={10}
+        y={10}
+        items={[
+          {
+            type: "item",
+            id: "delete",
+            label: "Delete…",
+            disabled: true,
+            disabledReason: "Still indexing",
+            onSelect: onDelete,
+          },
+        ]}
+        onClose={onClose}
+      />,
+    );
+    await user.click(await screen.findByTestId("context-menu-item-delete"));
+    expect(onDelete).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/employer/documents/_workspace/__tests__/SourceRail.contextMenu.test.tsx
+++ b/apps/web/src/app/employer/documents/_workspace/__tests__/SourceRail.contextMenu.test.tsx
@@ -1,0 +1,121 @@
+/** @jest-environment jsdom */
+
+import React, { useState } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { SourceRail } from "../SourceRail";
+import type { WorkspaceFolder, WorkspaceSource } from "../types";
+
+const source: WorkspaceSource = {
+  id: "d1",
+  documentId: 12,
+  title:
+    "Claude Code (global) — projects/-Users-aurea-Pensieve-new-frontend/memory/reference_design_bundles.md",
+  type: "doc",
+  size: "",
+  added: "just now",
+  folder: "Launchstack Future Plans 2",
+  tags: [],
+  domain: "General",
+};
+
+const folders: WorkspaceFolder[] = [
+  { id: "cat-1", name: "Launchstack Future Plans 2", color: "x" },
+];
+
+function RailHarness({
+  onRenameSource = jest.fn(),
+  onDeleteSource = jest.fn(),
+  onOpenSource = jest.fn(),
+  onOpenAdd = jest.fn(),
+  onNewFolder = jest.fn(),
+  onMoveToFolder = jest.fn(),
+}: {
+  onRenameSource?: (source: WorkspaceSource) => void;
+  onDeleteSource?: (source: WorkspaceSource) => void;
+  onOpenSource?: (source: WorkspaceSource) => void;
+  onOpenAdd?: () => void;
+  onNewFolder?: () => void;
+  onMoveToFolder?: (id: string, name: string) => void;
+}) {
+  const [selected, setSelected] = useState<string[]>([]);
+  const [activeFolder, setActiveFolder] = useState<string | null>(null);
+  const [activeTag, setActiveTag] = useState<string | null>(null);
+  return (
+    <SourceRail
+      sources={[source]}
+      folders={folders}
+      selected={selected}
+      setSelected={setSelected}
+      onOpenAdd={onOpenAdd}
+      onOpenSource={onOpenSource}
+      onNewFolder={onNewFolder}
+      onMoveToFolder={onMoveToFolder}
+      onRenameSource={onRenameSource}
+      onDeleteSource={onDeleteSource}
+      activeFolder={activeFolder}
+      setActiveFolder={setActiveFolder}
+      activeTag={activeTag}
+      setActiveTag={setActiveTag}
+    />
+  );
+}
+
+describe("SourceRail context menu", () => {
+  it("opens a file menu on right-click and exposes modify actions", async () => {
+    const user = userEvent.setup();
+    const onRenameSource = jest.fn();
+    const onDeleteSource = jest.fn();
+    const onOpenSource = jest.fn();
+    render(
+      <RailHarness
+        onRenameSource={onRenameSource}
+        onDeleteSource={onDeleteSource}
+        onOpenSource={onOpenSource}
+      />,
+    );
+
+    fireEvent.contextMenu(screen.getByTestId("source-row-d1"), {
+      clientX: 90,
+      clientY: 220,
+    });
+
+    expect(await screen.findByTestId("context-menu")).toBeInTheDocument();
+    expect(screen.getByTestId("context-menu-item-open")).toBeInTheDocument();
+    expect(screen.getByTestId("context-menu-item-rename")).toBeInTheDocument();
+    expect(screen.getByTestId("context-menu-item-delete")).toBeInTheDocument();
+    expect(screen.getByTestId("context-menu-item-move")).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("context-menu-item-rename"));
+    expect(onRenameSource).toHaveBeenCalledWith(source);
+    expect(screen.queryByTestId("context-menu")).not.toBeInTheDocument();
+  });
+
+  it("opens a blank-rail menu when right-clicking empty list space", async () => {
+    const user = userEvent.setup();
+    const onOpenAdd = jest.fn();
+    const onNewFolder = jest.fn();
+    render(<RailHarness onOpenAdd={onOpenAdd} onNewFolder={onNewFolder} />);
+
+    fireEvent.contextMenu(screen.getByTestId("source-rail-list"), {
+      clientX: 40,
+      clientY: 400,
+    });
+
+    expect(await screen.findByTestId("context-menu-item-add")).toBeInTheDocument();
+    await user.click(screen.getByTestId("context-menu-item-new-folder"));
+    expect(onNewFolder).toHaveBeenCalled();
+  });
+
+  it("opens the same file menu from the hover actions button", async () => {
+    const user = userEvent.setup();
+    const onDeleteSource = jest.fn();
+    render(<RailHarness onDeleteSource={onDeleteSource} />);
+
+    fireEvent.mouseEnter(screen.getByTestId("source-row-d1"));
+    await user.click(screen.getByTestId("source-row-menu-d1"));
+    await user.click(await screen.findByTestId("context-menu-item-delete"));
+    expect(onDeleteSource).toHaveBeenCalledWith(source);
+  });
+});

--- a/apps/web/src/app/employer/documents/_workspace/__tests__/placeMenu.test.ts
+++ b/apps/web/src/app/employer/documents/_workspace/__tests__/placeMenu.test.ts
@@ -1,0 +1,74 @@
+import { placeMenu, placeSubmenu } from "../placeMenu";
+
+describe("placeMenu", () => {
+  it("keeps the click point when the menu fits", () => {
+    expect(
+      placeMenu({
+        x: 40,
+        y: 80,
+        width: 200,
+        height: 240,
+        viewportWidth: 1280,
+        viewportHeight: 800,
+      }),
+    ).toEqual({ left: 40, top: 80 });
+  });
+
+  it("flips left and up when the menu would overflow the viewport", () => {
+    expect(
+      placeMenu({
+        x: 1200,
+        y: 760,
+        width: 200,
+        height: 240,
+        viewportWidth: 1280,
+        viewportHeight: 800,
+      }),
+    ).toEqual({ left: 1072, top: 552 });
+  });
+
+  it("never places the menu past the padded origin", () => {
+    expect(
+      placeMenu({
+        x: -40,
+        y: -20,
+        width: 200,
+        height: 100,
+        viewportWidth: 400,
+        viewportHeight: 300,
+      }),
+    ).toEqual({ left: 8, top: 8 });
+  });
+});
+
+describe("placeSubmenu", () => {
+  it("opens to the right of the parent when there is room", () => {
+    expect(
+      placeSubmenu({
+        parentLeft: 100,
+        parentTop: 100,
+        parentWidth: 200,
+        itemOffsetTop: 40,
+        width: 196,
+        height: 160,
+        viewportWidth: 1280,
+        viewportHeight: 800,
+      }),
+    ).toEqual({ left: 296, top: 140 });
+  });
+
+  it("opens to the left when the right side would overflow", () => {
+    expect(
+      placeSubmenu({
+        parentLeft: 1100,
+        parentTop: 100,
+        parentWidth: 200,
+        itemOffsetTop: 0,
+        width: 196,
+        height: 160,
+        viewportWidth: 1280,
+        viewportHeight: 800,
+      }),
+    ).toEqual({ left: 908, top: 100 });
+  });
+});

--- a/apps/web/src/app/employer/documents/_workspace/__tests__/sourceActionDialogs.test.tsx
+++ b/apps/web/src/app/employer/documents/_workspace/__tests__/sourceActionDialogs.test.tsx
@@ -1,0 +1,75 @@
+/** @jest-environment jsdom */
+
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { RenameSourceDialog } from "../RenameSourceDialog";
+import { ConfirmActionDialog } from "../ConfirmActionDialog";
+import type { WorkspaceSource } from "../types";
+
+const source: WorkspaceSource = {
+  id: "d1",
+  documentId: 12,
+  title: "reference_design_bundles.md",
+  type: "doc",
+  size: "",
+  added: "",
+  folder: "Unfiled",
+  tags: [],
+  domain: "General",
+};
+
+describe("RenameSourceDialog", () => {
+  it("saves a trimmed title through onRename", async () => {
+    const user = userEvent.setup();
+    const onRename = jest.fn().mockResolvedValue(true);
+    const onClose = jest.fn();
+    render(
+      <RenameSourceDialog
+        open
+        source={source}
+        onRename={onRename}
+        onClose={onClose}
+      />,
+    );
+
+    const input = screen.getByTestId("rename-source-input");
+    await user.clear(input);
+    await user.type(input, "New name");
+    await user.click(screen.getByTestId("rename-source-save"));
+    expect(onRename).toHaveBeenCalledWith(12, "New name");
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("keeps Save disabled when the title is unchanged", () => {
+    render(
+      <RenameSourceDialog
+        open
+        source={source}
+        onRename={jest.fn()}
+        onClose={jest.fn()}
+      />,
+    );
+    expect(screen.getByTestId("rename-source-save")).toBeDisabled();
+  });
+});
+
+describe("ConfirmActionDialog", () => {
+  it("confirms a destructive action", async () => {
+    const user = userEvent.setup();
+    const onConfirm = jest.fn();
+    render(
+      <ConfirmActionDialog
+        open
+        title="Delete this source?"
+        body="This cannot be undone."
+        confirmLabel="Delete"
+        onConfirm={onConfirm}
+        onClose={jest.fn()}
+      />,
+    );
+    await user.click(screen.getByTestId("confirm-action-confirm"));
+    expect(onConfirm).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/employer/documents/_workspace/__tests__/sourceContextMenu.test.ts
+++ b/apps/web/src/app/employer/documents/_workspace/__tests__/sourceContextMenu.test.ts
@@ -1,0 +1,144 @@
+import {
+  buildBlankRailMenuItems,
+  buildFolderMenuItems,
+  buildSourceMenuItems,
+  isPersistedSource,
+} from "../sourceContextMenu";
+import type { WorkspaceFolder, WorkspaceSource } from "../types";
+
+function source(overrides: Partial<WorkspaceSource> = {}): WorkspaceSource {
+  return {
+    id: "d1",
+    documentId: 1,
+    title: "Claude Code (global) — memory.md",
+    type: "doc",
+    size: "",
+    added: "just now",
+    folder: "Unfiled",
+    tags: [],
+    domain: "General",
+    ...overrides,
+  };
+}
+
+const folders: WorkspaceFolder[] = [
+  { id: "cat-1", name: "Contracts", color: "x" },
+  { id: "f-Unfiled", name: "Unfiled", color: "y" },
+];
+
+describe("isPersistedSource", () => {
+  it("treats optimistic rows as not yet writable", () => {
+    expect(isPersistedSource(source({ documentId: undefined }))).toBe(false);
+    expect(isPersistedSource(source({ documentId: 0 }))).toBe(false);
+    expect(isPersistedSource(source({ documentId: 9 }))).toBe(true);
+  });
+});
+
+describe("buildSourceMenuItems", () => {
+  it("exposes open, rename, move, copy, and delete for a persisted file", () => {
+    const onOpen = jest.fn();
+    const onRename = jest.fn();
+    const onDelete = jest.fn();
+    const items = buildSourceMenuItems(source(), folders, [], {
+      onOpen,
+      onRename,
+      onDelete,
+      onCopyTitle: jest.fn(),
+      onMoveToFolder: jest.fn(),
+      onToggleContext: jest.fn(),
+    });
+    const ids = items.map((item) => item.id);
+    expect(ids).toEqual([
+      "title",
+      "open",
+      "context",
+      "sep-modify",
+      "rename",
+      "move",
+      "copy",
+      "sep-danger",
+      "delete",
+    ]);
+    const rename = items.find((item) => item.id === "rename");
+    expect(rename?.type === "item" && rename.disabled).toBe(false);
+    const del = items.find((item) => item.id === "delete");
+    expect(del?.type === "item" && del.danger).toBe(true);
+  });
+
+  it("disables mutations while a source is still indexing", () => {
+    const items = buildSourceMenuItems(
+      source({ documentId: undefined, pending: true }),
+      folders,
+      [],
+      {
+        onRename: jest.fn(),
+        onDelete: jest.fn(),
+        onMoveToFolder: jest.fn(),
+      },
+    );
+    const rename = items.find((item) => item.id === "rename");
+    const move = items.find((item) => item.id === "move");
+    const del = items.find((item) => item.id === "delete");
+    expect(rename?.type === "item" && rename.disabled).toBe(true);
+    expect(move?.type === "submenu" && move.disabled).toBe(true);
+    expect(del?.type === "item" && del.disabled).toBe(true);
+  });
+
+  it("labels context toggle based on current selection", () => {
+    const selected = buildSourceMenuItems(source(), folders, ["d1"], {
+      onToggleContext: jest.fn(),
+    });
+    const item = selected.find((entry) => entry.id === "context");
+    expect(item?.type === "item" && item.label).toBe("Remove from context");
+  });
+
+  it("invokes handlers from the matching item", () => {
+    const onRename = jest.fn();
+    const onMoveToFolder = jest.fn();
+    const file = source({ folder: "Contracts" });
+    const items = buildSourceMenuItems(file, folders, [], {
+      onRename,
+      onMoveToFolder,
+    });
+    const rename = items.find((item) => item.id === "rename");
+    if (rename?.type === "item") rename.onSelect();
+    expect(onRename).toHaveBeenCalledWith(file);
+
+    const move = items.find((item) => item.id === "move");
+    expect(move?.type).toBe("submenu");
+    if (move?.type === "submenu") {
+      const unfiled = move.items.find((item) => item.id === "move-Unfiled");
+      if (unfiled?.type === "item") unfiled.onSelect();
+    }
+    expect(onMoveToFolder).toHaveBeenCalledWith("d1", "Unfiled");
+  });
+});
+
+describe("buildFolderMenuItems", () => {
+  it("offers rename and select-all", () => {
+    const onRename = jest.fn();
+    const onSelectAll = jest.fn();
+    const items = buildFolderMenuItems("Contracts", {
+      onRename,
+      onSelectAll,
+      selectState: "none",
+    });
+    expect(items.map((item) => item.id)).toEqual([
+      "title",
+      "rename-folder",
+      "select-folder",
+    ]);
+    const select = items.find((item) => item.id === "select-folder");
+    if (select?.type === "item") select.onSelect();
+    expect(onSelectAll).toHaveBeenCalledWith(true);
+  });
+});
+
+describe("buildBlankRailMenuItems", () => {
+  it("offers add knowledge and new folder", () => {
+    const onAddKnowledge = jest.fn();
+    const onNewFolder = jest.fn();
+    const items = buildBlankRailMenuItems({ onAddKnowledge, onNewFolder });
+    expect(items.map((item) => item.id)).toEqual(["add", "new-folder"]);
+  });
+});

--- a/apps/web/src/app/employer/documents/_workspace/placeMenu.ts
+++ b/apps/web/src/app/employer/documents/_workspace/placeMenu.ts
@@ -1,0 +1,61 @@
+/**
+ * Viewport-aware placement for floating menus. Pure so tests can pin the
+ * overflow cases without mounting a DOM.
+ */
+
+export interface MenuPoint {
+  left: number;
+  top: number;
+}
+
+const DEFAULT_PAD = 8;
+
+export function placeMenu(opts: {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  viewportWidth: number;
+  viewportHeight: number;
+  pad?: number;
+}): MenuPoint {
+  const pad = opts.pad ?? DEFAULT_PAD;
+  let left = opts.x;
+  let top = opts.y;
+  if (left + opts.width > opts.viewportWidth - pad) {
+    left = opts.viewportWidth - opts.width - pad;
+  }
+  if (top + opts.height > opts.viewportHeight - pad) {
+    top = opts.viewportHeight - opts.height - pad;
+  }
+  return {
+    left: Math.max(pad, left),
+    top: Math.max(pad, top),
+  };
+}
+
+export function placeSubmenu(opts: {
+  parentLeft: number;
+  parentTop: number;
+  parentWidth: number;
+  itemOffsetTop: number;
+  width: number;
+  height: number;
+  viewportWidth: number;
+  viewportHeight: number;
+  pad?: number;
+}): MenuPoint {
+  const pad = opts.pad ?? DEFAULT_PAD;
+  let left = opts.parentLeft + opts.parentWidth - 4;
+  if (left + opts.width > opts.viewportWidth - pad) {
+    left = opts.parentLeft - opts.width + 4;
+  }
+  let top = opts.parentTop + opts.itemOffsetTop;
+  if (top + opts.height > opts.viewportHeight - pad) {
+    top = opts.viewportHeight - opts.height - pad;
+  }
+  return {
+    left: Math.max(pad, left),
+    top: Math.max(pad, top),
+  };
+}

--- a/apps/web/src/app/employer/documents/_workspace/sourceContextMenu.ts
+++ b/apps/web/src/app/employer/documents/_workspace/sourceContextMenu.ts
@@ -1,0 +1,236 @@
+import type { WorkspaceFolder, WorkspaceSource } from "./types";
+
+/**
+ * Declarative items for the source / folder / blank-rail context menus.
+ * Kept as data so the menu chrome can stay dumb and tests can assert the
+ * action set without rendering portals.
+ */
+
+export type SourceContextMenuItem =
+  | {
+      type: "label";
+      id: string;
+      label: string;
+    }
+  | {
+      type: "separator";
+      id: string;
+    }
+  | {
+      type: "item";
+      id: string;
+      label: string;
+      danger?: boolean;
+      disabled?: boolean;
+      disabledReason?: string;
+      checked?: boolean;
+      shortcut?: string;
+      icon?: "open" | "ask" | "rename" | "copy" | "delete" | "folder" | "plus" | "check";
+      onSelect: () => void;
+    }
+  | {
+      type: "submenu";
+      id: string;
+      label: string;
+      icon?: "folder";
+      disabled?: boolean;
+      disabledReason?: string;
+      items: SourceContextMenuItem[];
+    };
+
+export interface SourceMenuHandlers {
+  onOpen?: (source: WorkspaceSource) => void;
+  onToggleContext?: (source: WorkspaceSource) => void;
+  onRename?: (source: WorkspaceSource) => void;
+  onMoveToFolder?: (sourceId: string, folderName: string) => void;
+  onCopyTitle?: (source: WorkspaceSource) => void;
+  onDelete?: (source: WorkspaceSource) => void;
+}
+
+export function isPersistedSource(source: WorkspaceSource): boolean {
+  return typeof source.documentId === "number" && source.documentId > 0;
+}
+
+export function buildSourceMenuItems(
+  source: WorkspaceSource,
+  folders: WorkspaceFolder[],
+  selected: string[],
+  handlers: SourceMenuHandlers,
+): SourceContextMenuItem[] {
+  const persisted = isPersistedSource(source);
+  const indexingReason = "This source is still being indexed.";
+  const inContext = selected.includes(source.id);
+  const currentFolder = source.folder?.trim() || "Unfiled";
+  const items: SourceContextMenuItem[] = [
+    { type: "label", id: "title", label: source.title },
+  ];
+
+  if (handlers.onOpen) {
+    items.push({
+      type: "item",
+      id: "open",
+      label: "Open",
+      icon: "open",
+      onSelect: () => handlers.onOpen?.(source),
+    });
+  }
+
+  if (handlers.onToggleContext) {
+    items.push({
+      type: "item",
+      id: "context",
+      label: inContext ? "Remove from context" : "Add to context",
+      icon: "ask",
+      onSelect: () => handlers.onToggleContext?.(source),
+    });
+  }
+
+  if (
+    handlers.onRename ||
+    handlers.onMoveToFolder ||
+    handlers.onCopyTitle
+  ) {
+    items.push({ type: "separator", id: "sep-modify" });
+  }
+
+  if (handlers.onRename) {
+    items.push({
+      type: "item",
+      id: "rename",
+      label: "Rename…",
+      icon: "rename",
+      disabled: !persisted,
+      disabledReason: persisted ? undefined : indexingReason,
+      onSelect: () => handlers.onRename?.(source),
+    });
+  }
+
+  if (handlers.onMoveToFolder) {
+    const folderNames = uniqueFolderNames(folders, currentFolder);
+    items.push({
+      type: "submenu",
+      id: "move",
+      label: "Move to folder",
+      icon: "folder",
+      disabled: !persisted,
+      disabledReason: persisted ? undefined : indexingReason,
+      items: folderNames.map((name) => ({
+        type: "item" as const,
+        id: `move-${name}`,
+        label: name,
+        icon: name === currentFolder ? "check" : undefined,
+        checked: name === currentFolder,
+        disabled: name === currentFolder,
+        onSelect: () => handlers.onMoveToFolder?.(source.id, name),
+      })),
+    });
+  }
+
+  if (handlers.onCopyTitle) {
+    items.push({
+      type: "item",
+      id: "copy",
+      label: "Copy title",
+      icon: "copy",
+      onSelect: () => handlers.onCopyTitle?.(source),
+    });
+  }
+
+  if (handlers.onDelete) {
+    items.push({ type: "separator", id: "sep-danger" });
+    items.push({
+      type: "item",
+      id: "delete",
+      label: "Delete…",
+      icon: "delete",
+      danger: true,
+      disabled: !persisted,
+      disabledReason: persisted ? undefined : indexingReason,
+      onSelect: () => handlers.onDelete?.(source),
+    });
+  }
+
+  return items;
+}
+
+export interface FolderMenuHandlers {
+  onRename?: () => void;
+  onSelectAll?: (add: boolean) => void;
+  selectState?: "none" | "some" | "all";
+}
+
+export function buildFolderMenuItems(
+  folderName: string,
+  handlers: FolderMenuHandlers,
+): SourceContextMenuItem[] {
+  const items: SourceContextMenuItem[] = [
+    { type: "label", id: "title", label: folderName },
+  ];
+  if (handlers.onRename) {
+    items.push({
+      type: "item",
+      id: "rename-folder",
+      label: "Rename or delete…",
+      icon: "rename",
+      onSelect: () => handlers.onRename?.(),
+    });
+  }
+  if (handlers.onSelectAll) {
+    const all = handlers.selectState === "all";
+    items.push({
+      type: "item",
+      id: "select-folder",
+      label: all ? "Deselect all in folder" : "Select all in folder",
+      icon: "check",
+      onSelect: () => handlers.onSelectAll?.(!all),
+    });
+  }
+  return items;
+}
+
+export interface BlankRailMenuHandlers {
+  onAddKnowledge?: () => void;
+  onNewFolder?: () => void;
+}
+
+export function buildBlankRailMenuItems(
+  handlers: BlankRailMenuHandlers,
+): SourceContextMenuItem[] {
+  const items: SourceContextMenuItem[] = [];
+  if (handlers.onAddKnowledge) {
+    items.push({
+      type: "item",
+      id: "add",
+      label: "Add knowledge",
+      icon: "plus",
+      onSelect: () => handlers.onAddKnowledge?.(),
+    });
+  }
+  if (handlers.onNewFolder) {
+    items.push({
+      type: "item",
+      id: "new-folder",
+      label: "New folder",
+      icon: "folder",
+      onSelect: () => handlers.onNewFolder?.(),
+    });
+  }
+  return items;
+}
+
+function uniqueFolderNames(
+  folders: WorkspaceFolder[],
+  currentFolder: string,
+): string[] {
+  const names = new Set<string>(["Unfiled"]);
+  for (const folder of folders) {
+    const name = folder.name.trim();
+    if (name) names.add(name);
+  }
+  names.add(currentFolder);
+  return [...names].sort((a, b) => {
+    if (a === "Unfiled") return 1;
+    if (b === "Unfiled") return -1;
+    return a.localeCompare(b);
+  });
+}


### PR DESCRIPTION
## What

Right-clicking a source, a folder, or blank space in the documents workspace source rail now opens a context menu. Previously those actions lived only behind hover affordances and the command palette, so rename and delete were hard to reach — and delete went straight through `window.confirm` / `alert`.

## How

**Menu contents are pure data.** `sourceContextMenu.ts` exports builders (`buildSourceMenuItems`, `buildFolderMenuItems`, `buildBlankRailMenuItems`) that derive item state from the row itself. Optimistic rows with no `documentId` yet, and sources still indexing, get their mutating items **disabled rather than hidden**, so the menu doesn't reshape under the cursor while an upload settles.

**Placement is pure too.** `placeMenu.ts` computes position from the click point and viewport — flipping left/up on overflow and clamping to a padded origin — so the overflow cases are pinned by tests without mounting a DOM. Submenus reuse `MenuPanel` recursively via `placeSubmenu`.

**Destructive actions get real dialogs.** Delete routes through `ConfirmActionDialog` with inline busy/error state instead of `alert()`; rename through `RenameSourceDialog`. `handleDeleteDoc` keeps its existing `alert` path for non-menu callers by delegating to an extracted `deleteDocumentById`, so nothing else changes behavior.

## Also in here

- `apps/web/.gitignore` ignoring `/.clerk/`, which can contain secrets. Unrelated to the feature but worth not losing.
- A dev-only `/dev/source-rail` route for exercising the menu without a seeded workspace.

## Verification

- `pnpm --filter @launchstack/web typecheck` — clean
- `eslint src/app/employer/documents/_workspace src/app/dev` — 0 problems
- 21 tests across 5 suites, all passing

Two issues were found and fixed while validating: `MenuPanel`'s named function expression shadowed the outer `const` inside its own body, so the recursive submenu JSX resolved to the raw `(props, ref)` render function (TS6229); and a dead `MENU_MAX_WIDTH` constant duplicating the CSS `max-width`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches document delete and rename flows in the main workspace shell; behavior is covered by tests but delete still hits the same API as before.
> 
> **Overview**
> Adds **right-click and keyboard context menus** on the documents workspace **source rail**, **Knowledge** grid/list, and **folder/blank rail** areas, so open, context toggle, rename, move, copy title, and delete are reachable without hunting hover controls.
> 
> Menu structure comes from **`sourceContextMenu.ts`** builders; a new **`ContextMenu`** (portal, submenus, keyboard nav) uses **`placeMenu`** for viewport-aware positioning. **Rename** and **delete** from the menu open **`RenameSourceDialog`** and **`ConfirmActionDialog`**; shell delete is refactored through **`deleteDocumentById`** with inline busy/error on confirm instead of immediate `window.confirm` for that path.
> 
> Also includes a **non-production** `/dev/source-rail` harness, **`/.clerk/`** in `.gitignore`, and unit tests for menus, placement, and dialogs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 354f7d78bf73d304d94383447ec1ac6122ef101d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->