### PR TITLE
Fix optional Zod fields in native structured output

### DIFF
--- a/apps/web/__tests__/lib/llm/chat-endpoint.test.ts
+++ b/apps/web/__tests__/lib/llm/chat-endpoint.test.ts
@@ -10,6 +10,7 @@ import { createServer, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 import { z } from "zod";
+import { FounderWeeklyReviewV2RecommendationSchema } from "@launchstack/features/founder-weekly-review";
 import {
     createChatModelsConfig,
     describeChatEndpointError,
@@ -367,6 +368,131 @@ describe("structured output", () => {
         expect(captured[0]!.body.response_format).toMatchObject({
             type: "json_schema",
         });
+    });
+
+    it("uses the validated JSON fallback for an optional field", async () => {
+        respondWith = () => ({
+            status: 200,
+            payload: completion(JSON.stringify({ required: "yes" })),
+        });
+
+        const OptionalSchema = z.object({
+            required: z.string(),
+            optional: z.string().optional(),
+        });
+        const resolved = resolveChatModel({
+            config: deployment(`      input: [text]
+      reasoning: { mode: none }
+      nativeStructuredOutput: [json-schema]
+      parameters:
+        temperature: supported
+        systemMessages: supported
+        streaming: supported
+        maxOutputTokens: supported`),
+        });
+        await expect(
+            invokeStructured(resolved, OptionalSchema, [new HumanMessage("q")], {
+                name: "optional_example",
+            })
+        ).resolves.toEqual({ required: "yes" });
+
+        expect(captured).toHaveLength(1);
+        expect(captured[0]!.body).not.toHaveProperty("response_format");
+        expect(JSON.stringify(captured[0]!.body.messages)).toContain("optional");
+    });
+
+    it("accepts a present optional value and rejects an invalid one through the original schema", async () => {
+        respondWith = () => ({
+            status: 200,
+            payload: completion(JSON.stringify({ required: "yes", optional: "present" })),
+        });
+        const OptionalSchema = z.object({
+            required: z.string(),
+            optional: z.string().optional(),
+        });
+        const resolved = resolveChatModel({
+            config: deployment(`      input: [text]
+      reasoning: { mode: none }
+      nativeStructuredOutput: [json-schema]
+      parameters:
+        temperature: supported
+        systemMessages: supported
+        streaming: supported
+        maxOutputTokens: supported`),
+        });
+        await expect(
+            invokeStructured(resolved, OptionalSchema, [new HumanMessage("q")], {
+                name: "optional_present",
+            })
+        ).resolves.toEqual({ required: "yes", optional: "present" });
+
+        respondWith = () => ({
+            status: 200,
+            payload: completion(JSON.stringify({ required: "yes", optional: 42 })),
+        });
+        await expect(
+            invokeStructured(resolved, OptionalSchema, [new HumanMessage("q")], {
+                name: "optional_invalid",
+            })
+        ).rejects.toBeInstanceOf(StructuredOutputError);
+        expect(captured).toHaveLength(3);
+    });
+
+    it("uses the fallback for the current Founder Weekly Review recommendation schema", async () => {
+        respondWith = () => ({
+            status: 200,
+            payload: completion(
+                JSON.stringify({
+                    kind: "recommendation",
+                    label: "Recommendation",
+                    text: "Review the evidence.",
+                    sourceIds: ["document_change:example"],
+                    confidence: 0.5,
+                })
+            ),
+        });
+        const resolved = resolveChatModel({
+            config: deployment(`      input: [text]
+      reasoning: { mode: none }
+      nativeStructuredOutput: [json-schema]
+      parameters:
+        temperature: supported
+        systemMessages: supported
+        streaming: supported
+        maxOutputTokens: supported`),
+        });
+        await expect(
+            invokeStructured(
+                resolved,
+                FounderWeeklyReviewV2RecommendationSchema,
+                [new HumanMessage("q")],
+                { name: "founder_weekly_review_v2" }
+            )
+        ).resolves.toMatchObject({ kind: "recommendation", text: "Review the evidence." });
+        expect(captured).toHaveLength(1);
+        expect(captured[0]!.body).not.toHaveProperty("response_format");
+    });
+
+    it("does not reroute a normal native provider failure", async () => {
+        respondWith = () => ({
+            status: 401,
+            payload: { error: { message: "provider failed" } },
+        });
+        const resolved = resolveChatModel({
+            config: deployment(`      input: [text]
+      reasoning: { mode: none }
+      nativeStructuredOutput: [json-schema]
+      parameters:
+        temperature: supported
+        systemMessages: supported
+        streaming: supported
+        maxOutputTokens: supported`),
+        });
+        await expect(
+            invokeStructured(resolved, Schema, [new HumanMessage("q")], { name: "native_error" })
+        ).rejects.toThrow();
+        expect(captured).toHaveLength(1);
+        expect(captured[0]!.body.response_format).toMatchObject({ type: "json_schema" });
     });
 
     it("falls back to a strict JSON prompt carrying the schema", async () => {

--- a/packages/adapters/src/llm/structured-output.ts
+++ b/packages/adapters/src/llm/structured-output.ts
@@ -55,6 +55,59 @@ const LANGCHAIN_METHOD = {
     "json-object": "jsonMode",
 } as const;
 
+type JsonSchemaNode = Record<string, unknown>;
+
+function isJsonSchemaNode(value: unknown): value is JsonSchemaNode {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Native OpenAI-compatible strict JSON Schema requires every object property to
+ * be present. Zod's optional object properties are valid JSON Schema, but they
+ * cannot be passed through that native LangChain method. Detect that shape
+ * before invoking the model so the existing provider-neutral JSON fallback can
+ * preserve the original Zod contract without spending a failed request.
+ */
+function hasOptionalObjectFields(schema: z.ZodType<unknown>, name: string): boolean {
+    const root = zodToJsonSchema(schema, name) as JsonSchemaNode;
+    const definitions = isJsonSchemaNode(root.definitions) ? root.definitions : {};
+    const visited = new Set<JsonSchemaNode>();
+
+    function visit(value: unknown): boolean {
+        if (!isJsonSchemaNode(value) || visited.has(value)) return false;
+
+        const reference = value.$ref;
+        if (typeof reference === "string" && reference.startsWith("#/definitions/")) {
+            const definition = definitions[reference.slice("#/definitions/".length)];
+            return visit(definition);
+        }
+
+        visited.add(value);
+        const properties = value.properties;
+        if (isJsonSchemaNode(properties)) {
+            const required = new Set(
+                Array.isArray(value.required)
+                    ? value.required.filter((entry): entry is string => typeof entry === "string")
+                    : []
+            );
+            for (const [property, child] of Object.entries(properties)) {
+                if (!required.has(property) || visit(child)) return true;
+            }
+        }
+
+        for (const key of ["items", "additionalProperties"] as const) {
+            if (visit(value[key])) return true;
+        }
+        for (const key of ["anyOf", "oneOf", "allOf"] as const) {
+            const branches = value[key];
+            if (Array.isArray(branches) && branches.some(visit)) return true;
+        }
+        return false;
+    }
+
+    return visit(root);
+}
+
 function jsonInstruction(schema: z.ZodType<unknown>, name: string): string {
     const jsonSchema = JSON.stringify(zodToJsonSchema(schema, name), null, 2);
     return [
@@ -152,6 +205,10 @@ export async function invokeStructured<T>(
 ): Promise<T> {
     const native = pickNativeStructuredMode(resolved.behavior.nativeStructuredOutput);
     if (!native) {
+        return invokeJsonFallback(resolved, schema, messages, options);
+    }
+
+    if (native === "json-schema" && hasOptionalObjectFields(schema, options.name)) {
         return invokeJsonFallback(resolved, schema, messages, options);
     }
 


### PR DESCRIPTION
## Summary

Fixes #335.

The shared structured-output path could fail before making a provider request when native `json-schema` mode was selected for a Zod schema containing optional object properties such as:

```ts
z.object({
  required: z.string(),
  optional: z.string().optional(),
})
```

The adapter now detects this native-schema incompatibility before invocation and uses the existing strict-JSON prompt plus local Zod validation fallback. Required schemas continue to use native JSON Schema, and ordinary provider failures are not rerouted.

The current Founder Weekly Review recommendation schema is covered without changing the FWR schema itself.

## Validation

- Shared LLM surface: 6 suites, 111 tests passed
- Focused structured-output regression: 8 tests passed
- Current-main FWR generation tests: 30 tests passed
- Affected-package typechecks: PASS
- Changed-file lint: PASS
- Formatting: PASS
- `git diff --check`: PASS
- No live provider calls were made; local mock endpoints proved the path proceeds beyond schema preparation.

No migrations, provider-specific routing, retry/outbox logic, or unrelated infrastructure were changed.
