### PR TITLE
Design-system guardrails: lint boundaries and written conventions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,40 @@
+# CLAUDE.md
+
+Monorepo: `apps/web` (the application), `apps/landing` (marketing site),
+`packages/*` (layered engine — see `REPOSITORY.md` and the lint-enforced
+boundaries in `eslint.config.js`), `services/*`. pnpm workspaces.
+
+## Frontend rules (apps/web, apps/landing)
+
+- UI primitives come from `~/components/ui/<name>`. If one is missing, add it
+  with `npx shadcn@latest add <name>` (run in apps/web) — never hand-roll a
+  button, input, table, or overlay. Modals use `~/components/ui/dialog`.
+- `cn` comes from `~/lib/utils`. There is exactly one copy.
+- Colors are design tokens: `var(--…)` from `packages/design-tokens/tokens.css`
+  or semantic Tailwind classes (`bg-panel`, `text-ink-2`, `border-line`,
+  `bg-brand`, `text-danger`). Never hex literals, never new inline `style`
+  colors, never the raw Tailwind palette (`purple-600`, `slate-800`) in new code.
+- The shadcn color names (`bg-background`, `text-muted-foreground`, …) are a
+  deprecated compat layer (`apps/web/src/styles/compat.css`). Don't extend it.
+- Dark mode: `data-theme="dark"` on `<html>`. Use `dark:` variants or
+  `[data-theme="dark"]` CSS; never branch on `resolvedTheme` in JS for colors.
+- Icons: `lucide-react`; brand marks from `~/components/icons/brand`.
+- Fonts: `var(--font-sans|serif|mono)` only; loaded once in `src/app/fonts.ts`.
+- Never import across route areas (`app/employer/**` ↔ `app/employee/**`).
+  Shared pieces go in `~/components` or `~/lib`.
+- `app/employer/_components/primitives.tsx` and
+  `documents/_workspace/icons.tsx` are deprecated — do not add imports.
+- Touch-it-migrate-it: when editing existing UI for feature work, convert the
+  region you touch to kit + tokens; never launch a bulk rewrite.
+- Full conventions: `apps/web/README.md`.
+
+## Workflow
+
+- Format with `pnpm format:write` (Prettier owns style incl. Tailwind class
+  order); lint warnings from the design-system guardrails are a ratchet — the
+  count may only go down.
+- `public/templates/*.docx` are live production data resolved at runtime via
+  `process.cwd()` — do not move them.
+- A script that imports `__tests__` helpers will pass CI but break every
+  Vercel deploy (`.vercelignore` excludes `__tests__`); keep deploy-time code
+  free of test imports.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -1,0 +1,84 @@
+# @launchstack/web — frontend conventions
+
+The application (employer/employee workspaces, auth, API/BFF). The marketing
+site lives in `apps/landing`. Both apps share one visual language through
+`@launchstack/design-tokens`; this page is the contract that keeps new
+frontend work consistent. ESLint enforces the hard rules (see the
+"Design-system guardrails" blocks in the root `eslint.config.js`).
+
+## Component sourcing order
+
+When you need UI, take the first thing that exists:
+
+1. **`~/components/ui/<name>`** — the base kit (shadcn primitives themed by
+   the design tokens). Per-file imports, no barrel.
+2. **`~/components/*`** — shared composed components (`icons/brand`, and the
+   growing layout/callout/code-block layer).
+3. **Your route area's own `_components/`** — feature-specific pieces.
+
+Never import from another route area (`app/employer/**` ↔ `app/employee/**`)
+— lint blocks it. If two areas need the same thing, promote it to
+`~/components` or `~/lib`.
+
+## Adding primitives
+
+A primitive missing from `~/components/ui`? Don't hand-roll it:
+
+```bash
+cd apps/web && npx shadcn@latest add <name>
+```
+
+`components.json` is configured; generated files land in `~/components/ui`
+already wired to `cn` from `~/lib/utils`. Modals/popovers come from the kit
+(`dialog`, `sheet`) — never hand-rolled overlays.
+
+## Styling
+
+- **Colors are tokens.** `var(--…)` from `@launchstack/design-tokens`, or the
+  semantic Tailwind namespace: `surface/panel/ink/line/brand-*/success/
+danger/warn/info`. New hex literals trigger a lint warning; don't add any.
+- The shadcn names (`bg-background`, `text-muted-foreground`, …) live in
+  `src/styles/compat.css` — a **deprecated** quarantine that dies when the
+  kit is re-themed. Don't add to it; prefer the semantic namespace.
+- Dark mode keys off `data-theme="dark"` on `<html>` (next-themes sets it).
+  `dark:` variants and `[data-theme="dark"]` CSS both work; never branch on
+  `resolvedTheme` in JS just to pick colors — use a token that flips.
+- Fonts: `var(--font-sans|serif|mono)` (Inter Tight/Inter, Instrument Serif,
+  JetBrains Mono, loaded once in `src/app/fonts.ts`). Never name a font
+  family in CSS directly.
+
+## Icons
+
+`lucide-react` for everything, except brand marks (Slack, Notion, Gmail,
+Drive, Dropbox, YouTube, GitHub) from `~/components/icons/brand`. The old
+hand-drawn set at `documents/_workspace/icons.tsx` is deprecated.
+
+## Assets
+
+- `public/brand/` — logo exports (`logo.svg`); the canonical in-app mark is
+  the `LaunchstackMark` component — keep the two in sync.
+- `public/templates/*.docx` — **live production data**, resolved at runtime
+  by `packages/features/src/legal-templates/template-service.ts` via
+  `process.cwd()`. Do not move or rename without fixing that coupling.
+- Anything a component imports goes through the bundler, not `public/`.
+- `.vercelignore` (repo root) excludes `__tests__` from deploys — a script
+  that imports test helpers will pass CI and then break every Vercel deploy.
+
+## The migration boundary rule
+
+New files must use the kit + tokens — no inline color styles, no raw
+`<button>` where `Button` fits, no hand-rolled modals. Existing files migrate
+only when you are already changing their UI: touch a component's markup for
+feature work → convert the region you touch. Pure logic fixes never trigger
+migration. Nobody rewrites the ~100 inline-style files as a project.
+
+## Deprecated (do not extend)
+
+| Module                                        | Replacement                               |
+| --------------------------------------------- | ----------------------------------------- |
+| `app/employer/_components/primitives.tsx`     | `~/components/ui` + tokens                |
+| `app/employer/documents/_workspace/icons.tsx` | lucide-react + `~/components/icons/brand` |
+| `src/styles/compat.css` + shadcn color names  | semantic Tailwind namespace / tokens      |
+| `.lsw-root` wrapper class                     | inert; tokens are global now              |
+
+Lint warnings on these are a ratchet: the count only goes down.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,6 +15,74 @@ const compat = new FlatCompat({
     allConfig: js.configs.all,
 });
 
+// Flat config REPLACES a rule's options when a later block matches the same
+// file — it never merges them. Every block below that re-declares
+// no-restricted-imports for an apps/web scope must therefore carry the full
+// set of error-level restrictions itself; these shared pieces keep that
+// composition in one place.
+const chatClientImportBans = [
+    {
+        name: "@langchain/openai",
+        importNames: ["ChatOpenAI"],
+        message:
+            "Resolve a route with @launchstack/core/llm instead. " +
+            "ChatOpenAI belongs to openai-compatible-transport.ts alone. " +
+            "(OpenAIEmbeddings is fine — embeddings are configured separately.)",
+    },
+    {
+        name: "@langchain/anthropic",
+        importNames: ["ChatAnthropic"],
+        message:
+            "Chat reaches one OpenAI-compatible endpoint; native provider " +
+            "transports are tracked in the multi-endpoint follow-up issue.",
+    },
+    {
+        name: "@langchain/google-genai",
+        importNames: ["ChatGoogleGenerativeAI"],
+        message:
+            "Chat reaches one OpenAI-compatible endpoint; native provider " +
+            "transports are tracked in the multi-endpoint follow-up issue.",
+    },
+    {
+        name: "@langchain/ollama",
+        importNames: ["ChatOllama"],
+        message:
+            "Point CHAT_BASE_URL at Ollama's OpenAI-compatible /v1 surface " +
+            "instead. (OllamaEmbeddings is fine — embeddings are separate.)",
+    },
+];
+
+const oldKitTombstone = {
+    group: ["~/app/employer/documents/components/ui/*", "**/documents/components/ui/*"],
+    message: "The base kit moved: import from ~/components/ui/<name>.",
+};
+
+// no-restricted-imports matches the raw specifier, so relative escapes from
+// a route area must be banned explicitly alongside the alias forms.
+const relativeReaches = area => [
+    `../${area}/*`,
+    `../../${area}/*`,
+    `../../../${area}/*`,
+    `../../../../${area}/*`,
+    `../../../../../${area}/*`,
+    `../../../../../../${area}/*`,
+];
+
+const deprecatedModuleWarns = [
+    {
+        group: ["**/_workspace/icons"],
+        message:
+            "Legacy icon set. Use lucide-react for general icons " +
+            "and ~/components/icons/brand for brand marks.",
+    },
+    {
+        group: ["~/app/employer/_components/primitives", "**/_components/primitives"],
+        message:
+            "Deprecated inline-style primitives. Use ~/components/ui " +
+            "(shadcn base kit on the design tokens) instead.",
+    },
+];
+
 const eslintConfig = [
     {
         // Flat-config patterns are anchored: without a `**/` prefix they only
@@ -392,88 +460,23 @@ const eslintConfig = [
         files: ["packages/**/src/**/*.{ts,tsx}", "apps/web/src/**/*.{ts,tsx}"],
         ignores: ["packages/adapters/src/llm/openai-compatible-transport.ts"],
         rules: {
-            "no-restricted-imports": [
-                "error",
-                {
-                    paths: [
-                        {
-                            name: "@langchain/openai",
-                            importNames: ["ChatOpenAI"],
-                            message:
-                                "Resolve a route with @launchstack/core/llm instead. " +
-                                "ChatOpenAI belongs to openai-compatible-transport.ts alone. " +
-                                "(OpenAIEmbeddings is fine — embeddings are configured separately.)",
-                        },
-                        {
-                            name: "@langchain/anthropic",
-                            importNames: ["ChatAnthropic"],
-                            message:
-                                "Chat reaches one OpenAI-compatible endpoint; native provider " +
-                                "transports are tracked in the multi-endpoint follow-up issue.",
-                        },
-                        {
-                            name: "@langchain/google-genai",
-                            importNames: ["ChatGoogleGenerativeAI"],
-                            message:
-                                "Chat reaches one OpenAI-compatible endpoint; native provider " +
-                                "transports are tracked in the multi-endpoint follow-up issue.",
-                        },
-                        {
-                            name: "@langchain/ollama",
-                            importNames: ["ChatOllama"],
-                            message:
-                                "Point CHAT_BASE_URL at Ollama's OpenAI-compatible /v1 surface " +
-                                "instead. (OllamaEmbeddings is fine — embeddings are separate.)",
-                        },
-                    ],
-                },
-            ],
+            "no-restricted-imports": ["error", { paths: chatClientImportBans }],
         },
     },
-    // Design-system guardrails (see apps/web/README.md). Errors are
-    // tombstones with zero legitimate uses; warns are ratchets over the
-    // pre-existing baseline — the count may only go down.
+    // Design-system guardrails (see apps/web/README.md). Two tiers so that
+    // error- and warn-level restrictions can coexist on the same files
+    // (one rule id holds one severity): hard boundaries live in the base
+    // no-restricted-imports — every block that redefines it for a narrower
+    // web scope repeats the wider scope's restrictions, because flat
+    // config replaces rather than merges — and warn-level deprecation
+    // ratchets live in the @typescript-eslint twin rule. Warn counts may
+    // only go down.
     {
         files: ["apps/web/src/**/*.{ts,tsx}"],
         rules: {
             "no-restricted-imports": [
                 "error",
-                {
-                    patterns: [
-                        {
-                            group: [
-                                "~/app/employer/documents/components/ui/*",
-                                "**/documents/components/ui/*",
-                            ],
-                            message: "The base kit moved: import from ~/components/ui/<name>.",
-                        },
-                    ],
-                },
-            ],
-        },
-    },
-    {
-        files: ["apps/web/src/**/*.{ts,tsx}"],
-        ignores: ["apps/web/src/app/employer/documents/_workspace/**"],
-        rules: {
-            "no-restricted-imports": [
-                "warn",
-                {
-                    patterns: [
-                        {
-                            group: ["**/_workspace/icons"],
-                            message:
-                                "Legacy icon set. Use lucide-react for general icons " +
-                                "and ~/components/icons/brand for brand marks.",
-                        },
-                        {
-                            group: ["~/app/employer/_components/primitives"],
-                            message:
-                                "Deprecated inline-style primitives. Use ~/components/ui " +
-                                "(shadcn base kit on the design tokens) instead.",
-                        },
-                    ],
-                },
+                { paths: chatClientImportBans, patterns: [oldKitTombstone] },
             ],
         },
     },
@@ -481,17 +484,23 @@ const eslintConfig = [
     // each other. Shared pieces belong in ~/components, ~/lib, or
     // ~/app/_components. The employee → employer leg has 5 pre-existing
     // violations (ProfileDropdown, WorkspaceShell, NavBar, Employer
-    // styles), so it warns until they migrate; the reverse leg is clean
-    // and stays an error.
+    // styles), so it warns below until they migrate; this reverse leg is
+    // clean and stays an error.
     {
         files: ["apps/web/src/app/employer/**/*.{ts,tsx}"],
         rules: {
             "no-restricted-imports": [
                 "error",
                 {
+                    paths: chatClientImportBans,
                     patterns: [
+                        oldKitTombstone,
                         {
-                            group: ["~/app/employee/*", "**/app/employee/*"],
+                            group: [
+                                "~/app/employee/*",
+                                "**/app/employee/*",
+                                ...relativeReaches("employee"),
+                            ],
                             message:
                                 "employer must not import from the employee area; " +
                                 "promote shared code to ~/components or ~/lib.",
@@ -502,14 +511,29 @@ const eslintConfig = [
         },
     },
     {
+        files: ["apps/web/src/**/*.{ts,tsx}"],
+        ignores: ["apps/web/src/app/employer/documents/_workspace/**"],
+        rules: {
+            "@typescript-eslint/no-restricted-imports": [
+                "warn",
+                { patterns: deprecatedModuleWarns },
+            ],
+        },
+    },
+    {
         files: ["apps/web/src/app/employee/**/*.{ts,tsx}"],
         rules: {
-            "no-restricted-imports": [
+            "@typescript-eslint/no-restricted-imports": [
                 "warn",
                 {
                     patterns: [
+                        ...deprecatedModuleWarns,
                         {
-                            group: ["~/app/employer/*", "~/styles/Employer/*"],
+                            group: [
+                                "~/app/employer/*",
+                                "~/styles/Employer/*",
+                                ...relativeReaches("employer"),
+                            ],
                             message:
                                 "employee reaching into employer — promote the shared " +
                                 "piece to ~/components (or duplicate the style) when " +
@@ -521,7 +545,8 @@ const eslintConfig = [
         },
     },
     // Colors come from tokens (var(--…) / semantic Tailwind classes), not
-    // hex literals. Warn-level ratchet; baseline ~74 occurrences.
+    // hex literals in any CSS form (#rgb, #rgba, #rrggbb, #rrggbbaa).
+    // Warn-level ratchet; baseline ~74 occurrences.
     {
         files: ["apps/web/src/**/*.tsx"],
         rules: {
@@ -529,13 +554,14 @@ const eslintConfig = [
                 "warn",
                 {
                     selector:
-                        "Literal[value=/#[0-9a-fA-F]{6}([0-9a-fA-F]{2})?\\b/], Literal[value=/#[0-9a-fA-F]{3}\\b/]",
+                        "Literal[value=/#([0-9a-fA-F]{6}([0-9a-fA-F]{2})?|[0-9a-fA-F]{3,4})\\b/]",
                     message:
                         "Use design tokens (var(--…) or semantic Tailwind classes " +
                         "like bg-panel/text-ink/border-line) instead of hex colors.",
                 },
                 {
-                    selector: "TemplateElement[value.raw=/#[0-9a-fA-F]{6}\\b/]",
+                    selector:
+                        "TemplateElement[value.raw=/#([0-9a-fA-F]{6}([0-9a-fA-F]{2})?|[0-9a-fA-F]{3,4})\\b/]",
                     message:
                         "Use design tokens (var(--…) or semantic Tailwind classes) " +
                         "instead of hex colors.",

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -430,6 +430,119 @@ const eslintConfig = [
             ],
         },
     },
+    // Design-system guardrails (see apps/web/README.md). Errors are
+    // tombstones with zero legitimate uses; warns are ratchets over the
+    // pre-existing baseline — the count may only go down.
+    {
+        files: ["apps/web/src/**/*.{ts,tsx}"],
+        rules: {
+            "no-restricted-imports": [
+                "error",
+                {
+                    patterns: [
+                        {
+                            group: [
+                                "~/app/employer/documents/components/ui/*",
+                                "**/documents/components/ui/*",
+                            ],
+                            message: "The base kit moved: import from ~/components/ui/<name>.",
+                        },
+                    ],
+                },
+            ],
+        },
+    },
+    {
+        files: ["apps/web/src/**/*.{ts,tsx}"],
+        ignores: ["apps/web/src/app/employer/documents/_workspace/**"],
+        rules: {
+            "no-restricted-imports": [
+                "warn",
+                {
+                    patterns: [
+                        {
+                            group: ["**/_workspace/icons"],
+                            message:
+                                "Legacy icon set. Use lucide-react for general icons " +
+                                "and ~/components/icons/brand for brand marks.",
+                        },
+                        {
+                            group: ["~/app/employer/_components/primitives"],
+                            message:
+                                "Deprecated inline-style primitives. Use ~/components/ui " +
+                                "(shadcn base kit on the design tokens) instead.",
+                        },
+                    ],
+                },
+            ],
+        },
+    },
+    // Route areas are products: employer and employee must not reach into
+    // each other. Shared pieces belong in ~/components, ~/lib, or
+    // ~/app/_components. The employee → employer leg has 5 pre-existing
+    // violations (ProfileDropdown, WorkspaceShell, NavBar, Employer
+    // styles), so it warns until they migrate; the reverse leg is clean
+    // and stays an error.
+    {
+        files: ["apps/web/src/app/employer/**/*.{ts,tsx}"],
+        rules: {
+            "no-restricted-imports": [
+                "error",
+                {
+                    patterns: [
+                        {
+                            group: ["~/app/employee/*", "**/app/employee/*"],
+                            message:
+                                "employer must not import from the employee area; " +
+                                "promote shared code to ~/components or ~/lib.",
+                        },
+                    ],
+                },
+            ],
+        },
+    },
+    {
+        files: ["apps/web/src/app/employee/**/*.{ts,tsx}"],
+        rules: {
+            "no-restricted-imports": [
+                "warn",
+                {
+                    patterns: [
+                        {
+                            group: ["~/app/employer/*", "~/styles/Employer/*"],
+                            message:
+                                "employee reaching into employer — promote the shared " +
+                                "piece to ~/components (or duplicate the style) when " +
+                                "you touch this code.",
+                        },
+                    ],
+                },
+            ],
+        },
+    },
+    // Colors come from tokens (var(--…) / semantic Tailwind classes), not
+    // hex literals. Warn-level ratchet; baseline ~74 occurrences.
+    {
+        files: ["apps/web/src/**/*.tsx"],
+        rules: {
+            "no-restricted-syntax": [
+                "warn",
+                {
+                    selector:
+                        "Literal[value=/#[0-9a-fA-F]{6}([0-9a-fA-F]{2})?\\b/], Literal[value=/#[0-9a-fA-F]{3}\\b/]",
+                    message:
+                        "Use design tokens (var(--…) or semantic Tailwind classes " +
+                        "like bg-panel/text-ink/border-line) instead of hex colors.",
+                },
+                {
+                    selector: "TemplateElement[value.raw=/#[0-9a-fA-F]{6}\\b/]",
+                    message:
+                        "Use design tokens (var(--…) or semantic Tailwind classes) " +
+                        "instead of hex colors.",
+                },
+            ],
+        },
+    },
 ];
 
 export default eslintConfig;


### PR DESCRIPTION
Stage 3 of the design-system unification plan — the part that keeps future features consistent. No runtime changes; lint config + docs only.

## Lint guardrails (root eslint.config.js, scoped to apps/web, existing idiom)

| Rule | Severity | Baseline |
|---|---|---|
| Imports of the old kit path (`**/documents/components/ui/*`) | **error** | 0 — tombstone |
| `employer/**` importing from `app/employee/**` | **error** | 0 |
| `employee/**` importing from `app/employer/**` or `~/styles/Employer/*` | warn | 5 pre-existing (ProfileDropdown ×2, WorkspaceShell, NavBar, Home styles) |
| Imports of deprecated `primitives.tsx` / `_workspace/icons` (outside its own feature) | warn | existing consumers |
| New hex color literals in TSX | warn | 74 |

Warnings are a ratchet — the count may only go down. `pnpm lint`: **0 errors / 82 warnings** in web, clean in landing; CI's plain `pnpm lint` is unaffected by warnings.

## Conventions written down

- **`apps/web/README.md`** — the frontend contract: component sourcing order (`~/components/ui` → shared composed → your area's `_components`), `npx shadcn add` for missing primitives, tokens-not-hexes with the semantic Tailwind namespace, dark-mode and font rules, asset constraints (the live `.docx` runtime coupling; the `.vercelignore`/`__tests__` deploy trap that broke Vercel last week), the touch-it-migrate-it migration rule, and the deprecation table.
- **Root `CLAUDE.md`** (the repo had none) — the same contract in imperative form for AI-assisted sessions. Given most commits here are Claude-authored, this is the highest-leverage consistency artifact in the plan.

## Verification

- Rules verified live: the cross-area warns fire on the 5 known violations, the hex warn fires on `not-found.tsx`, and nothing new errors.
- `pnpm lint` exits 0 for web and landing.

This completes the structural stages (0–3) of the plan. What remains is Stage 4 — opportunistic convergence under these rules (hotspots: AddSourceModal and the bespoke dialogs → `ui/dialog`, the 31-raw-button marketing workspace), ending when `compat.css` can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only plus ESLint policy; no runtime behavior. New rules are mostly warn-level ratchets with documented baselines; employer cross-area import is error on a clean leg.
> 
> **Overview**
> **Stage 3 of design-system unification:** enforce consistency through lint and written conventions only—no application code changes.
> 
> **`eslint.config.js`** refactors chat-client `no-restricted-imports` into shared `chatClientImportBans` and adds **design-system guardrails** scoped to `apps/web`: **error** on the old kit path (`documents/components/ui`) and employer→employee cross-area imports; **warn** on deprecated `primitives` / `_workspace/icons`, employee→employer (and `~/styles/Employer/*`) imports, and hex color literals in TSX. Flat-config composition is documented so each overlapping block repeats full restriction sets.
> 
> **`apps/web/README.md`** is new—the frontend contract (component sourcing, shadcn add flow, tokens, dark mode, assets/deploy traps, touch-it-migrate-it, deprecation table).
> 
> **`CLAUDE.md`** at repo root mirrors that contract for AI-assisted work plus workflow notes (format, templates, Vercel/`__tests__` import trap).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7eddf67eedf1aa3c889a5f1761d26a63abb9c8bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->