### PR TITLE
feat(call-notes): implement enrichment and knowledge integration

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -33,9 +33,9 @@ A company-visible marker that the Call Note owner attaches to an immutable Trans
 _Avoid_: Private highlight, transcript edit
 
 **Call Note**:
-The one canonical editable note for a Call, owned by the first LaunchStack user whose capture start succeeds. It is company-visible by default but the owner can make it private; other users then see the Transcript without a note and cannot create another. Ownership does not transfer in the initial product.
-_Avoid_: User Note, collaborative note, multiple notes per Call
+The one canonical editable note for a Call, owned by the first LaunchStack user whose capture start succeeds. It is company-visible by default but the owner can make it private; other users then see the Transcript without a note and cannot create another. Ownership does not transfer in the initial product. After the Call, the owner can explicitly and reversibly include a company-visible canonical revision in company knowledge; Capture completion alone never indexes it, and private Call Notes are excluded.
+_Avoid_: User Note, collaborative note, multiple notes per Call, automatically indexed note
 
 **Enriched Note**:
-An AI-proposed revision grounded in the Call's Transcript. It preserves existing owner steering and emphasis, may propose a complete Call Note when blank, and becomes the next canonical revision only after the owner accepts it.
-_Avoid_: Call summary, transcript summary
+An explicit post-call AI-proposed revision grounded in the finalized Transcript. Transcript chronology and substantive-topic coverage shape the proposal; the owner's existing note controls emphasis and intent, including visibly labelled owner context that the Transcript cannot support. The proposal remains separate and editable until the owner accepts it, at which point it becomes the next canonical Call Note revision.
+_Avoid_: Call summary, transcript summary, automatic overwrite, unaccepted knowledge

--- a/apps/web/__tests__/callNotes/company-notes-only-search.test.ts
+++ b/apps/web/__tests__/callNotes/company-notes-only-search.test.ts
@@ -1,0 +1,184 @@
+import { Document } from "@langchain/core/documents";
+
+jest.mock("~/env", () => ({
+    env: {
+        server: {
+            ENABLE_NOTES_RETRIEVER: true,
+            ENABLE_GRAPH_RETRIEVER: false,
+        },
+    },
+}));
+
+const mockGetCompanyChunks = jest.fn();
+const mockCreateCompanyBm25Retriever = jest.fn().mockResolvedValue({ kind: "bm25" });
+jest.mock("~/lib/tools/rag/retrievers/bm25-retriever", () => ({
+    getCompanyChunks: (...args: unknown[]) => mockGetCompanyChunks(...args),
+    getDocumentChunks: jest.fn(),
+    getMultiDocChunks: jest.fn(),
+    chunksToDocuments: jest.fn(),
+    createCompanyBM25Retriever: (...args: unknown[]) => mockCreateCompanyBm25Retriever(...args),
+    createDocumentBM25Retriever: jest.fn(),
+    createMultiDocBM25Retriever: jest.fn(),
+}));
+
+const mockCreateCompanyVectorRetriever = jest.fn().mockReturnValue({ kind: "vector" });
+jest.mock("~/lib/tools/rag/retrievers/vector-retriever", () => ({
+    createCompanyVectorRetriever: (...args: unknown[]) => mockCreateCompanyVectorRetriever(...args),
+    createDocumentVectorRetriever: jest.fn(),
+    createMultiDocVectorRetriever: jest.fn(),
+}));
+
+const mockNotesGetRelevantDocuments = jest.fn();
+const mockCreateCompanyNotesRetriever = jest.fn().mockReturnValue({
+    kind: "notes",
+    getRelevantDocuments: (...args: unknown[]) => mockNotesGetRelevantDocuments(...args),
+});
+jest.mock("~/lib/tools/rag/retrievers/notes-retriever", () => ({
+    createCompanyNotesRetriever: (...args: unknown[]) => mockCreateCompanyNotesRetriever(...args),
+    createDocumentNotesRetriever: jest.fn(),
+    createMultiDocNotesRetriever: jest.fn(),
+}));
+
+const mockEnsembleGetRelevantDocuments = jest.fn();
+const mockEnsembleConstructor = jest.fn().mockImplementation(() => ({
+    getRelevantDocuments: (...args: unknown[]) => mockEnsembleGetRelevantDocuments(...args),
+}));
+jest.mock("langchain/retrievers/ensemble", () => ({
+    EnsembleRetriever: class {
+        constructor(...args: unknown[]) {
+            mockEnsembleConstructor(...args);
+        }
+
+        getRelevantDocuments(...args: unknown[]) {
+            return mockEnsembleGetRelevantDocuments(...args);
+        }
+    },
+}));
+
+jest.mock("@langchain/community/retrievers/bm25", () => ({
+    BM25Retriever: { fromDocuments: jest.fn() },
+}));
+jest.mock("~/lib/tools/rag/retrievers/neo4j-graph-retriever", () => ({
+    createNeo4jGraphRetriever: jest.fn(),
+    shouldUseNeo4jRetriever: jest.fn().mockReturnValue(false),
+}));
+jest.mock("~/lib/tools/rag/retrievers/graph-retriever", () => ({
+    createGraphRetriever: jest.fn(),
+}));
+jest.mock("@launchstack/core/providers/reranking", () => ({
+    getRerankProvider: jest.fn(),
+    isRerankConfigured: jest.fn().mockReturnValue(false),
+}));
+
+const mockDocumentEmbeddings = { embedQuery: jest.fn() };
+const mockNoteEmbeddings = { embedQuery: jest.fn() };
+jest.mock("@launchstack/core/embeddings", () => ({
+    createEmbeddingModel: jest.fn(() => mockDocumentEmbeddings),
+    resolveEmbeddingIndex: jest.fn().mockReturnValue({
+        indexKey: "document-index",
+        dimension: 768,
+    }),
+}));
+jest.mock("~/server/notes/embedding-config", () => ({
+    resolveNoteEmbeddingRuntime: jest.fn(() => ({
+        embeddings: mockNoteEmbeddings,
+        index: { indexKey: "legacy-openai-1536" },
+    })),
+}));
+
+import { companyEnsembleSearch } from "~/lib/tools/rag/search/ensemble-search";
+import { env as mockedEnv } from "~/env";
+import { resolveNoteEmbeddingRuntime } from "~/server/notes/embedding-config";
+
+const mockEnv = mockedEnv as typeof mockedEnv & {
+    server: { ENABLE_NOTES_RETRIEVER: boolean; ENABLE_GRAPH_RETRIEVER: boolean };
+};
+const mockResolveNoteEmbeddingRuntime = resolveNoteEmbeddingRuntime as jest.Mock;
+
+function callNoteDocument(): Document {
+    return new Document({
+        pageContent: "Accepted Call Note",
+        metadata: {
+            source: "call_note",
+            noteId: 20,
+            callId: "call-20",
+            revision: 4,
+        },
+    });
+}
+
+describe("companyEnsembleSearch notes-only behavior", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockEnv.server.ENABLE_NOTES_RETRIEVER = true;
+        mockGetCompanyChunks.mockResolvedValue([]);
+        mockNotesGetRelevantDocuments.mockResolvedValue([]);
+        mockEnsembleGetRelevantDocuments.mockResolvedValue([]);
+    });
+
+    it("returns [] with zero document chunks and no eligible notes", async () => {
+        const results = await companyEnsembleSearch("customer", { companyId: 42, topK: 5 });
+
+        expect(results).toEqual([]);
+        expect(mockCreateCompanyNotesRetriever).toHaveBeenCalledWith(42, mockNoteEmbeddings, 8);
+        expect(mockEnsembleConstructor).not.toHaveBeenCalled();
+    });
+
+    it("returns eligible Call Notes when the company has zero document chunks", async () => {
+        mockNotesGetRelevantDocuments.mockResolvedValue([callNoteDocument()]);
+
+        const [result] = await companyEnsembleSearch("customer", { companyId: 42, topK: 5 });
+
+        expect(result).toMatchObject({
+            pageContent: "Accepted Call Note",
+            metadata: {
+                retrievalMethod: "vector_ann",
+                searchScope: "company",
+                source: "call_note",
+                noteId: 20,
+                callId: "call-20",
+                revision: 4,
+            },
+        });
+        expect(mockEnsembleConstructor).not.toHaveBeenCalled();
+    });
+
+    it("preserves the normal ensemble when document chunks and notes exist", async () => {
+        mockGetCompanyChunks.mockResolvedValue([{ id: 1, content: "document chunk" }]);
+        mockEnsembleGetRelevantDocuments.mockResolvedValue([callNoteDocument()]);
+
+        const [result] = await companyEnsembleSearch("customer", { companyId: 42, topK: 5 });
+
+        expect(mockCreateCompanyBm25Retriever).toHaveBeenCalled();
+        expect(mockCreateCompanyVectorRetriever).toHaveBeenCalled();
+        expect(mockCreateCompanyNotesRetriever).toHaveBeenCalledWith(42, mockNoteEmbeddings, 8);
+        expect(mockEnsembleConstructor).toHaveBeenCalledWith(
+            expect.objectContaining({
+                retrievers: expect.arrayContaining([
+                    expect.objectContaining({ kind: "bm25" }),
+                    expect.objectContaining({ kind: "vector" }),
+                    expect.objectContaining({ kind: "notes" }),
+                ]),
+            })
+        );
+        expect(result?.metadata.retrievalMethod).toBe("ensemble_rrf");
+    });
+
+    it("fails safely when company chunk loading fails", async () => {
+        mockGetCompanyChunks.mockRejectedValueOnce(new Error("database unavailable"));
+
+        await expect(
+            companyEnsembleSearch("customer", { companyId: 42, topK: 5 })
+        ).resolves.toEqual([]);
+    });
+
+    it("fails safely when the note embedding runtime cannot be resolved", async () => {
+        mockResolveNoteEmbeddingRuntime.mockImplementationOnce(() => {
+            throw new Error("embedding configuration unavailable");
+        });
+
+        await expect(
+            companyEnsembleSearch("customer", { companyId: 42, topK: 5 })
+        ).resolves.toEqual([]);
+    });
+});

--- a/apps/web/__tests__/callNotes/contracts.test.ts
+++ b/apps/web/__tests__/callNotes/contracts.test.ts
@@ -1,0 +1,104 @@
+import {
+    CALL_NOTES_CAPTURE_EVENTS,
+    CALL_NOTES_DETECTED_CANDIDATE,
+    CALL_NOTES_DISMISS_COMMAND,
+    CALL_NOTES_ENRICHMENT_PROPOSAL,
+    CALL_NOTES_FIXTURE_IDS,
+    CALL_NOTES_START_COMMAND,
+    CallNotesCommandSchema,
+    CallStatusSchema,
+    CaptureEventSchema,
+    DetectedCallCandidateSchema,
+    EnrichedNoteProposalSchema,
+    assertCaptureSourceContract,
+    createScriptedCaptureSource,
+} from "@launchstack/features/call-notes";
+
+import type { CaptureAttemptHandle, CaptureSource } from "@launchstack/features/call-notes";
+
+describe("Call Notes contract baseline", () => {
+    it("keeps one occurrence across pause and same-user return attempts", () => {
+        const events = CALL_NOTES_CAPTURE_EVENTS.map(event => CaptureEventSchema.parse(event));
+
+        expect(new Set(events.map(event => event.occurrenceKey))).toEqual(
+            new Set([CALL_NOTES_FIXTURE_IDS.occurrenceKey])
+        );
+        expect(
+            new Set(events.flatMap(event => (event.attemptKey ? [event.attemptKey] : []))).size
+        ).toBe(2);
+        expect(events.filter(event => event.kind === "transcript_segment")).toHaveLength(3);
+        expect(events.some(event => event.kind === "attempt_paused")).toBe(true);
+        expect(events.some(event => event.kind === "participant_returned")).toBe(true);
+    });
+
+    it("requires replay-safe evidence identity on every transcript segment", () => {
+        const segment = CALL_NOTES_CAPTURE_EVENTS.find(
+            event => event.kind === "transcript_segment"
+        );
+        if (!segment) throw new Error("fixture transcript segment missing");
+        const withoutHash: Partial<typeof segment> = { ...segment };
+        delete withoutHash.sourcePacketHash;
+
+        expect(() => CaptureEventSchema.parse(withoutHash)).toThrow();
+    });
+
+    it("rejects unsupported capture providers at the command boundary", () => {
+        expect(() =>
+            CallNotesCommandSchema.parse({ ...CALL_NOTES_START_COMMAND, provider: "google_meet" })
+        ).toThrow();
+    });
+    it("keeps detected suggestions separate from Calls until Start", () => {
+        const candidate = DetectedCallCandidateSchema.parse(CALL_NOTES_DETECTED_CANDIDATE);
+
+        expect(candidate.occurrenceKey).toBe(CALL_NOTES_DISMISS_COMMAND.occurrenceKey);
+        expect(CALL_NOTES_DISMISS_COMMAND.kind).toBe("dismiss_detected_occurrence");
+        expect(CALL_NOTES_DISMISS_COMMAND).not.toHaveProperty("callId");
+        expect(CallStatusSchema.options).not.toContain("detected");
+    });
+
+    it("keeps enrichment as a structured reviewable proposal", () => {
+        const proposal = EnrichedNoteProposalSchema.parse(CALL_NOTES_ENRICHMENT_PROPOSAL);
+
+        expect(proposal.chronologicalSections.map(section => section.heading)).toEqual([
+            "Onboarding launch risk",
+            "Next step",
+        ]);
+        expect(proposal.actionItems).toEqual([
+            expect.objectContaining({ ownerName: "Alex Founder" }),
+        ]);
+        expect(proposal.contentMarkdown).toContain("## Summary");
+    });
+
+    it("exercises start, Pause, and Resume through the capture-source conformance suite", async () => {
+        await expect(
+            assertCaptureSourceContract(createScriptedCaptureSource())
+        ).resolves.toBeUndefined();
+
+        const missingResume: CaptureSource = {
+            capabilities: {
+                attributedTranscript: true,
+                nativePauseResume: true,
+                transportReconnect: true,
+                observesCaptureUserReturn: true,
+            },
+            async startAttempt(input, sink): Promise<CaptureAttemptHandle> {
+                await sink.append(CALL_NOTES_CAPTURE_EVENTS[0]!);
+                return {
+                    async pause() {
+                        await sink.append(CALL_NOTES_CAPTURE_EVENTS[4]!);
+                    },
+                    async resume() {
+                        return undefined;
+                    },
+                    async dispose() {
+                        return undefined;
+                    },
+                };
+            },
+        };
+
+        await expect(assertCaptureSourceContract(missingResume)).rejects.toThrow(
+            "missing resumed event"
+        );
+    });
+});

--- a/apps/web/__tests__/callNotes/enrichment-core.test.ts
+++ b/apps/web/__tests__/callNotes/enrichment-core.test.ts
@@ -1,0 +1,404 @@
+import {
+    CALL_NOTES_ENRICHMENT_SCHEMA_VERSION,
+    EnrichedNoteProposalSchema,
+    EnrichmentInputSchema,
+    EnrichmentResultSchema,
+    type EnrichedNoteProposal,
+} from "@launchstack/features/call-notes";
+import { invokeStructured } from "@launchstack/core/llm";
+
+import { resolveConfiguredChatModel } from "~/lib/models";
+import {
+    CALL_NOTES_ENRICHMENT_ROUTE,
+    ConfiguredCallNotesEnrichmentModel,
+} from "~/server/call-notes/enrichment-model";
+import {
+    buildCallNotesEnrichmentPrompt,
+    CALL_NOTES_ENRICHMENT_PROMPT_VERSION,
+    CALL_NOTES_ENRICHMENT_SYSTEM_PROMPT,
+} from "~/server/call-notes/enrichment-prompts";
+import {
+    EnrichmentProvenanceValidationError,
+    validateEnrichmentProvenance,
+} from "~/server/call-notes/enrichment-validation";
+
+jest.mock("@launchstack/core/llm", () => ({
+    invokeStructured: jest.fn(),
+}));
+
+jest.mock("~/lib/models", () => ({
+    resolveConfiguredChatModel: jest.fn(),
+}));
+
+const INPUT = EnrichmentInputSchema.parse({
+    schemaVersion: CALL_NOTES_ENRICHMENT_SCHEMA_VERSION,
+    callId: "call-a1",
+    transcriptFingerprint: "a".repeat(64),
+    transcript: [
+        {
+            id: "segment-customer",
+            attemptId: "attempt-1",
+            participantId: "participant-customer",
+            speakerName: "Maya Customer",
+            providerStartMs: 1_000,
+            providerEndMs: 4_000,
+            receivedAt: "2026-08-15T14:00:04.100Z",
+            receiveOrder: 1,
+            text: "We need to reduce onboarding time before the September launch.",
+            language: "en",
+        },
+        {
+            id: "segment-owner",
+            attemptId: "attempt-1",
+            participantId: "participant-owner",
+            speakerName: "Alex Founder",
+            providerStartMs: 421_000,
+            providerEndMs: 425_000,
+            receivedAt: "2026-08-15T14:07:05.050Z",
+            receiveOrder: 2,
+            text: "I will send the revised onboarding checklist by Friday.",
+            language: "en",
+        },
+    ],
+    gaps: [
+        {
+            id: "gap-paused",
+            attemptId: "attempt-1",
+            kind: "user_paused",
+            startedAt: "2026-08-15T14:05:00.000Z",
+            endedAt: "2026-08-15T14:07:00.000Z",
+        },
+    ],
+    bookmarks: [
+        {
+            id: "bookmark-customer",
+            segmentId: "segment-customer",
+            comment: "Emphasize this launch risk in the summary.",
+            createdAt: "2026-08-15T14:00:05.000Z",
+        },
+    ],
+    note: {
+        documentNoteId: 41,
+        ownerUserId: "user-owner",
+        visibility: "private",
+        knowledgeIncluded: false,
+        revision: 3,
+        title: "Owner's onboarding notes",
+        contentMarkdown: "Customer is worried about onboarding time. Preserve my wording.",
+        contentRich: { type: "doc", attrs: { b: 2, a: 1 }, content: [] },
+        saveState: "saved",
+    },
+});
+
+const GROUNDED_PROPOSAL = EnrichedNoteProposalSchema.parse({
+    schemaVersion: CALL_NOTES_ENRICHMENT_SCHEMA_VERSION,
+    chronologicalSections: [
+        {
+            heading: "Onboarding launch risk",
+            markdown: "Maya needs onboarding time reduced before the September launch.",
+            ownerContextLabels: ["Owner noted onboarding concern"],
+        },
+    ],
+    summary: "Onboarding time is a stated launch risk.",
+    actionItems: [
+        {
+            text: "Send the revised onboarding checklist.",
+            ownerName: "Alex Founder",
+            dueDate: null,
+        },
+    ],
+    bookmarkPassages: [
+        {
+            markdown: "Maya identified onboarding time as a launch risk.",
+            citations: [
+                {
+                    bookmarkId: "bookmark-customer",
+                    segmentId: "segment-customer",
+                    speakerName: "Maya Customer",
+                    providerStartMs: 1_000,
+                },
+            ],
+        },
+    ],
+    conflicts: [],
+    contentMarkdown: "## Onboarding launch risk\nMaya needs onboarding time reduced.",
+    contentRich: { type: "doc", content: [] },
+});
+
+function citationProposal(
+    overrides: Partial<EnrichedNoteProposal["bookmarkPassages"][number]["citations"][number]> = {}
+): EnrichedNoteProposal {
+    const citation = GROUNDED_PROPOSAL.bookmarkPassages[0]!.citations[0]!;
+    return EnrichedNoteProposalSchema.parse({
+        ...GROUNDED_PROPOSAL,
+        bookmarkPassages: [
+            {
+                ...GROUNDED_PROPOSAL.bookmarkPassages[0],
+                citations: [{ ...citation, ...overrides }],
+            },
+        ],
+    });
+}
+
+function issueCodes(error: unknown): string[] {
+    expect(error).toBeInstanceOf(EnrichmentProvenanceValidationError);
+    return (error as EnrichmentProvenanceValidationError).issues.map(issue => issue.code);
+}
+
+interface ParsedEnrichmentPrompt {
+    promptVersion: string;
+    outputSchemaVersion: string;
+    generationMode: string;
+    currentOwnerCallNote: {
+        sourceRole: string;
+        revision: number;
+        contentMarkdown: string;
+    };
+    bookmarks: Array<{
+        bookmarkId: string;
+        linkedTranscriptSegmentId: string;
+        userGuidance: string | null;
+        guidanceRole: string;
+    }>;
+    transcriptGaps: Array<{
+        id: string;
+        evidenceAvailability: string;
+        instruction: string;
+    }>;
+}
+
+function parsePrompt(input = INPUT): ParsedEnrichmentPrompt {
+    return JSON.parse(buildCallNotesEnrichmentPrompt(input)) as ParsedEnrichmentPrompt;
+}
+
+describe("Call Notes enrichment prompt", () => {
+    it("serializes equivalent input deterministically", () => {
+        const reorderedRichTextInput = EnrichmentInputSchema.parse({
+            ...INPUT,
+            note: {
+                ...INPUT.note,
+                contentRich: { content: [], attrs: { a: 1, b: 2 }, type: "doc" },
+            },
+        });
+
+        expect(buildCallNotesEnrichmentPrompt(INPUT)).toBe(
+            buildCallNotesEnrichmentPrompt(reorderedRichTextInput)
+        );
+    });
+
+    it("labels the owner-authored note as source context and preserves its content", () => {
+        const prompt = parsePrompt();
+
+        expect(prompt.currentOwnerCallNote).toMatchObject({
+            sourceRole: "owner-authored current Call Note",
+            revision: 3,
+            contentMarkdown: INPUT.note.contentMarkdown,
+        });
+    });
+
+    it("represents Bookmark comments as strong user guidance, not evidence", () => {
+        const prompt = parsePrompt();
+
+        expect(prompt.bookmarks[0]).toMatchObject({
+            bookmarkId: "bookmark-customer",
+            linkedTranscriptSegmentId: "segment-customer",
+            userGuidance: "Emphasize this launch risk in the summary.",
+            guidanceRole: "strong user steering, not independent factual evidence",
+        });
+    });
+
+    it("represents Transcript gaps explicitly as unavailable evidence", () => {
+        const prompt = parsePrompt();
+
+        expect(prompt.transcriptGaps[0]).toMatchObject({
+            id: "gap-paused",
+            evidenceAvailability: "unavailable",
+            instruction: "Do not infer or reconstruct content during this gap.",
+        });
+    });
+
+    it("prohibits ambiguous outcomes and inference across gaps", () => {
+        expect(CALL_NOTES_ENRICHMENT_SYSTEM_PROMPT).toContain(
+            "uncertain discussion, suggestions, questions, or possibilities"
+        );
+        expect(CALL_NOTES_ENRICHMENT_SYSTEM_PROMPT).toContain(
+            "Never infer, reconstruct, summarize, or bridge content"
+        );
+        expect(CALL_NOTES_ENRICHMENT_SYSTEM_PROMPT).toContain(
+            "Never invent decisions, action items, owners, deadlines"
+        );
+    });
+
+    it("requests a separate proposal with the frozen version", () => {
+        const prompt = parsePrompt();
+
+        expect(prompt.promptVersion).toBe(CALL_NOTES_ENRICHMENT_PROMPT_VERSION);
+        expect(prompt.outputSchemaVersion).toBe(CALL_NOTES_ENRICHMENT_SCHEMA_VERSION);
+        expect(prompt.generationMode).toContain("separate proposal");
+    });
+});
+
+describe("Call Notes enrichment provenance", () => {
+    it("accepts a Bookmark citation copied exactly from canonical input", () => {
+        expect(validateEnrichmentProvenance(INPUT, GROUNDED_PROPOSAL)).toEqual(GROUNDED_PROPOSAL);
+    });
+
+    it("rejects an invented Bookmark ID", () => {
+        let thrown: unknown;
+        try {
+            validateEnrichmentProvenance(
+                INPUT,
+                citationProposal({ bookmarkId: "bookmark-invented" })
+            );
+        } catch (error) {
+            thrown = error;
+        }
+
+        expect(issueCodes(thrown)).toContain("unknown_bookmark_id");
+    });
+
+    it("rejects an invented Transcript segment ID", () => {
+        let thrown: unknown;
+        try {
+            validateEnrichmentProvenance(
+                INPUT,
+                citationProposal({ segmentId: "segment-invented" })
+            );
+        } catch (error) {
+            thrown = error;
+        }
+
+        expect(issueCodes(thrown)).toContain("unknown_transcript_segment_id");
+    });
+
+    it("rejects a citation to a segment unrelated to its Bookmark", () => {
+        let thrown: unknown;
+        try {
+            validateEnrichmentProvenance(
+                INPUT,
+                citationProposal({
+                    segmentId: "segment-owner",
+                    speakerName: "Alex Founder",
+                    providerStartMs: 421_000,
+                })
+            );
+        } catch (error) {
+            thrown = error;
+        }
+
+        expect(issueCodes(thrown)).toContain("bookmark_segment_mismatch");
+    });
+
+    it("rejects a mismatched speaker identity", () => {
+        let thrown: unknown;
+        try {
+            validateEnrichmentProvenance(
+                INPUT,
+                citationProposal({ speakerName: "Invented Speaker" })
+            );
+        } catch (error) {
+            thrown = error;
+        }
+
+        expect(issueCodes(thrown)).toContain("speaker_mismatch");
+    });
+
+    it("rejects a mismatched citation timestamp", () => {
+        let thrown: unknown;
+        try {
+            validateEnrichmentProvenance(INPUT, citationProposal({ providerStartMs: 999 }));
+        } catch (error) {
+            thrown = error;
+        }
+
+        expect(issueCodes(thrown)).toContain("timestamp_mismatch");
+    });
+
+    it("rejects a citation when its canonical segment has an invalid timestamp range", () => {
+        const invalidRangeInput = EnrichmentInputSchema.parse({
+            ...INPUT,
+            transcript: INPUT.transcript.map(segment =>
+                segment.id === "segment-customer"
+                    ? { ...segment, providerStartMs: 4_000, providerEndMs: 1_000 }
+                    : segment
+            ),
+        });
+        let thrown: unknown;
+        try {
+            validateEnrichmentProvenance(
+                invalidRangeInput,
+                citationProposal({ providerStartMs: 4_000 })
+            );
+        } catch (error) {
+            thrown = error;
+        }
+
+        expect(issueCodes(thrown)).toContain("invalid_transcript_timestamp_range");
+    });
+});
+
+describe("ConfiguredCallNotesEnrichmentModel", () => {
+    const resolveModelMock = resolveConfiguredChatModel as jest.Mock;
+    const invokeStructuredMock = invokeStructured as jest.Mock;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        resolveModelMock.mockReturnValue({
+            route: "reasoning",
+            name: "configured-label",
+            modelId: "configured-reasoning-model",
+        });
+        invokeStructuredMock.mockResolvedValue(GROUNDED_PROPOSAL);
+    });
+
+    it("generates a normal grounded enrichment without mutating its input", async () => {
+        const before = structuredClone(INPUT);
+
+        const result = await new ConfiguredCallNotesEnrichmentModel().generate(INPUT);
+
+        expect(result.proposal).toEqual(GROUNDED_PROPOSAL);
+        expect(INPUT).toEqual(before);
+    });
+
+    it("rejects structurally invalid model output", async () => {
+        invokeStructuredMock.mockResolvedValue({
+            schemaVersion: CALL_NOTES_ENRICHMENT_SCHEMA_VERSION,
+            chronologicalSections: [],
+        });
+
+        await expect(new ConfiguredCallNotesEnrichmentModel().generate(INPUT)).rejects.toThrow();
+    });
+
+    it("propagates model exceptions without a persistence side effect", async () => {
+        const failure = new Error("configured model timed out");
+        invokeStructuredMock.mockRejectedValue(failure);
+
+        await expect(new ConfiguredCallNotesEnrichmentModel().generate(INPUT)).rejects.toBe(
+            failure
+        );
+    });
+
+    it("resolves the configured reasoning route", async () => {
+        await new ConfiguredCallNotesEnrichmentModel().generate(INPUT);
+
+        expect(resolveModelMock).toHaveBeenCalledWith({ route: CALL_NOTES_ENRICHMENT_ROUTE });
+        expect(invokeStructuredMock).toHaveBeenCalledWith(
+            expect.objectContaining({ modelId: "configured-reasoning-model" }),
+            EnrichedNoteProposalSchema,
+            expect.any(Array),
+            { name: "call_notes_enrichment_v1" }
+        );
+    });
+
+    it("returns a final result that validates against the frozen schema", async () => {
+        const result = await new ConfiguredCallNotesEnrichmentModel().generate(INPUT);
+
+        expect(() => EnrichmentResultSchema.parse(result)).not.toThrow();
+        expect(result.modelMetadata).toEqual({
+            model: "configured-reasoning-model",
+            promptVersion: CALL_NOTES_ENRICHMENT_PROMPT_VERSION,
+        });
+        expect(result.modelMetadata).not.toHaveProperty("provider");
+        expect(result.modelMetadata).not.toHaveProperty("completionId");
+    });
+});

--- a/apps/web/__tests__/callNotes/knowledge-note-sink.test.ts
+++ b/apps/web/__tests__/callNotes/knowledge-note-sink.test.ts
@@ -1,0 +1,251 @@
+import type { KnowledgeNote } from "@launchstack/features/call-notes";
+
+jest.mock("~/server/db", () => ({ db: {} }));
+jest.mock("~/server/notes/embed-note", () => ({ requestNoteEmbedding: jest.fn() }));
+
+import {
+    createKnowledgeNoteSink,
+    type CanonicalDocumentNoteState,
+    type KnowledgeCallState,
+    type KnowledgeNoteStore,
+} from "~/server/call-notes/knowledge-note-sink";
+
+const COMPANY_ID = 42n;
+const CALL_ID = "call-42";
+const NOTE_ID = 314;
+
+function knowledgeNote(overrides: Partial<KnowledgeNote> = {}): KnowledgeNote {
+    return {
+        companyId: COMPANY_ID.toString(),
+        callId: CALL_ID,
+        documentNoteId: NOTE_ID,
+        ownerUserId: "user-owner",
+        revision: 3,
+        title: "Founder sync",
+        contentMarkdown: "## Canonical owner note\n\nApproved outcome.",
+        deepLink: "/calls/call-42",
+        ...overrides,
+    };
+}
+
+function callState(overrides: Partial<KnowledgeCallState> = {}): KnowledgeCallState {
+    return {
+        id: CALL_ID,
+        companyId: COMPANY_ID,
+        status: "completed",
+        documentNoteId: NOTE_ID,
+        noteOwnerUserId: "user-owner",
+        noteVisibility: "company",
+        knowledgeIncluded: true,
+        currentNoteRevision: 3,
+        ...overrides,
+    };
+}
+
+function documentNote(
+    overrides: Partial<CanonicalDocumentNoteState> = {}
+): CanonicalDocumentNoteState {
+    return {
+        id: NOTE_ID,
+        userId: "user-owner",
+        companyId: COMPANY_ID.toString(),
+        title: "Founder sync",
+        content: null,
+        contentMarkdown: "## Canonical owner note\n\nApproved outcome.",
+        ...overrides,
+    };
+}
+
+class FakeKnowledgeNoteStore implements KnowledgeNoteStore {
+    call: KnowledgeCallState | null = callState();
+    note: CanonicalDocumentNoteState | null = documentNote();
+    projectionPresent = true;
+    readonly operations: string[] = [];
+    readonly embeddingRequests: Array<{ noteId: number; companyId: bigint }> = [];
+
+    async findCall(companyId: bigint, callId: string): Promise<KnowledgeCallState | null> {
+        this.operations.push(`find-call:${companyId}:${callId}`);
+        if (this.call?.companyId !== companyId || this.call.id !== callId) return null;
+        return this.call;
+    }
+
+    async findDocumentNote(documentNoteId: number): Promise<CanonicalDocumentNoteState | null> {
+        this.operations.push(`find-note:${documentNoteId}`);
+        return this.note?.id === documentNoteId ? this.note : null;
+    }
+
+    async removeProjection(documentNoteId: number): Promise<void> {
+        this.operations.push(`remove-projection:${documentNoteId}`);
+        this.projectionPresent = false;
+    }
+
+    async enqueueEmbedding(documentNoteId: number, companyId: bigint): Promise<void> {
+        this.operations.push(`enqueue:${documentNoteId}:${companyId}`);
+        this.embeddingRequests.push({ noteId: documentNoteId, companyId });
+    }
+}
+
+describe("LaunchStackKnowledgeNoteSink", () => {
+    it("removes the stale projection and enqueues the current accepted Call Note", async () => {
+        const store = new FakeKnowledgeNoteStore();
+        const sink = createKnowledgeNoteSink(store);
+
+        await sink.upsert(knowledgeNote());
+
+        expect(store.operations).toEqual([
+            "find-call:42:call-42",
+            "find-note:314",
+            "remove-projection:314",
+            "enqueue:314:42",
+        ]);
+        expect(store.projectionPresent).toBe(false);
+        expect(store.embeddingRequests).toEqual([{ noteId: NOTE_ID, companyId: COMPANY_ID }]);
+    });
+
+    it("rejects knowledge inclusion when the default-off flag is false", async () => {
+        const store = new FakeKnowledgeNoteStore();
+        store.call = callState({ knowledgeIncluded: false });
+
+        await expect(createKnowledgeNoteSink(store).upsert(knowledgeNote())).rejects.toMatchObject({
+            code: "knowledge_disabled",
+        });
+        expect(store.embeddingRequests).toHaveLength(0);
+    });
+
+    it("rejects a private Call Note", async () => {
+        const store = new FakeKnowledgeNoteStore();
+        store.call = callState({ noteVisibility: "private" });
+
+        await expect(createKnowledgeNoteSink(store).upsert(knowledgeNote())).rejects.toMatchObject({
+            code: "private_note",
+        });
+    });
+
+    it.each(["active", "finalizing", "failed"] as const)(
+        "rejects an ineligible %s Call",
+        async status => {
+            const store = new FakeKnowledgeNoteStore();
+            store.call = callState({ status });
+
+            await expect(
+                createKnowledgeNoteSink(store).upsert(knowledgeNote())
+            ).rejects.toMatchObject({ code: "call_not_completed" });
+        }
+    );
+
+    it("rejects a stale canonical revision", async () => {
+        const store = new FakeKnowledgeNoteStore();
+        store.call = callState({ currentNoteRevision: 4 });
+
+        await expect(createKnowledgeNoteSink(store).upsert(knowledgeNote())).rejects.toMatchObject({
+            code: "stale_revision",
+        });
+    });
+
+    it("fails closed for the wrong company", async () => {
+        const store = new FakeKnowledgeNoteStore();
+
+        await expect(
+            createKnowledgeNoteSink(store).upsert(knowledgeNote({ companyId: "99" }))
+        ).rejects.toMatchObject({ code: "call_not_found" });
+    });
+
+    it("rejects a company id that cannot round-trip through the durable event protocol", async () => {
+        const store = new FakeKnowledgeNoteStore();
+
+        await expect(
+            createKnowledgeNoteSink(store).upsert(knowledgeNote({ companyId: "9007199254740993" }))
+        ).rejects.toMatchObject({ code: "unsupported_company_id" });
+        expect(store.operations).toHaveLength(0);
+    });
+
+    it("rejects the wrong owner at both Call and document-note identity seams", async () => {
+        const callStore = new FakeKnowledgeNoteStore();
+        callStore.call = callState({ noteOwnerUserId: "someone-else" });
+        await expect(
+            createKnowledgeNoteSink(callStore).upsert(knowledgeNote())
+        ).rejects.toMatchObject({ code: "wrong_owner" });
+
+        const documentStore = new FakeKnowledgeNoteStore();
+        documentStore.note = documentNote({ userId: "someone-else" });
+        await expect(
+            createKnowledgeNoteSink(documentStore).upsert(knowledgeNote())
+        ).rejects.toMatchObject({ code: "wrong_owner" });
+    });
+
+    it("rejects a document note that is not the Call's canonical note", async () => {
+        const store = new FakeKnowledgeNoteStore();
+
+        await expect(
+            createKnowledgeNoteSink(store).upsert(knowledgeNote({ documentNoteId: 999 }))
+        ).rejects.toMatchObject({ code: "wrong_document_note" });
+    });
+
+    it("rejects stale payload content before enqueueing", async () => {
+        const store = new FakeKnowledgeNoteStore();
+
+        await expect(
+            createKnowledgeNoteSink(store).upsert(
+                knowledgeNote({ contentMarkdown: "A stale accepted proposal" })
+            )
+        ).rejects.toMatchObject({ code: "content_mismatch" });
+        expect(store.embeddingRequests).toHaveLength(0);
+    });
+
+    it("rejects a missing canonical document note and a document-note company mismatch", async () => {
+        const missingStore = new FakeKnowledgeNoteStore();
+        missingStore.note = null;
+        await expect(
+            createKnowledgeNoteSink(missingStore).upsert(knowledgeNote())
+        ).rejects.toMatchObject({ code: "document_note_not_found" });
+
+        const wrongCompanyStore = new FakeKnowledgeNoteStore();
+        wrongCompanyStore.note = documentNote({ companyId: "99" });
+        await expect(
+            createKnowledgeNoteSink(wrongCompanyStore).upsert(knowledgeNote())
+        ).rejects.toMatchObject({ code: "wrong_company" });
+    });
+
+    it("remove deletes only the retrieval projection", async () => {
+        const store = new FakeKnowledgeNoteStore();
+        const originalCall = structuredClone(store.call);
+        const originalNote = structuredClone(store.note);
+
+        await createKnowledgeNoteSink(store).remove(COMPANY_ID.toString(), CALL_ID);
+
+        expect(store.projectionPresent).toBe(false);
+        expect(store.call).toEqual(originalCall);
+        expect(store.note).toEqual(originalNote);
+        expect(store.embeddingRequests).toHaveLength(0);
+    });
+
+    it("does not send Transcript, Bookmark, or proposal content into the embedding request", async () => {
+        const store = new FakeKnowledgeNoteStore();
+
+        await createKnowledgeNoteSink(store).upsert(knowledgeNote());
+
+        expect(store.embeddingRequests).toEqual([{ noteId: NOTE_ID, companyId: COMPANY_ID }]);
+        expect(Object.keys(store.embeddingRequests[0] ?? {})).toEqual(["noteId", "companyId"]);
+    });
+
+    it("does not mutate Call lifecycle or canonical document-note state", async () => {
+        const store = new FakeKnowledgeNoteStore();
+        const originalCall = structuredClone(store.call);
+        const originalNote = structuredClone(store.note);
+
+        await createKnowledgeNoteSink(store).upsert(knowledgeNote());
+
+        expect(store.call).toEqual(originalCall);
+        expect(store.note).toEqual(originalNote);
+    });
+
+    it("stays fail closed when durable enqueue fails after projection removal", async () => {
+        const store = new FakeKnowledgeNoteStore();
+        store.enqueueEmbedding = jest.fn().mockRejectedValue(new Error("outbox unavailable"));
+
+        await expect(createKnowledgeNoteSink(store).upsert(knowledgeNote())).rejects.toThrow(
+            "outbox unavailable"
+        );
+        expect(store.projectionPresent).toBe(false);
+    });
+});

--- a/apps/web/__tests__/callNotes/note-embedding-provider.test.ts
+++ b/apps/web/__tests__/callNotes/note-embedding-provider.test.ts
@@ -1,0 +1,109 @@
+const mockEmbeddingClientOptions: Array<Record<string, unknown>> = [];
+const mockVector = Array.from({ length: 1536 }, (_, index) => index / 1536);
+
+jest.mock("@langchain/openai", () => ({
+    OpenAIEmbeddings: jest.fn().mockImplementation((options: Record<string, unknown>) => {
+        mockEmbeddingClientOptions.push(options);
+        return {
+            embedDocuments: jest.fn().mockResolvedValue([mockVector]),
+            embedQuery: jest.fn().mockResolvedValue(mockVector),
+        };
+    }),
+}));
+
+jest.mock("~/server/db", () => ({ db: {} }));
+jest.mock("~/server/db/index", () => ({
+    db: { execute: jest.fn().mockResolvedValue([]) },
+    toRows: (value: unknown) => value,
+}));
+
+import {
+    embedNoteWithDependencies,
+    type NoteEmbeddingProjection,
+    type NoteEmbeddingSnapshot,
+    type NoteEmbeddingStore,
+} from "~/server/notes/embed-note";
+import { NOTE_EMBEDDING_INDEX, resolveNoteEmbeddingRuntime } from "~/server/notes/embedding-config";
+import { searchNotes } from "~/server/notes/search";
+import { db as mockedSearchDb } from "~/server/db/index";
+
+const mockExecute = mockedSearchDb.execute as jest.Mock;
+
+describe("legacy note embedding provider consistency", () => {
+    const previousBaseUrl = process.env.EMBEDDING_API_BASE_URL;
+    const previousKey = process.env.EMBEDDING_API_KEY;
+
+    beforeAll(() => {
+        process.env.EMBEDDING_API_BASE_URL = "https://embedding.example/v1";
+        process.env.EMBEDDING_API_KEY = "test-key";
+    });
+
+    afterAll(() => {
+        if (previousBaseUrl === undefined) delete process.env.EMBEDDING_API_BASE_URL;
+        else process.env.EMBEDDING_API_BASE_URL = previousBaseUrl;
+        if (previousKey === undefined) delete process.env.EMBEDDING_API_KEY;
+        else process.env.EMBEDDING_API_KEY = previousKey;
+    });
+
+    beforeEach(() => {
+        mockEmbeddingClientOptions.length = 0;
+        mockExecute.mockClear();
+    });
+
+    it("uses the same fixed legacy model and dimensions for note writes and note queries", async () => {
+        const snapshot: NoteEmbeddingSnapshot = {
+            note: {
+                id: 5,
+                userId: "owner",
+                companyId: "9",
+                documentId: null,
+                versionId: null,
+                title: "Note",
+                content: null,
+                contentMarkdown: "Body",
+                anchor: null,
+                createdAt: new Date("2026-08-21T00:00:00.000Z"),
+                updatedAt: null,
+            },
+            call: null,
+        };
+        let written: NoteEmbeddingProjection | null = null;
+        const store: NoteEmbeddingStore = {
+            loadSnapshot: async () => snapshot,
+            removeProjection: async () => undefined,
+            removeIfCurrent: async () => "removed",
+            replaceIfCurrent: async (_expected, projection) => {
+                written = projection;
+                return "written";
+            },
+        };
+
+        const writeRuntime = resolveNoteEmbeddingRuntime();
+        expect(writeRuntime).not.toBeNull();
+        await embedNoteWithDependencies(5, { store, runtime: writeRuntime });
+
+        await searchNotes({
+            userId: "owner",
+            companyId: "9",
+            query: "body",
+            scope: "company",
+        });
+
+        expect(mockEmbeddingClientOptions).toHaveLength(2);
+        expect(mockEmbeddingClientOptions).toEqual([
+            expect.objectContaining({
+                modelName: NOTE_EMBEDDING_INDEX.model,
+                dimensions: NOTE_EMBEDDING_INDEX.dimension,
+            }),
+            expect.objectContaining({
+                modelName: NOTE_EMBEDDING_INDEX.model,
+                dimensions: NOTE_EMBEDDING_INDEX.dimension,
+            }),
+        ]);
+        expect(written).toMatchObject({
+            modelVersion: NOTE_EMBEDDING_INDEX.model,
+            embeddingShort: mockVector.slice(0, NOTE_EMBEDDING_INDEX.shortDimension),
+        });
+        expect(mockExecute).toHaveBeenCalledTimes(1);
+    });
+});

--- a/apps/web/__tests__/callNotes/note-embedding-race.test.ts
+++ b/apps/web/__tests__/callNotes/note-embedding-race.test.ts
@@ -1,0 +1,287 @@
+jest.mock("~/server/db", () => ({ db: {} }));
+
+import {
+    embedNoteWithDependencies,
+    evaluateEmbeddingFreshness,
+    type CallNoteEmbeddingState,
+    type NoteEmbeddingProjection,
+    type NoteEmbeddingCleanupResult,
+    type NoteEmbeddingSnapshot,
+    type NoteEmbeddingStore,
+    type NoteEmbeddingWriteResult,
+} from "~/server/notes/embed-note";
+import type { NoteEmbeddingRuntime } from "~/server/notes/embedding-config";
+
+const NOTE_ID = 77;
+
+function callState(overrides: Partial<CallNoteEmbeddingState> = {}): CallNoteEmbeddingState {
+    return {
+        id: "call-77",
+        companyId: 42n,
+        status: "completed",
+        documentNoteId: NOTE_ID,
+        noteOwnerUserId: "owner-77",
+        noteVisibility: "company",
+        knowledgeIncluded: true,
+        currentNoteRevision: 2,
+        ...overrides,
+    };
+}
+
+function snapshot(
+    overrides: Partial<NoteEmbeddingSnapshot["note"]> = {},
+    call: CallNoteEmbeddingState | null = callState()
+): NoteEmbeddingSnapshot {
+    return {
+        note: {
+            id: NOTE_ID,
+            userId: "owner-77",
+            companyId: "42",
+            documentId: null,
+            versionId: null,
+            title: "Canonical Call Note",
+            content: null,
+            contentMarkdown: "Current accepted note",
+            anchor: null,
+            createdAt: new Date("2026-08-21T00:00:00.000Z"),
+            updatedAt: new Date("2026-08-21T00:02:00.000Z"),
+            ...overrides,
+        },
+        call,
+    };
+}
+
+class InMemoryEmbeddingStore implements NoteEmbeddingStore {
+    current: NoteEmbeddingSnapshot | null;
+    projections: NoteEmbeddingProjection[] = [
+        {
+            content: "previous",
+            tokenCount: 2,
+            embedding: [0, 0, 0],
+            embeddingShort: [0, 0],
+            modelVersion: "old",
+        },
+    ];
+    removeCount = 0;
+    beforeGuardedRemove?: () => void;
+    private replacementQueue: Promise<void> = Promise.resolve();
+
+    constructor(current: NoteEmbeddingSnapshot | null) {
+        this.current = structuredClone(current);
+    }
+
+    async loadSnapshot(): Promise<NoteEmbeddingSnapshot | null> {
+        return structuredClone(this.current);
+    }
+
+    async removeProjection(): Promise<void> {
+        this.removeCount += 1;
+        this.projections = [];
+    }
+
+    async removeIfCurrent(expected: NoteEmbeddingSnapshot): Promise<NoteEmbeddingCleanupResult> {
+        this.beforeGuardedRemove?.();
+        const freshness = evaluateEmbeddingFreshness(expected, this.current);
+        if (freshness === "stale") return "stale";
+        this.removeCount += 1;
+        this.projections = [];
+        return freshness === "missing" ? "missing" : "removed";
+    }
+
+    async replaceIfCurrent(
+        expected: NoteEmbeddingSnapshot,
+        projection: NoteEmbeddingProjection
+    ): Promise<NoteEmbeddingWriteResult> {
+        let result: NoteEmbeddingWriteResult = "missing";
+        const previous = this.replacementQueue;
+        let release: () => void = () => undefined;
+        this.replacementQueue = new Promise<void>(resolve => {
+            release = resolve;
+        });
+        await previous;
+        try {
+            result = evaluateEmbeddingFreshness(expected, this.current);
+            if (result === "written") {
+                this.projections = [projection];
+            } else if (
+                result !== "stale" ||
+                expected.call !== null ||
+                this.current?.call !== null
+            ) {
+                this.projections = [];
+            }
+            return result;
+        } finally {
+            release();
+        }
+    }
+}
+
+function runtime(onEmbed?: () => void): NoteEmbeddingRuntime {
+    return {
+        index: {
+            indexKey: "test-note-index",
+            model: "test-note-model",
+            dimension: 3,
+            shortDimension: 2,
+            version: "test",
+        },
+        embeddings: {
+            embedQuery: async () => [1, 2, 3],
+            embedDocuments: async () => {
+                onEmbed?.();
+                return [[1, 2, 3]];
+            },
+        },
+    };
+}
+
+describe("Call Note embedding final revalidation", () => {
+    it("does not restore a projection after knowledge inclusion is turned off", async () => {
+        const store = new InMemoryEmbeddingStore(snapshot());
+
+        const result = await embedNoteWithDependencies(NOTE_ID, {
+            store,
+            runtime: runtime(() => {
+                if (store.current?.call) store.current.call.knowledgeIncluded = false;
+            }),
+        });
+
+        expect(result).toBe("ineligible");
+        expect(store.projections).toEqual([]);
+    });
+
+    it("does not restore a projection after visibility becomes private", async () => {
+        const store = new InMemoryEmbeddingStore(snapshot());
+
+        const result = await embedNoteWithDependencies(NOTE_ID, {
+            store,
+            runtime: runtime(() => {
+                if (store.current?.call) store.current.call.noteVisibility = "private";
+            }),
+        });
+
+        expect(result).toBe("ineligible");
+        expect(store.projections).toEqual([]);
+    });
+
+    it("prevents an old Call Note revision from overwriting the current revision", async () => {
+        const store = new InMemoryEmbeddingStore(snapshot());
+
+        const result = await embedNoteWithDependencies(NOTE_ID, {
+            store,
+            runtime: runtime(() => {
+                if (store.current?.call) store.current.call.currentNoteRevision = 3;
+            }),
+        });
+
+        expect(result).toBe("stale");
+        expect(store.projections).toEqual([]);
+    });
+
+    it("suppresses a vector when canonical content changes during embedding", async () => {
+        const store = new InMemoryEmbeddingStore(snapshot());
+
+        const result = await embedNoteWithDependencies(NOTE_ID, {
+            store,
+            runtime: runtime(() => {
+                if (store.current) {
+                    store.current.note.contentMarkdown = "Newer canonical content";
+                    store.current.note.updatedAt = new Date("2026-08-21T00:03:00.000Z");
+                }
+            }),
+        });
+
+        expect(result).toBe("stale");
+        expect(store.projections).toEqual([]);
+    });
+
+    it("preserves ordinary non-Call note embedding behavior", async () => {
+        const store = new InMemoryEmbeddingStore(snapshot({}, null));
+
+        const result = await embedNoteWithDependencies(NOTE_ID, { store, runtime: runtime() });
+
+        expect(result).toBe("written");
+        expect(store.projections).toHaveLength(1);
+        expect(store.projections[0]).toMatchObject({
+            content: "Canonical Call Note\n\nCurrent accepted note",
+            embedding: [1, 2, 3],
+            embeddingShort: [1, 2],
+            modelVersion: "test-note-model",
+        });
+    });
+
+    it("serializes concurrent replacements into one effective projection", async () => {
+        const store = new InMemoryEmbeddingStore(snapshot());
+
+        const results = await Promise.all([
+            embedNoteWithDependencies(NOTE_ID, { store, runtime: runtime() }),
+            embedNoteWithDependencies(NOTE_ID, { store, runtime: runtime() }),
+        ]);
+
+        expect(results).toEqual(["written", "written"]);
+        expect(store.projections).toHaveLength(1);
+    });
+
+    it("removes an already projected Call Note when the delayed job starts ineligible", async () => {
+        const store = new InMemoryEmbeddingStore(
+            snapshot({}, callState({ knowledgeIncluded: false }))
+        );
+
+        const result = await embedNoteWithDependencies(NOTE_ID, { store, runtime: runtime() });
+
+        expect(result).toBe("ineligible");
+        expect(store.removeCount).toBe(1);
+        expect(store.projections).toEqual([]);
+    });
+
+    it("does not let stale ineligible cleanup erase a newly eligible projection", async () => {
+        const store = new InMemoryEmbeddingStore(
+            snapshot({}, callState({ knowledgeIncluded: false }))
+        );
+        store.beforeGuardedRemove = () => {
+            if (store.current?.call) store.current.call.knowledgeIncluded = true;
+            store.projections = [
+                {
+                    content: "new eligible projection",
+                    tokenCount: 5,
+                    embedding: [3, 2, 1],
+                    embeddingShort: [3, 2],
+                    modelVersion: "new",
+                },
+            ];
+        };
+
+        const result = await embedNoteWithDependencies(NOTE_ID, { store, runtime: runtime() });
+
+        expect(result).toBe("stale");
+        expect(store.projections).toHaveLength(1);
+        expect(store.projections[0]?.content).toBe("new eligible projection");
+    });
+
+    it("does not let stale empty-content cleanup erase a newer ordinary-note projection", async () => {
+        const store = new InMemoryEmbeddingStore(
+            snapshot({ title: null, contentMarkdown: "" }, null)
+        );
+        store.beforeGuardedRemove = () => {
+            if (store.current) {
+                store.current.note.contentMarkdown = "new ordinary note content";
+                store.current.note.updatedAt = new Date("2026-08-21T00:04:00.000Z");
+            }
+            store.projections = [
+                {
+                    content: "new ordinary note content",
+                    tokenCount: 5,
+                    embedding: [3, 2, 1],
+                    embeddingShort: [3, 2],
+                    modelVersion: "new",
+                },
+            ];
+        };
+
+        const result = await embedNoteWithDependencies(NOTE_ID, { store, runtime: runtime() });
+
+        expect(result).toBe("stale");
+        expect(store.projections[0]?.content).toBe("new ordinary note content");
+    });
+});

--- a/apps/web/__tests__/callNotes/notes-retriever-call-notes.test.ts
+++ b/apps/web/__tests__/callNotes/notes-retriever-call-notes.test.ts
@@ -1,0 +1,158 @@
+const mockExecute = jest.fn();
+jest.mock("~/server/db/index", () => ({
+    db: { execute: (...args: unknown[]) => mockExecute(...args) },
+    toRows: (value: unknown) => value,
+}));
+
+import { PgDialect } from "drizzle-orm/pg-core";
+import type { SQL } from "drizzle-orm";
+
+import { createCompanyNotesRetriever } from "~/lib/tools/rag/retrievers/notes-retriever";
+
+const embeddings = {
+    embedQuery: jest.fn().mockResolvedValue(Array.from({ length: 1536 }, () => 0.01)),
+};
+
+type RetrieverRow = {
+    note_id: number;
+    note_user_id: string;
+    note_company_id: string | null;
+    document_id: string | null;
+    company_id: string | null;
+    version_id: string | null;
+    content: string;
+    title: string | null;
+    content_markdown: string | null;
+    anchor: unknown;
+    anchor_status: string | null;
+    distance: number;
+    call_id: string | null;
+    call_company_id: string | null;
+    call_status: string | null;
+    call_document_note_id: number | null;
+    call_owner_user_id: string | null;
+    call_visibility: string | null;
+    call_knowledge_included: boolean | null;
+    call_revision: number | null;
+};
+
+function ordinaryNote(overrides: Partial<RetrieverRow> = {}): RetrieverRow {
+    return {
+        note_id: 10,
+        note_user_id: "ordinary-owner",
+        note_company_id: "42",
+        document_id: "123",
+        company_id: "42",
+        version_id: "7",
+        content: "Ordinary note content",
+        title: "Ordinary note",
+        content_markdown: "Ordinary note content",
+        anchor: null,
+        anchor_status: "resolved",
+        distance: 0.1,
+        call_id: null,
+        call_company_id: null,
+        call_status: null,
+        call_document_note_id: null,
+        call_owner_user_id: null,
+        call_visibility: null,
+        call_knowledge_included: null,
+        call_revision: null,
+        ...overrides,
+    };
+}
+
+function callNote(overrides: Partial<RetrieverRow> = {}): RetrieverRow {
+    return ordinaryNote({
+        note_id: 20,
+        note_user_id: "call-owner",
+        note_company_id: "42",
+        document_id: null,
+        version_id: null,
+        content: "Accepted canonical Call Note",
+        title: "Customer call",
+        call_id: "call-20",
+        call_company_id: "42",
+        call_status: "completed",
+        call_document_note_id: 20,
+        call_owner_user_id: "call-owner",
+        call_visibility: "company",
+        call_knowledge_included: true,
+        call_revision: 4,
+        ...overrides,
+    });
+}
+
+async function retrieve(rows: RetrieverRow[]) {
+    mockExecute.mockResolvedValueOnce(rows);
+    return createCompanyNotesRetriever(42, embeddings, 10)._getRelevantDocuments("customer");
+}
+
+describe("company NotesRetriever Call Note eligibility", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("preserves ordinary company Note behavior and metadata", async () => {
+        const [result] = await retrieve([ordinaryNote()]);
+
+        expect(result?.metadata).toMatchObject({
+            source: "note",
+            noteId: 10,
+            documentId: "123",
+            companyId: "42",
+        });
+        expect(result?.metadata).not.toHaveProperty("callId");
+    });
+
+    it("returns an eligible current company Call Note with canonical identity", async () => {
+        const [result] = await retrieve([callNote()]);
+
+        expect(result?.pageContent).toContain("Accepted canonical Call Note");
+        expect(result?.metadata).toMatchObject({
+            source: "call_note",
+            noteId: 20,
+            callId: "call-20",
+            revision: 4,
+            companyId: "42",
+        });
+    });
+
+    it.each([
+        ["knowledge disabled", { call_knowledge_included: false }],
+        ["private", { call_visibility: "private" }],
+        ["active", { call_status: "active" }],
+        ["finalizing", { call_status: "finalizing" }],
+        ["failed", { call_status: "failed" }],
+        ["zero revision", { call_revision: 0 }],
+    ] as const)("excludes a %s Call Note projection", async (_label, overrides) => {
+        const results = await retrieve([callNote(overrides)]);
+
+        expect(results).toEqual([]);
+    });
+
+    it.each([
+        ["wrong canonical note", { call_document_note_id: 999 }],
+        ["wrong owner", { call_owner_user_id: "different-owner" }],
+        ["wrong Call company", { call_company_id: "99" }],
+        ["wrong note company", { note_company_id: "99" }],
+        ["wrong projection company", { company_id: "99" }],
+    ] as const)("fails closed for %s identity", async (_label, overrides) => {
+        const results = await retrieve([callNote(overrides)]);
+
+        expect(results).toEqual([]);
+    });
+
+    it("keeps the company filter and live Call eligibility predicates in SQL", async () => {
+        await retrieve([]);
+
+        const query = mockExecute.mock.calls[0]?.[0] as SQL;
+        const compiled = new PgDialect().sqlToQuery(query).sql;
+        expect(compiled).toContain("LEFT JOIN");
+        expect(compiled).toContain("call_notes_calls");
+        expect(compiled).toContain("knowledge_included");
+        expect(compiled).toContain("note_visibility");
+        expect(compiled).toContain("current_note_revision");
+        expect(compiled).toContain("ne.company_id");
+    });
+});

--- a/apps/web/__tests__/callNotes/rag-call-note-metadata.test.ts
+++ b/apps/web/__tests__/callNotes/rag-call-note-metadata.test.ts
@@ -1,0 +1,115 @@
+const mockCompanyEnsembleSearch = jest.fn();
+const mockEmbeddings = { embedQuery: jest.fn() };
+
+jest.mock("~/lib/tools/rag", () => ({
+    companyEnsembleSearch: (...args: unknown[]) => mockCompanyEnsembleSearch(...args),
+    createOpenAIEmbeddings: jest.fn(() => mockEmbeddings),
+}));
+
+import { createAppRagPort } from "~/server/rag/port";
+
+describe("RagPort note metadata propagation", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it("keeps ordinary document metadata unchanged", async () => {
+        mockCompanyEnsembleSearch.mockResolvedValueOnce([
+            {
+                pageContent: "Document evidence",
+                pageNumber: 2,
+                title: "Plan",
+                documentId: 11,
+                source: "document",
+                retrievalMethod: "ensemble_rrf",
+                metadata: {
+                    chunkId: 7,
+                    page: 2,
+                    documentId: 11,
+                    documentTitle: "Plan",
+                    distance: 0.2,
+                    confidence: 0.8,
+                    source: "document",
+                    searchScope: "company",
+                    embeddingIndexKey: "document-index",
+                    rerankScore: 0.9,
+                    timestamp: "2026-08-21T00:00:00.000Z",
+                },
+            },
+        ]);
+
+        const [result] = await createAppRagPort().companyEnsembleSearch("plan", {
+            companyId: 42,
+        });
+
+        expect(result).toEqual({
+            pageContent: "Document evidence",
+            pageNumber: 2,
+            title: "Plan",
+            documentId: 11,
+            source: "document",
+            retrievalMethod: "ensemble_rrf",
+            metadata: {
+                chunkId: 7,
+                page: 2,
+                documentId: 11,
+                documentTitle: "Plan",
+                distance: 0.2,
+                confidence: 0.8,
+                source: "document",
+                embeddingIndexKey: "document-index",
+                rerankScore: 0.9,
+                timestamp: "2026-08-21T00:00:00.000Z",
+            },
+        });
+    });
+
+    it("preserves ordinary Note source and noteId from metadata", async () => {
+        mockCompanyEnsembleSearch.mockResolvedValueOnce([
+            {
+                pageContent: "Ordinary Note",
+                metadata: {
+                    source: "note",
+                    noteId: 10,
+                    searchScope: "company",
+                },
+            },
+        ]);
+
+        const [result] = await createAppRagPort().companyEnsembleSearch("note", {
+            companyId: 42,
+        });
+
+        expect(result?.source).toBe("note");
+        expect(result?.metadata).toMatchObject({ source: "note", noteId: 10 });
+        expect(result?.metadata).not.toHaveProperty("callId");
+    });
+
+    it("preserves Call Note source, noteId, callId, and revision", async () => {
+        mockCompanyEnsembleSearch.mockResolvedValueOnce([
+            {
+                pageContent: "Accepted Call Note",
+                metadata: {
+                    source: "call_note",
+                    noteId: 20,
+                    callId: "call-20",
+                    revision: 4,
+                    searchScope: "company",
+                },
+            },
+        ]);
+
+        const [result] = await createAppRagPort().companyEnsembleSearch("customer", {
+            companyId: 42,
+        });
+
+        expect(result?.source).toBe("call_note");
+        expect(result?.metadata).toMatchObject({
+            source: "call_note",
+            noteId: 20,
+            callId: "call-20",
+            revision: 4,
+        });
+        expect(result?.metadata).not.toHaveProperty("deepLink");
+    });
+});

--- a/apps/web/__tests__/components/CallNotesPrototype.test.tsx
+++ b/apps/web/__tests__/components/CallNotesPrototype.test.tsx
@@ -1,0 +1,152 @@
+/** @jest-environment jsdom */
+
+import React from "react";
+import { act, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent, { type UserEvent } from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+
+import { CallNotesPrototype } from "~/app/prototypes/call-notes/CallNotesPrototype";
+
+function setRoute(scenario = "detected") {
+    window.history.replaceState(null, "", `/prototypes/call-notes?scenario=${scenario}`);
+}
+
+async function startDetectedCall(user: UserEvent) {
+    const notification = screen.getByRole("region", { name: /detected zoom call/i });
+    await user.click(within(notification).getByRole("button", { name: /start capture/i }));
+    expect(screen.getByRole("status", { name: /capture status/i })).toHaveTextContent(
+        /connecting/i
+    );
+    await waitFor(() =>
+        expect(screen.getByRole("status", { name: /capture status/i })).toHaveTextContent(/live/i)
+    );
+}
+
+describe("Call Notes collapsed workspace", () => {
+    it("keeps the Calls rail visible and switches between note views", async () => {
+        const user = userEvent.setup();
+        setRoute();
+        render(<CallNotesPrototype />);
+
+        expect(screen.getByRole("complementary", { name: /calls library/i })).toBeInTheDocument();
+        expect(screen.getByRole("main")).toBeInTheDocument();
+        expect(
+            screen.queryByRole("navigation", { name: /prototype variants/i })
+        ).not.toBeInTheDocument();
+        expect(screen.getByRole("button", { name: /^transcript/i })).toHaveAttribute(
+            "aria-expanded",
+            "false"
+        );
+        expect(screen.getByRole("tab", { name: /my notes/i })).toHaveAttribute(
+            "aria-selected",
+            "true"
+        );
+        await user.click(screen.getByRole("tab", { name: /ai enhanced/i }));
+        expect(screen.getByRole("tabpanel", { name: /ai enhanced note/i })).toHaveTextContent(
+            /starts after capture/i
+        );
+        await user.click(screen.getByRole("tab", { name: /my notes/i }));
+        expect(screen.getByRole("textbox", { name: /call note/i })).toBeInTheDocument();
+    });
+
+    it("filters transcript segments and clears the search", async () => {
+        const user = userEvent.setup();
+        setRoute("review");
+        render(<CallNotesPrototype />);
+
+        await user.click(screen.getByRole("button", { name: /^transcript/i }));
+        await user.type(screen.getByRole("textbox", { name: /search transcript/i }), "operations");
+        const transcript = screen.getByLabelText("Transcript segments");
+        expect(within(transcript).getByText(/pricing still feels hard/i)).toBeInTheDocument();
+        expect(within(transcript).queryByText(/thanks for making time/i)).not.toBeInTheDocument();
+
+        await user.click(screen.getByRole("button", { name: /clear transcript search/i }));
+        expect(within(transcript).getByText(/thanks for making time/i)).toBeInTheDocument();
+    });
+
+    it("starts a detected Call, preserves the note, and records a paused interval", async () => {
+        const user = userEvent.setup();
+        setRoute();
+        render(<CallNotesPrototype />);
+        await startDetectedCall(user);
+
+        const note = screen.getByRole("textbox", { name: /call note/i });
+        await user.click(note);
+        await user.keyboard("Pricing concerns and launch sequencing.");
+        expect(note).toHaveTextContent(/pricing concerns/i);
+
+        await user.click(screen.getByRole("button", { name: /^transcript/i }));
+        await user.click(screen.getByRole("button", { name: /pause/i }));
+        const captureStatus = screen.getByRole("status", { name: /capture status/i });
+        expect(captureStatus).toHaveTextContent(/paused/i);
+        expect(captureStatus).toHaveTextContent(/partial/i);
+        expect(screen.getByText("Capture paused")).toBeInTheDocument();
+
+        await user.click(screen.getByRole("button", { name: /resume/i }));
+        expect(screen.getByRole("status", { name: /capture status/i })).toHaveTextContent(/live/i);
+        expect(note).toHaveTextContent(/pricing concerns/i);
+    });
+
+    it("lets the owner change visibility and add a commented shared Bookmark", async () => {
+        const user = userEvent.setup();
+        setRoute();
+        render(<CallNotesPrototype />);
+        await startDetectedCall(user);
+
+        const visibility = screen.getByRole("switch", { name: /shared with company/i });
+        expect(visibility).toBeChecked();
+        await user.click(visibility);
+        expect(visibility).not.toBeChecked();
+        expect(screen.getByText(/private to you/i)).toBeInTheDocument();
+
+        await user.click(screen.getByRole("button", { name: /^transcript/i }));
+        await user.click(screen.getAllByRole("button", { name: /bookmark segment/i })[0]!);
+        const bookmarkDialog = screen.getByRole("dialog", { name: /add bookmark/i });
+        await user.type(
+            within(bookmarkDialog).getByRole("textbox", { name: /bookmark comment/i }),
+            "Keep the exact customer wording."
+        );
+        await user.click(within(bookmarkDialog).getByRole("button", { name: /save bookmark/i }));
+
+        expect(screen.getByText("Keep the exact customer wording.")).toBeInTheDocument();
+    });
+
+    it("keeps a failed Call Note and retries through the same capture flow", async () => {
+        const user = userEvent.setup();
+        setRoute("failure");
+        render(<CallNotesPrototype />);
+
+        expect(screen.getByRole("alert")).toHaveTextContent(/could not start rtms/i);
+        expect(screen.getByRole("textbox", { name: /call note/i })).toBeInTheDocument();
+        await user.click(screen.getByRole("button", { name: /retry capture/i }));
+        expect(screen.getByRole("status", { name: /capture status/i })).toHaveTextContent(
+            /connecting/i
+        );
+        await waitFor(() =>
+            expect(screen.getByRole("status", { name: /capture status/i })).toHaveTextContent(
+                /live/i
+            )
+        );
+    });
+
+    it("reviews an owner-only enrichment proposal beside the canonical Call Note", async () => {
+        const user = userEvent.setup();
+        setRoute("review");
+        render(<CallNotesPrototype />);
+
+        expect(screen.getByLabelText(/enrichment ready/i)).toBeInTheDocument();
+        await user.click(screen.getByRole("tab", { name: /ai enhanced/i }));
+        expect(screen.getByText(/ready to review/i)).toBeInTheDocument();
+        await user.click(screen.getByRole("button", { name: /review enrichment/i }));
+        expect(screen.getByRole("region", { name: /current call note/i })).toBeInTheDocument();
+        expect(screen.getByRole("region", { name: /enriched note proposal/i })).toBeInTheDocument();
+
+        await user.click(screen.getByRole("button", { name: /open transcript evidence/i }));
+        expect(screen.getByRole("dialog", { name: /transcript evidence/i })).toBeInTheDocument();
+        await user.keyboard("{Escape}");
+        await act(async () => {
+            await user.click(screen.getByRole("button", { name: /accept proposal/i }));
+        });
+        expect(screen.getByText(/revision accepted/i)).toBeInTheDocument();
+    });
+});

--- a/apps/web/__tests__/lib/llm/chat-endpoint.test.ts
+++ b/apps/web/__tests__/lib/llm/chat-endpoint.test.ts
@@ -9,7 +9,12 @@
 import { createServer, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
+import {
+    CALL_NOTES_ENRICHMENT_PROPOSAL,
+    EnrichedNoteProposalSchema,
+} from "@launchstack/features/call-notes";
 import { z } from "zod";
+import { FounderWeeklyReviewV2RecommendationSchema } from "@launchstack/features/founder-weekly-review";
 import {
     createChatModelsConfig,
     describeChatEndpointError,
@@ -367,6 +372,219 @@ describe("structured output", () => {
         expect(captured[0]!.body.response_format).toMatchObject({
             type: "json_schema",
         });
+    });
+
+    it("uses the validated JSON fallback for an optional field", async () => {
+        respondWith = () => ({
+            status: 200,
+            payload: completion(JSON.stringify({ required: "yes" })),
+        });
+
+        const OptionalSchema = z.object({
+            required: z.string(),
+            optional: z.string().optional(),
+        });
+        const resolved = resolveChatModel({
+            config: deployment(`      input: [text]
+      reasoning: { mode: none }
+      nativeStructuredOutput: [json-schema]
+      parameters:
+        temperature: supported
+        systemMessages: supported
+        streaming: supported
+        maxOutputTokens: supported`),
+        });
+        await expect(
+            invokeStructured(resolved, OptionalSchema, [new HumanMessage("q")], {
+                name: "optional_example",
+            })
+        ).resolves.toEqual({ required: "yes" });
+
+        expect(captured).toHaveLength(1);
+        expect(captured[0]!.body).not.toHaveProperty("response_format");
+        expect(JSON.stringify(captured[0]!.body.messages)).toContain("optional");
+    });
+
+    it("accepts a present optional value and rejects an invalid one through the original schema", async () => {
+        respondWith = () => ({
+            status: 200,
+            payload: completion(JSON.stringify({ required: "yes", optional: "present" })),
+        });
+        const OptionalSchema = z.object({
+            required: z.string(),
+            optional: z.string().optional(),
+        });
+        const resolved = resolveChatModel({
+            config: deployment(`      input: [text]
+      reasoning: { mode: none }
+      nativeStructuredOutput: [json-schema]
+      parameters:
+        temperature: supported
+        systemMessages: supported
+        streaming: supported
+        maxOutputTokens: supported`),
+        });
+        await expect(
+            invokeStructured(resolved, OptionalSchema, [new HumanMessage("q")], {
+                name: "optional_present",
+            })
+        ).resolves.toEqual({ required: "yes", optional: "present" });
+
+        respondWith = () => ({
+            status: 200,
+            payload: completion(JSON.stringify({ required: "yes", optional: 42 })),
+        });
+        await expect(
+            invokeStructured(resolved, OptionalSchema, [new HumanMessage("q")], {
+                name: "optional_invalid",
+            })
+        ).rejects.toBeInstanceOf(StructuredOutputError);
+        expect(captured).toHaveLength(3);
+    });
+
+    it("uses the fallback for a defaulted object field and preserves Zod defaults", async () => {
+        respondWith = () => ({
+            status: 200,
+            payload: completion(JSON.stringify({ required: "yes" })),
+        });
+        const DefaultedSchema = z.object({
+            required: z.string(),
+            defaulted: z.string().default("from-zod"),
+        });
+        const resolved = resolveChatModel({
+            config: deployment(`      input: [text]
+      reasoning: { mode: none }
+      nativeStructuredOutput: [json-schema]
+      parameters:
+        temperature: supported
+        systemMessages: supported
+        streaming: supported
+        maxOutputTokens: supported`),
+        });
+
+        await expect(
+            invokeStructured(resolved, DefaultedSchema, [new HumanMessage("q")], {
+                name: "defaulted_example",
+            })
+        ).resolves.toEqual({ required: "yes", defaulted: "from-zod" });
+        expect(captured).toHaveLength(1);
+        expect(captured[0]!.body).not.toHaveProperty("response_format");
+    });
+
+    it("detects optional and defaulted fields nested inside an object", async () => {
+        respondWith = () => ({
+            status: 200,
+            payload: completion(JSON.stringify({ nested: { required: "yes" } })),
+        });
+        const NestedSchema = z.object({
+            nested: z.object({
+                required: z.string(),
+                optional: z.string().optional(),
+                defaulted: z.string().default("nested-default"),
+            }),
+        });
+        const resolved = resolveChatModel({
+            config: deployment(`      input: [text]
+      reasoning: { mode: none }
+      nativeStructuredOutput: [json-schema]
+      parameters:
+        temperature: supported
+        systemMessages: supported
+        streaming: supported
+        maxOutputTokens: supported`),
+        });
+
+        await expect(
+            invokeStructured(resolved, NestedSchema, [new HumanMessage("q")], {
+                name: "nested_optional_example",
+            })
+        ).resolves.toEqual({
+            nested: { required: "yes", defaulted: "nested-default" },
+        });
+        expect(captured).toHaveLength(1);
+        expect(captured[0]!.body).not.toHaveProperty("response_format");
+    });
+
+    it("uses the fallback for the current Founder Weekly Review recommendation schema", async () => {
+        respondWith = () => ({
+            status: 200,
+            payload: completion(
+                JSON.stringify({
+                    kind: "recommendation",
+                    label: "Recommendation",
+                    text: "Review the evidence.",
+                    sourceIds: ["document_change:example"],
+                    confidence: 0.5,
+                })
+            ),
+        });
+        const resolved = resolveChatModel({
+            config: deployment(`      input: [text]
+      reasoning: { mode: none }
+      nativeStructuredOutput: [json-schema]
+      parameters:
+        temperature: supported
+        systemMessages: supported
+        streaming: supported
+        maxOutputTokens: supported`),
+        });
+        await expect(
+            invokeStructured(
+                resolved,
+                FounderWeeklyReviewV2RecommendationSchema,
+                [new HumanMessage("q")],
+                { name: "founder_weekly_review_v2" }
+            )
+        ).resolves.toMatchObject({ kind: "recommendation", text: "Review the evidence." });
+        expect(captured).toHaveLength(1);
+        expect(captured[0]!.body).not.toHaveProperty("response_format");
+    });
+
+    it("uses the fallback for the frozen Call Notes enrichment proposal schema", async () => {
+        respondWith = () => ({
+            status: 200,
+            payload: completion(JSON.stringify(CALL_NOTES_ENRICHMENT_PROPOSAL)),
+        });
+        const resolved = resolveChatModel({
+            config: deployment(`      input: [text]
+      reasoning: { mode: none }
+      nativeStructuredOutput: [json-schema]
+      parameters:
+        temperature: supported
+        systemMessages: supported
+        streaming: supported
+        maxOutputTokens: supported`),
+        });
+
+        await expect(
+            invokeStructured(resolved, EnrichedNoteProposalSchema, [new HumanMessage("q")], {
+                name: "call_notes_enrichment_v1",
+            })
+        ).resolves.toEqual(CALL_NOTES_ENRICHMENT_PROPOSAL);
+        expect(captured).toHaveLength(1);
+        expect(captured[0]!.body).not.toHaveProperty("response_format");
+    });
+
+    it("does not reroute a normal native provider failure", async () => {
+        respondWith = () => ({
+            status: 401,
+            payload: { error: { message: "provider failed" } },
+        });
+        const resolved = resolveChatModel({
+            config: deployment(`      input: [text]
+      reasoning: { mode: none }
+      nativeStructuredOutput: [json-schema]
+      parameters:
+        temperature: supported
+        systemMessages: supported
+        streaming: supported
+        maxOutputTokens: supported`),
+        });
+        await expect(
+            invokeStructured(resolved, Schema, [new HumanMessage("q")], { name: "native_error" })
+        ).rejects.toThrow();
+        expect(captured).toHaveLength(1);
+        expect(captured[0]!.body.response_format).toMatchObject({ type: "json_schema" });
     });
 
     it("falls back to a strict JSON prompt carrying the schema", async () => {

--- a/apps/web/drizzle/20260820010959_simple_khan.sql
+++ b/apps/web/drizzle/20260820010959_simple_khan.sql
@@ -1,0 +1,229 @@
+CREATE TABLE "pdr_ai_v2_call_notes_bookmarks" (
+	"id" varchar(64) PRIMARY KEY NOT NULL,
+	"call_id" varchar(64) NOT NULL,
+	"segment_id" varchar(64) NOT NULL,
+	"company_id" bigint NOT NULL,
+	"created_by_user_id" varchar(256) NOT NULL,
+	"comment" text,
+	"created_at" timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "pdr_ai_v2_call_notes_calls" (
+	"id" varchar(64) PRIMARY KEY NOT NULL,
+	"company_id" bigint NOT NULL,
+	"provider" varchar(32) NOT NULL,
+	"provider_occurrence_key" varchar(256) NOT NULL,
+	"title" varchar(512) NOT NULL,
+	"status" varchar(32) DEFAULT 'detected' NOT NULL,
+	"document_note_id" bigint,
+	"note_owner_user_id" varchar(256),
+	"note_visibility" varchar(16) DEFAULT 'company' NOT NULL,
+	"knowledge_included" boolean DEFAULT false NOT NULL,
+	"current_note_revision" integer DEFAULT 0 NOT NULL,
+	"failure_code" varchar(128),
+	"failure_message" varchar(1024),
+	"started_at" timestamp with time zone,
+	"finalized_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	"updated_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE "pdr_ai_v2_call_notes_capture_attempts" (
+	"id" varchar(64) PRIMARY KEY NOT NULL,
+	"capture_id" varchar(64) NOT NULL,
+	"call_id" varchar(64) NOT NULL,
+	"company_id" bigint NOT NULL,
+	"provider_attempt_key" varchar(256) NOT NULL,
+	"provider_stream_key" varchar(256),
+	"lifecycle" varchar(24) DEFAULT 'connecting' NOT NULL,
+	"lease_token" varchar(128),
+	"lease_owner" varchar(256),
+	"lease_expires_at" timestamp with time zone,
+	"started_at" timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	"ended_at" timestamp with time zone,
+	"failure_code" varchar(128),
+	"failure_message" varchar(1024)
+);
+--> statement-breakpoint
+CREATE TABLE "pdr_ai_v2_call_notes_captures" (
+	"id" varchar(64) PRIMARY KEY NOT NULL,
+	"call_id" varchar(64) NOT NULL,
+	"company_id" bigint NOT NULL,
+	"capture_user_connection_id" varchar(64) NOT NULL,
+	"capture_user_provider_key" varchar(256) NOT NULL,
+	"desired_mode" varchar(16) DEFAULT 'running' NOT NULL,
+	"lifecycle" varchar(32) DEFAULT 'connecting' NOT NULL,
+	"outcome" varchar(16),
+	"active_attempt_id" varchar(64),
+	"started_at" timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	"ended_at" timestamp with time zone,
+	"updated_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE "pdr_ai_v2_call_notes_enrichment_runs" (
+	"id" varchar(64) PRIMARY KEY NOT NULL,
+	"call_id" varchar(64) NOT NULL,
+	"company_id" bigint NOT NULL,
+	"requested_by_user_id" varchar(256) NOT NULL,
+	"base_note_revision" integer NOT NULL,
+	"transcript_fingerprint" varchar(64) NOT NULL,
+	"status" varchar(24) DEFAULT 'queued' NOT NULL,
+	"original_output" jsonb,
+	"editable_proposal" jsonb,
+	"model_metadata" jsonb,
+	"error_code" varchar(128),
+	"error_message" varchar(1024),
+	"resolved_by_user_id" varchar(256),
+	"created_at" timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	"generated_at" timestamp with time zone,
+	"resolved_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE "pdr_ai_v2_call_notes_gaps" (
+	"id" varchar(64) PRIMARY KEY NOT NULL,
+	"call_id" varchar(64) NOT NULL,
+	"capture_id" varchar(64) NOT NULL,
+	"attempt_id" varchar(64),
+	"company_id" bigint NOT NULL,
+	"kind" varchar(32) NOT NULL,
+	"started_at" timestamp with time zone NOT NULL,
+	"ended_at" timestamp with time zone,
+	"details" jsonb
+);
+--> statement-breakpoint
+CREATE TABLE "pdr_ai_v2_call_notes_note_revisions" (
+	"id" varchar(64) PRIMARY KEY NOT NULL,
+	"call_id" varchar(64) NOT NULL,
+	"company_id" bigint NOT NULL,
+	"document_note_id" bigint NOT NULL,
+	"revision" integer NOT NULL,
+	"origin" varchar(24) NOT NULL,
+	"enrichment_run_id" varchar(64),
+	"title" text,
+	"content_markdown" text NOT NULL,
+	"content_rich" jsonb NOT NULL,
+	"created_by_user_id" varchar(256) NOT NULL,
+	"created_at" timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "pdr_ai_v2_call_notes_participants" (
+	"id" varchar(64) PRIMARY KEY NOT NULL,
+	"call_id" varchar(64) NOT NULL,
+	"attempt_id" varchar(64) NOT NULL,
+	"company_id" bigint NOT NULL,
+	"provider_participant_key" varchar(256) NOT NULL,
+	"provider_session_key" varchar(256),
+	"display_name" varchar(512) NOT NULL,
+	"observed_at" timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	"left_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE "pdr_ai_v2_call_notes_transcript_segments" (
+	"id" varchar(64) PRIMARY KEY NOT NULL,
+	"call_id" varchar(64) NOT NULL,
+	"attempt_id" varchar(64) NOT NULL,
+	"participant_id" varchar(64),
+	"company_id" bigint NOT NULL,
+	"provider_event_key" varchar(256),
+	"source_packet_hash" varchar(64) NOT NULL,
+	"source_kind" varchar(32) NOT NULL,
+	"speaker_name" varchar(512),
+	"provider_start_ms" bigint,
+	"provider_end_ms" bigint,
+	"received_at" timestamp with time zone NOT NULL,
+	"receive_order" integer NOT NULL,
+	"text" text NOT NULL,
+	"language" varchar(32),
+	"created_at" timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "pdr_ai_v2_call_notes_work_items" (
+	"id" varchar(64) PRIMARY KEY NOT NULL,
+	"company_id" bigint NOT NULL,
+	"call_id" varchar(64),
+	"capture_id" varchar(64),
+	"kind" varchar(32) NOT NULL,
+	"idempotency_key" varchar(256) NOT NULL,
+	"payload" jsonb NOT NULL,
+	"status" varchar(24) DEFAULT 'pending' NOT NULL,
+	"lease_token" varchar(128),
+	"lease_owner" varchar(256),
+	"lease_expires_at" timestamp with time zone,
+	"attempts" integer DEFAULT 0 NOT NULL,
+	"error_code" varchar(128),
+	"error_message" varchar(1024),
+	"available_at" timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	"created_at" timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	"completed_at" timestamp with time zone
+);
+--> statement-breakpoint
+CREATE TABLE "pdr_ai_v2_call_notes_zoom_connections" (
+	"id" varchar(64) PRIMARY KEY NOT NULL,
+	"company_id" bigint NOT NULL,
+	"user_id" varchar(256) NOT NULL,
+	"zoom_account_id" varchar(256) NOT NULL,
+	"zoom_user_id" varchar(256) NOT NULL,
+	"encrypted_access_token" text NOT NULL,
+	"encrypted_refresh_token" text,
+	"token_expires_at" timestamp with time zone,
+	"scopes" text[] DEFAULT '{}' NOT NULL,
+	"status" varchar(24) DEFAULT 'active' NOT NULL,
+	"created_at" timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	"updated_at" timestamp with time zone
+);
+--> statement-breakpoint
+ALTER TABLE "pdr_ai_v2_call_notes_bookmarks" ADD CONSTRAINT "pdr_ai_v2_call_notes_bookmarks_call_id_pdr_ai_v2_call_notes_calls_id_fk" FOREIGN KEY ("call_id") REFERENCES "public"."pdr_ai_v2_call_notes_calls"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pdr_ai_v2_call_notes_bookmarks" ADD CONSTRAINT "pdr_ai_v2_call_notes_bookmarks_segment_id_pdr_ai_v2_call_notes_transcript_segments_id_fk" FOREIGN KEY ("segment_id") REFERENCES "public"."pdr_ai_v2_call_notes_transcript_segments"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pdr_ai_v2_call_notes_bookmarks" ADD CONSTRAINT "pdr_ai_v2_call_notes_bookmarks_company_id_pdr_ai_v2_company_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."pdr_ai_v2_company"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pdr_ai_v2_call_notes_calls" ADD CONSTRAINT "pdr_ai_v2_call_notes_calls_company_id_pdr_ai_v2_company_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."pdr_ai_v2_company"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pdr_ai_v2_call_notes_capture_attempts" ADD CONSTRAINT "pdr_ai_v2_call_notes_capture_attempts_capture_id_pdr_ai_v2_call_notes_captures_id_fk" FOREIGN KEY ("capture_id") REFERENCES "public"."pdr_ai_v2_call_notes_captures"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pdr_ai_v2_call_notes_capture_attempts" ADD CONSTRAINT "pdr_ai_v2_call_notes_capture_attempts_call_id_pdr_ai_v2_call_notes_calls_id_fk" FOREIGN KEY ("call_id") REFERENCES "public"."pdr_ai_v2_call_notes_calls"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pdr_ai_v2_call_notes_capture_attempts" ADD CONSTRAINT "pdr_ai_v2_call_notes_capture_attempts_company_id_pdr_ai_v2_company_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."pdr_ai_v2_company"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pdr_ai_v2_call_notes_captures" ADD CONSTRAINT "pdr_ai_v2_call_notes_captures_call_id_pdr_ai_v2_call_notes_calls_id_fk" FOREIGN KEY ("call_id") REFERENCES "public"."pdr_ai_v2_call_notes_calls"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pdr_ai_v2_call_notes_captures" ADD CONSTRAINT "pdr_ai_v2_call_notes_captures_company_id_pdr_ai_v2_company_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."pdr_ai_v2_company"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pdr_ai_v2_call_notes_captures" ADD CONSTRAINT "pdr_ai_v2_call_notes_captures_capture_user_connection_id_pdr_ai_v2_call_notes_zoom_connections_id_fk" FOREIGN KEY ("capture_user_connection_id") REFERENCES "public"."pdr_ai_v2_call_notes_zoom_connections"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pdr_ai_v2_call_notes_enrichment_runs" ADD CONSTRAINT "pdr_ai_v2_call_notes_enrichment_runs_call_id_pdr_ai_v2_call_notes_calls_id_fk" FOREIGN KEY ("call_id") REFERENCES "public"."pdr_ai_v2_call_notes_calls"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pdr_ai_v2_call_notes_enrichment_runs" ADD CONSTRAINT "pdr_ai_v2_call_notes_enrichment_runs_company_id_pdr_ai_v2_company_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."pdr_ai_v2_company"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pdr_ai_v2_call_notes_gaps" ADD CONSTRAINT "pdr_ai_v2_call_notes_gaps_call_id_pdr_ai_v2_call_notes_calls_id_fk" FOREIGN KEY ("call_id") REFERENCES "public"."pdr_ai_v2_call_notes_calls"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pdr_ai_v2_call_notes_gaps" ADD CONSTRAINT "pdr_ai_v2_call_notes_gaps_capture_id_pdr_ai_v2_call_notes_captures_id_fk" FOREIGN KEY ("capture_id") REFERENCES "public"."pdr_ai_v2_call_notes_captures"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pdr_ai_v2_call_notes_gaps" ADD CONSTRAINT "pdr_ai_v2_call_notes_gaps_attempt_id_pdr_ai_v2_call_notes_capture_attempts_id_fk" FOREIGN KEY ("attempt_id") REFERENCES "public"."pdr_ai_v2_call_notes_capture_attempts"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pdr_ai_v2_call_notes_gaps" ADD CONSTRAINT "pdr_ai_v2_call_notes_gaps_company_id_pdr_ai_v2_company_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."pdr_ai_v2_company"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pdr_ai_v2_call_notes_note_revisions" ADD CONSTRAINT "pdr_ai_v2_call_notes_note_revisions_call_id_pdr_ai_v2_call_notes_calls_id_fk" FOREIGN KEY ("call_id") REFERENCES "public"."pdr_ai_v2_call_notes_calls"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pdr_ai_v2_call_notes_note_revisions" ADD CONSTRAINT "pdr_ai_v2_call_notes_note_revisions_company_id_pdr_ai_v2_company_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."pdr_ai_v2_company"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pdr_ai_v2_call_notes_note_revisions" ADD CONSTRAINT "pdr_ai_v2_call_notes_note_revisions_enrichment_run_id_pdr_ai_v2_call_notes_enrichment_runs_id_fk" FOREIGN KEY ("enrichment_run_id") REFERENCES "public"."pdr_ai_v2_call_notes_enrichment_runs"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pdr_ai_v2_call_notes_participants" ADD CONSTRAINT "pdr_ai_v2_call_notes_participants_call_id_pdr_ai_v2_call_notes_calls_id_fk" FOREIGN KEY ("call_id") REFERENCES "public"."pdr_ai_v2_call_notes_calls"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pdr_ai_v2_call_notes_participants" ADD CONSTRAINT "pdr_ai_v2_call_notes_participants_attempt_id_pdr_ai_v2_call_notes_capture_attempts_id_fk" FOREIGN KEY ("attempt_id") REFERENCES "public"."pdr_ai_v2_call_notes_capture_attempts"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pdr_ai_v2_call_notes_participants" ADD CONSTRAINT "pdr_ai_v2_call_notes_participants_company_id_pdr_ai_v2_company_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."pdr_ai_v2_company"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pdr_ai_v2_call_notes_transcript_segments" ADD CONSTRAINT "pdr_ai_v2_call_notes_transcript_segments_call_id_pdr_ai_v2_call_notes_calls_id_fk" FOREIGN KEY ("call_id") REFERENCES "public"."pdr_ai_v2_call_notes_calls"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pdr_ai_v2_call_notes_transcript_segments" ADD CONSTRAINT "pdr_ai_v2_call_notes_transcript_segments_attempt_id_pdr_ai_v2_call_notes_capture_attempts_id_fk" FOREIGN KEY ("attempt_id") REFERENCES "public"."pdr_ai_v2_call_notes_capture_attempts"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pdr_ai_v2_call_notes_transcript_segments" ADD CONSTRAINT "pdr_ai_v2_call_notes_transcript_segments_participant_id_pdr_ai_v2_call_notes_participants_id_fk" FOREIGN KEY ("participant_id") REFERENCES "public"."pdr_ai_v2_call_notes_participants"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pdr_ai_v2_call_notes_transcript_segments" ADD CONSTRAINT "pdr_ai_v2_call_notes_transcript_segments_company_id_pdr_ai_v2_company_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."pdr_ai_v2_company"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pdr_ai_v2_call_notes_work_items" ADD CONSTRAINT "pdr_ai_v2_call_notes_work_items_company_id_pdr_ai_v2_company_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."pdr_ai_v2_company"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pdr_ai_v2_call_notes_work_items" ADD CONSTRAINT "pdr_ai_v2_call_notes_work_items_call_id_pdr_ai_v2_call_notes_calls_id_fk" FOREIGN KEY ("call_id") REFERENCES "public"."pdr_ai_v2_call_notes_calls"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pdr_ai_v2_call_notes_work_items" ADD CONSTRAINT "pdr_ai_v2_call_notes_work_items_capture_id_pdr_ai_v2_call_notes_captures_id_fk" FOREIGN KEY ("capture_id") REFERENCES "public"."pdr_ai_v2_call_notes_captures"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "pdr_ai_v2_call_notes_zoom_connections" ADD CONSTRAINT "pdr_ai_v2_call_notes_zoom_connections_company_id_pdr_ai_v2_company_id_fk" FOREIGN KEY ("company_id") REFERENCES "public"."pdr_ai_v2_company"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "call_notes_bookmarks_call_created_idx" ON "pdr_ai_v2_call_notes_bookmarks" USING btree ("call_id","created_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "call_notes_calls_company_occurrence_unique" ON "pdr_ai_v2_call_notes_calls" USING btree ("company_id","provider","provider_occurrence_key");--> statement-breakpoint
+CREATE INDEX "call_notes_calls_company_created_at_idx" ON "pdr_ai_v2_call_notes_calls" USING btree ("company_id","created_at");--> statement-breakpoint
+CREATE INDEX "call_notes_calls_company_status_idx" ON "pdr_ai_v2_call_notes_calls" USING btree ("company_id","status");--> statement-breakpoint
+CREATE UNIQUE INDEX "call_notes_calls_document_note_unique" ON "pdr_ai_v2_call_notes_calls" USING btree ("document_note_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "call_notes_capture_attempts_capture_provider_key_unique" ON "pdr_ai_v2_call_notes_capture_attempts" USING btree ("capture_id","provider_attempt_key");--> statement-breakpoint
+CREATE INDEX "call_notes_capture_attempts_capture_started_idx" ON "pdr_ai_v2_call_notes_capture_attempts" USING btree ("capture_id","started_at");--> statement-breakpoint
+CREATE INDEX "call_notes_capture_attempts_lease_idx" ON "pdr_ai_v2_call_notes_capture_attempts" USING btree ("lifecycle","lease_expires_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "call_notes_captures_call_unique" ON "pdr_ai_v2_call_notes_captures" USING btree ("call_id");--> statement-breakpoint
+CREATE INDEX "call_notes_captures_company_lifecycle_idx" ON "pdr_ai_v2_call_notes_captures" USING btree ("company_id","lifecycle");--> statement-breakpoint
+CREATE INDEX "call_notes_enrichment_runs_call_created_idx" ON "pdr_ai_v2_call_notes_enrichment_runs" USING btree ("call_id","created_at");--> statement-breakpoint
+CREATE INDEX "call_notes_enrichment_runs_company_status_idx" ON "pdr_ai_v2_call_notes_enrichment_runs" USING btree ("company_id","status");--> statement-breakpoint
+CREATE INDEX "call_notes_gaps_call_started_idx" ON "pdr_ai_v2_call_notes_gaps" USING btree ("call_id","started_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "call_notes_note_revisions_call_revision_unique" ON "pdr_ai_v2_call_notes_note_revisions" USING btree ("call_id","revision");--> statement-breakpoint
+CREATE INDEX "call_notes_note_revisions_document_note_idx" ON "pdr_ai_v2_call_notes_note_revisions" USING btree ("document_note_id");--> statement-breakpoint
+CREATE INDEX "call_notes_participants_attempt_key_idx" ON "pdr_ai_v2_call_notes_participants" USING btree ("attempt_id","provider_participant_key");--> statement-breakpoint
+CREATE INDEX "call_notes_participants_call_observed_idx" ON "pdr_ai_v2_call_notes_participants" USING btree ("call_id","observed_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "call_notes_segments_attempt_packet_unique" ON "pdr_ai_v2_call_notes_transcript_segments" USING btree ("attempt_id","source_packet_hash");--> statement-breakpoint
+CREATE INDEX "call_notes_segments_call_order_idx" ON "pdr_ai_v2_call_notes_transcript_segments" USING btree ("call_id","provider_start_ms","receive_order");--> statement-breakpoint
+CREATE INDEX "call_notes_segments_company_received_idx" ON "pdr_ai_v2_call_notes_transcript_segments" USING btree ("company_id","received_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "call_notes_work_items_company_kind_key_unique" ON "pdr_ai_v2_call_notes_work_items" USING btree ("company_id","kind","idempotency_key");--> statement-breakpoint
+CREATE INDEX "call_notes_work_items_claim_idx" ON "pdr_ai_v2_call_notes_work_items" USING btree ("status","available_at","lease_expires_at");--> statement-breakpoint
+CREATE INDEX "call_notes_work_items_call_created_idx" ON "pdr_ai_v2_call_notes_work_items" USING btree ("call_id","created_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "call_notes_zoom_connections_company_user_unique" ON "pdr_ai_v2_call_notes_zoom_connections" USING btree ("company_id","user_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "call_notes_zoom_connections_company_zoom_user_unique" ON "pdr_ai_v2_call_notes_zoom_connections" USING btree ("company_id","zoom_user_id");

--- a/apps/web/drizzle/20260820055456_deep_veda.sql
+++ b/apps/web/drizzle/20260820055456_deep_veda.sql
@@ -1,0 +1,2 @@
+CREATE UNIQUE INDEX "call_notes_capture_attempts_one_active_unique" ON "pdr_ai_v2_call_notes_capture_attempts" USING btree ("capture_id") WHERE "pdr_ai_v2_call_notes_capture_attempts"."lifecycle" in ('connecting', 'live', 'reconnecting');--> statement-breakpoint
+CREATE UNIQUE INDEX "call_notes_enrichment_runs_one_active_unique" ON "pdr_ai_v2_call_notes_enrichment_runs" USING btree ("call_id") WHERE "pdr_ai_v2_call_notes_enrichment_runs"."status" in ('queued', 'generating', 'ready');

--- a/apps/web/drizzle/20260820055726_famous_titanium_man.sql
+++ b/apps/web/drizzle/20260820055726_famous_titanium_man.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "pdr_ai_v2_call_notes_calls" ALTER COLUMN "status" SET DEFAULT 'active';

--- a/apps/web/drizzle/meta/20260820010959_snapshot.json
+++ b/apps/web/drizzle/meta/20260820010959_snapshot.json
@@ -1,0 +1,6709 @@
+{
+  "id": "73c342d4-bb26-4c14-bda8-a68bdb0be74d",
+  "prevId": "8eb40f38-8f42-4abb-8847-c5c9668c1081",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.pdr_ai_v2_agent_ai_chatbot_chat": {
+      "name": "pdr_ai_v2_agent_ai_chatbot_chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "agent_mode": {
+          "name": "agent_mode",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'interactive'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "ai_style": {
+          "name": "ai_style",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'concise'"
+        },
+        "ai_persona": {
+          "name": "ai_persona",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'general'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_agent_ai_chatbot_document": {
+      "name": "pdr_ai_v2_agent_ai_chatbot_document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pdr_ai_v2_agent_ai_chatbot_document_chat_id_pdr_ai_v2_agent_ai_chatbot_chat_id_fk": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_document_chat_id_pdr_ai_v2_agent_ai_chatbot_chat_id_fk",
+          "tableFrom": "pdr_ai_v2_agent_ai_chatbot_document",
+          "tableTo": "pdr_ai_v2_agent_ai_chatbot_chat",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_agent_ai_chatbot_document_task_id_pdr_ai_v2_agent_ai_chatbot_task_id_fk": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_document_task_id_pdr_ai_v2_agent_ai_chatbot_task_id_fk",
+          "tableFrom": "pdr_ai_v2_agent_ai_chatbot_document",
+          "tableTo": "pdr_ai_v2_agent_ai_chatbot_task",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "pdr_ai_v2_agent_ai_chatbot_document_id_created_at_pk": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_document_id_created_at_pk",
+          "columns": [
+            "id",
+            "created_at"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_agent_ai_chatbot_execution_step": {
+      "name": "pdr_ai_v2_agent_ai_chatbot_execution_step",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_number": {
+          "name": "step_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_type": {
+          "name": "step_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_execution_step_task_step_idx": {
+          "name": "agent_execution_step_task_step_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "step_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_agent_ai_chatbot_execution_step_task_id_pdr_ai_v2_agent_ai_chatbot_task_id_fk": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_execution_step_task_id_pdr_ai_v2_agent_ai_chatbot_task_id_fk",
+          "tableFrom": "pdr_ai_v2_agent_ai_chatbot_execution_step",
+          "tableTo": "pdr_ai_v2_agent_ai_chatbot_task",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_agent_ai_chatbot_memory": {
+      "name": "pdr_ai_v2_agent_ai_chatbot_memory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_type": {
+          "name": "memory_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importance": {
+          "name": "importance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "accessed_at": {
+          "name": "accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_memory_chat_idx": {
+          "name": "agent_memory_chat_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_memory_chat_type_idx": {
+          "name": "agent_memory_chat_type_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "memory_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_agent_ai_chatbot_memory_chat_id_pdr_ai_v2_agent_ai_chatbot_chat_id_fk": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_memory_chat_id_pdr_ai_v2_agent_ai_chatbot_chat_id_fk",
+          "tableFrom": "pdr_ai_v2_agent_ai_chatbot_memory",
+          "tableTo": "pdr_ai_v2_agent_ai_chatbot_chat",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_agent_ai_chatbot_message": {
+      "name": "pdr_ai_v2_agent_ai_chatbot_message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_type": {
+          "name": "message_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "parent_message_id": {
+          "name": "parent_message_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pdr_ai_v2_agent_ai_chatbot_message_chat_id_pdr_ai_v2_agent_ai_chatbot_chat_id_fk": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_message_chat_id_pdr_ai_v2_agent_ai_chatbot_chat_id_fk",
+          "tableFrom": "pdr_ai_v2_agent_ai_chatbot_message",
+          "tableTo": "pdr_ai_v2_agent_ai_chatbot_chat",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_agent_ai_chatbot_suggestion": {
+      "name": "pdr_ai_v2_agent_ai_chatbot_suggestion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_created_at": {
+          "name": "document_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_text": {
+          "name": "original_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_text": {
+          "name": "suggested_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_resolved": {
+          "name": "is_resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pdr_ai_v2_agent_ai_chatbot_suggestion_document_id_document_created_at_pdr_ai_v2_agent_ai_chatbot_document_id_created_at_fk": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_suggestion_document_id_document_created_at_pdr_ai_v2_agent_ai_chatbot_document_id_created_at_fk",
+          "tableFrom": "pdr_ai_v2_agent_ai_chatbot_suggestion",
+          "tableTo": "pdr_ai_v2_agent_ai_chatbot_document",
+          "columnsFrom": [
+            "document_id",
+            "document_created_at"
+          ],
+          "columnsTo": [
+            "id",
+            "created_at"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_agent_ai_chatbot_task": {
+      "name": "pdr_ai_v2_agent_ai_chatbot_task",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pdr_ai_v2_agent_ai_chatbot_task_chat_id_pdr_ai_v2_agent_ai_chatbot_chat_id_fk": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_task_chat_id_pdr_ai_v2_agent_ai_chatbot_chat_id_fk",
+          "tableFrom": "pdr_ai_v2_agent_ai_chatbot_task",
+          "tableTo": "pdr_ai_v2_agent_ai_chatbot_chat",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_agent_ai_chatbot_tool_call": {
+      "name": "pdr_ai_v2_agent_ai_chatbot_tool_call",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_input": {
+          "name": "tool_input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_output": {
+          "name": "tool_output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_time_ms": {
+          "name": "execution_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pdr_ai_v2_agent_ai_chatbot_tool_call_message_id_pdr_ai_v2_agent_ai_chatbot_message_id_fk": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_tool_call_message_id_pdr_ai_v2_agent_ai_chatbot_message_id_fk",
+          "tableFrom": "pdr_ai_v2_agent_ai_chatbot_tool_call",
+          "tableTo": "pdr_ai_v2_agent_ai_chatbot_message",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_agent_ai_chatbot_tool_call_task_id_pdr_ai_v2_agent_ai_chatbot_task_id_fk": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_tool_call_task_id_pdr_ai_v2_agent_ai_chatbot_task_id_fk",
+          "tableFrom": "pdr_ai_v2_agent_ai_chatbot_tool_call",
+          "tableTo": "pdr_ai_v2_agent_ai_chatbot_task",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_agent_ai_chatbot_tool_registry": {
+      "name": "pdr_ai_v2_agent_ai_chatbot_tool_registry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema": {
+          "name": "schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "required_permissions": {
+          "name": "required_permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit": {
+          "name": "rate_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pdr_ai_v2_agent_ai_chatbot_tool_registry_name_unique": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_tool_registry_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_agent_ai_chatbot_vote": {
+      "name": "pdr_ai_v2_agent_ai_chatbot_vote",
+      "schema": "",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_upvoted": {
+          "name": "is_upvoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pdr_ai_v2_agent_ai_chatbot_vote_chat_id_pdr_ai_v2_agent_ai_chatbot_chat_id_fk": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_vote_chat_id_pdr_ai_v2_agent_ai_chatbot_chat_id_fk",
+          "tableFrom": "pdr_ai_v2_agent_ai_chatbot_vote",
+          "tableTo": "pdr_ai_v2_agent_ai_chatbot_chat",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_agent_ai_chatbot_vote_message_id_pdr_ai_v2_agent_ai_chatbot_message_id_fk": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_vote_message_id_pdr_ai_v2_agent_ai_chatbot_message_id_fk",
+          "tableFrom": "pdr_ai_v2_agent_ai_chatbot_vote",
+          "tableTo": "pdr_ai_v2_agent_ai_chatbot_message",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "pdr_ai_v2_agent_ai_chatbot_vote_chat_id_message_id_pk": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_vote_chat_id_message_id_pk",
+          "columns": [
+            "chat_id",
+            "message_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_collab_agent_persona": {
+      "name": "pdr_ai_v2_collab_agent_persona",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route": {
+          "name": "route",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature_x100": {
+          "name": "temperature_x100",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_turn_chars": {
+          "name": "max_turn_chars",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accent": {
+          "name": "accent",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "collab_persona_company_key_idx": {
+          "name": "collab_persona_company_key_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_collab_agent_persona_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_collab_agent_persona_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_collab_agent_persona",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_collab_channel": {
+      "name": "pdr_ai_v2_collab_channel",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "collab_channel_company_slug_idx": {
+          "name": "collab_channel_company_slug_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collab_channel_company_idx": {
+          "name": "collab_channel_company_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_collab_channel_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_collab_channel_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_collab_channel",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_collab_meeting": {
+      "name": "pdr_ai_v2_collab_meeting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agenda": {
+          "name": "agenda",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "participants": {
+          "name": "participants",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "turn_policy": {
+          "name": "turn_policy",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'round_robin'"
+        },
+        "moderator_persona_id": {
+          "name": "moderator_persona_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_turns": {
+          "name": "max_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 12
+        },
+        "completion_marker": {
+          "name": "completion_marker",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "turn_index": {
+          "name": "turn_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_speaker_id": {
+          "name": "next_speaker_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "controller": {
+          "name": "controller",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_mirror_enabled": {
+          "name": "slack_mirror_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "slack_use_agent_identity": {
+          "name": "slack_use_agent_identity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "collab_meeting_company_idx": {
+          "name": "collab_meeting_company_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collab_meeting_channel_idx": {
+          "name": "collab_meeting_channel_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_collab_meeting_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_collab_meeting_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_collab_meeting",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_collab_meeting_channel_id_pdr_ai_v2_collab_channel_id_fk": {
+          "name": "pdr_ai_v2_collab_meeting_channel_id_pdr_ai_v2_collab_channel_id_fk",
+          "tableFrom": "pdr_ai_v2_collab_meeting",
+          "tableTo": "pdr_ai_v2_collab_channel",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_collab_message": {
+      "name": "pdr_ai_v2_collab_message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_kind": {
+          "name": "author_kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "on_behalf_of_persona_id": {
+          "name": "on_behalf_of_persona_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'chat'"
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_ts": {
+          "name": "slack_ts",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "collab_message_channel_seq_idx": {
+          "name": "collab_message_channel_seq_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collab_message_channel_created_idx": {
+          "name": "collab_message_channel_created_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_collab_message_channel_id_pdr_ai_v2_collab_channel_id_fk": {
+          "name": "pdr_ai_v2_collab_message_channel_id_pdr_ai_v2_collab_channel_id_fk",
+          "tableFrom": "pdr_ai_v2_collab_message",
+          "tableTo": "pdr_ai_v2_collab_channel",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_collab_node": {
+      "name": "pdr_ai_v2_collab_node",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "persona_ids": {
+          "name": "persona_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_remote_address": {
+          "name": "last_remote_address",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "collab_node_company_idx": {
+          "name": "collab_node_company_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_collab_node_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_collab_node_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_collab_node",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_token_accounts": {
+      "name": "pdr_ai_v2_token_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_tokens": {
+          "name": "balance_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lifetime_tokens_purchased": {
+          "name": "lifetime_tokens_purchased",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lifetime_tokens_granted": {
+          "name": "lifetime_tokens_granted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lifetime_tokens_used": {
+          "name": "lifetime_tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "token_accounts_company_id_idx": {
+          "name": "token_accounts_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_token_accounts_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_token_accounts_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_token_accounts",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_token_grants": {
+      "name": "pdr_ai_v2_token_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grant_type": {
+          "name": "grant_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "token_grants_company_id_idx": {
+          "name": "token_grants_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_token_grants_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_token_grants_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_token_grants",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_token_transactions": {
+      "name": "pdr_ai_v2_token_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_after": {
+          "name": "balance_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "token_tx_company_created_idx": {
+          "name": "token_tx_company_created_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "token_tx_company_service_idx": {
+          "name": "token_tx_company_service_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "service",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_token_transactions_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_token_transactions_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_token_transactions",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_token_usage_daily": {
+      "name": "pdr_ai_v2_token_usage_daily",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_count": {
+          "name": "operation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tokens_used": {
+          "name": "tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "token_usage_daily_company_date_service_idx": {
+          "name": "token_usage_daily_company_date_service_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "service",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_token_usage_daily_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_token_usage_daily_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_token_usage_daily",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_chat_history": {
+      "name": "pdr_ai_v2_chat_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_title": {
+          "name": "document_title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query_type": {
+          "name": "query_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'simple'"
+        },
+        "pages": {
+          "name": "pages",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "chat_history_user_id_idx": {
+          "name": "chat_history_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_history_user_id_created_at_idx": {
+          "name": "chat_history_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_history_document_id_idx": {
+          "name": "chat_history_document_id_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_chat_history_document_id_pdr_ai_v2_document_id_fk": {
+          "name": "pdr_ai_v2_chat_history_document_id_pdr_ai_v2_document_id_fk",
+          "tableFrom": "pdr_ai_v2_chat_history",
+          "tableTo": "pdr_ai_v2_document",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_document_reference_resolutions": {
+      "name": "pdr_ai_v2_document_reference_resolutions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_name": {
+          "name": "reference_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_in_document_id": {
+          "name": "resolved_in_document_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_details": {
+          "name": "resolution_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_reference_resolutions_company_ref_idx": {
+          "name": "document_reference_resolutions_company_ref_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_document_reference_resolutions_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_document_reference_resolutions_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_document_reference_resolutions",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_document_views": {
+      "name": "pdr_ai_v2_document_views",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "document_views_document_id_idx": {
+          "name": "document_views_document_id_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_views_company_id_idx": {
+          "name": "document_views_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_views_user_id_idx": {
+          "name": "document_views_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_views_company_id_viewed_at_idx": {
+          "name": "document_views_company_id_viewed_at_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "viewed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_document_views_document_id_pdr_ai_v2_document_id_fk": {
+          "name": "pdr_ai_v2_document_views_document_id_pdr_ai_v2_document_id_fk",
+          "tableFrom": "pdr_ai_v2_document_views",
+          "tableTo": "pdr_ai_v2_document",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_document_views_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_document_views_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_document_views",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_generated_documents": {
+      "name": "pdr_ai_v2_generated_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "citations": {
+          "name": "citations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "generated_documents_user_id_idx": {
+          "name": "generated_documents_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "generated_documents_company_id_idx": {
+          "name": "generated_documents_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "generated_documents_company_user_idx": {
+          "name": "generated_documents_company_user_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_generated_documents_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_generated_documents_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_generated_documents",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_predictive_document_analysis_results": {
+      "name": "pdr_ai_v2_predictive_document_analysis_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis_type": {
+          "name": "analysis_type",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "include_related_docs": {
+          "name": "include_related_docs",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "result_json": {
+          "name": "result_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "predictive_analysis_document_id_idx": {
+          "name": "predictive_analysis_document_id_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_predictive_document_analysis_results_document_id_pdr_ai_v2_document_id_fk": {
+          "name": "pdr_ai_v2_predictive_document_analysis_results_document_id_pdr_ai_v2_document_id_fk",
+          "tableFrom": "pdr_ai_v2_predictive_document_analysis_results",
+          "tableTo": "pdr_ai_v2_document",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_document_note_embeddings": {
+      "name": "pdr_ai_v2_document_note_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "note_id": {
+          "name": "note_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_short": {
+          "name": "embedding_short",
+          "type": "vector(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "doc_note_emb_note_id_idx": {
+          "name": "doc_note_emb_note_id_idx",
+          "columns": [
+            {
+              "expression": "note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doc_note_emb_user_id_idx": {
+          "name": "doc_note_emb_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doc_note_emb_document_id_idx": {
+          "name": "doc_note_emb_document_id_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doc_note_emb_company_id_idx": {
+          "name": "doc_note_emb_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doc_note_emb_embedding_short_idx": {
+          "name": "doc_note_emb_embedding_short_idx",
+          "columns": [
+            {
+              "expression": "embedding_short",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {
+            "m": 16,
+            "ef_construction": 64
+          }
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_document_notes": {
+      "name": "pdr_ai_v2_document_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_rich": {
+          "name": "content_rich",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_markdown": {
+          "name": "content_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anchor": {
+          "name": "anchor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anchor_status": {
+          "name": "anchor_status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'resolved'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "document_notes_user_idx": {
+          "name": "document_notes_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_notes_document_idx": {
+          "name": "document_notes_document_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_notes_company_idx": {
+          "name": "document_notes_company_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_notes_version_idx": {
+          "name": "document_notes_version_idx",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_notes_anchor_status_idx": {
+          "name": "document_notes_anchor_status_idx",
+          "columns": [
+            {
+              "expression": "anchor_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_note_links": {
+      "name": "pdr_ai_v2_note_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_note_id": {
+          "name": "source_note_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_note_id": {
+          "name": "target_note_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_document_id": {
+          "name": "target_document_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_title": {
+          "name": "target_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "note_links_source_idx": {
+          "name": "note_links_source_idx",
+          "columns": [
+            {
+              "expression": "source_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "note_links_target_note_idx": {
+          "name": "note_links_target_note_idx",
+          "columns": [
+            {
+              "expression": "target_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "note_links_target_document_idx": {
+          "name": "note_links_target_document_idx",
+          "columns": [
+            {
+              "expression": "target_document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "note_links_company_title_idx": {
+          "name": "note_links_company_title_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_invite_codes": {
+      "name": "pdr_ai_v2_invite_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "invite_codes_code_idx": {
+          "name": "invite_codes_code_idx",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invite_codes_company_id_idx": {
+          "name": "invite_codes_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_invite_codes_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_invite_codes_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_invite_codes",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pdr_ai_v2_invite_codes_code_unique": {
+          "name": "pdr_ai_v2_invite_codes_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_user_company_memberships": {
+      "name": "pdr_ai_v2_user_company_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "user_company_memberships_user_company_unique": {
+          "name": "user_company_memberships_user_company_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_company_memberships_user_id_idx": {
+          "name": "user_company_memberships_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_company_memberships_company_id_idx": {
+          "name": "user_company_memberships_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_user_company_memberships_user_id_pdr_ai_v2_users_id_fk": {
+          "name": "pdr_ai_v2_user_company_memberships_user_id_pdr_ai_v2_users_id_fk",
+          "tableFrom": "pdr_ai_v2_user_company_memberships",
+          "tableTo": "pdr_ai_v2_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_user_company_memberships_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_user_company_memberships_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_user_company_memberships",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_users": {
+      "name": "pdr_ai_v2_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_company_id_idx": {
+          "name": "users_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_user_id_idx": {
+          "name": "users_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_users_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_users_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_users",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pdr_ai_v2_users_userId_unique": {
+          "name": "pdr_ai_v2_users_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_trend_search_jobs": {
+      "name": "pdr_ai_v2_trend_search_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_context": {
+          "name": "company_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "categories": {
+          "name": "categories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "results": {
+          "name": "results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "trend_search_jobs_company_id_idx": {
+          "name": "trend_search_jobs_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trend_search_jobs_status_idx": {
+          "name": "trend_search_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trend_search_jobs_company_status_idx": {
+          "name": "trend_search_jobs_company_status_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_trend_search_jobs_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_trend_search_jobs_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_trend_search_jobs",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_trend_search_cache": {
+      "name": "pdr_ai_v2_trend_search_cache",
+      "schema": "",
+      "columns": {
+        "cache_key": {
+          "name": "cache_key",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_client_prospector_jobs": {
+      "name": "pdr_ai_v2_client_prospector_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_context": {
+          "name": "company_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_lat": {
+          "name": "location_lat",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_lng": {
+          "name": "location_lng",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "radius": {
+          "name": "radius",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5000
+        },
+        "categories": {
+          "name": "categories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "results": {
+          "name": "results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "client_prospector_jobs_company_id_idx": {
+          "name": "client_prospector_jobs_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "client_prospector_jobs_status_idx": {
+          "name": "client_prospector_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "client_prospector_jobs_company_status_idx": {
+          "name": "client_prospector_jobs_company_status_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_client_prospector_jobs_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_client_prospector_jobs_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_client_prospector_jobs",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_company_metadata": {
+      "name": "pdr_ai_v2_company_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0.0'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_extraction_document_id": {
+          "name": "last_extraction_document_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "company_metadata_company_id_unique": {
+          "name": "company_metadata_company_id_unique",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_company_metadata_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_company_metadata_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_company_metadata",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_company_metadata_last_extraction_document_id_pdr_ai_v2_document_id_fk": {
+          "name": "pdr_ai_v2_company_metadata_last_extraction_document_id_pdr_ai_v2_document_id_fk",
+          "tableFrom": "pdr_ai_v2_company_metadata",
+          "tableTo": "pdr_ai_v2_document",
+          "columnsFrom": [
+            "last_extraction_document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_company_metadata_history": {
+      "name": "pdr_ai_v2_company_metadata_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "diff": {
+          "name": "diff",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by": {
+          "name": "changed_by",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "company_metadata_history_company_id_idx": {
+          "name": "company_metadata_history_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "company_metadata_history_document_id_idx": {
+          "name": "company_metadata_history_document_id_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "company_metadata_history_created_at_idx": {
+          "name": "company_metadata_history_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "company_metadata_history_change_type_idx": {
+          "name": "company_metadata_history_change_type_idx",
+          "columns": [
+            {
+              "expression": "change_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_company_metadata_history_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_company_metadata_history_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_company_metadata_history",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_company_metadata_history_document_id_pdr_ai_v2_document_id_fk": {
+          "name": "pdr_ai_v2_company_metadata_history_document_id_pdr_ai_v2_document_id_fk",
+          "tableFrom": "pdr_ai_v2_company_metadata_history",
+          "tableTo": "pdr_ai_v2_document",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_marketing_content_history": {
+      "name": "pdr_ai_v2_marketing_content_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'post'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impressions": {
+          "name": "impressions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "engagements": {
+          "name": "engagements",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clicks": {
+          "name": "clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mch_company_id_idx": {
+          "name": "mch_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mch_platform_idx": {
+          "name": "mch_platform_idx",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_founder_weekly_review_operations": {
+      "name": "pdr_ai_v2_founder_weekly_review_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_type": {
+          "name": "operation_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_key": {
+          "name": "request_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_failure_sequence": {
+          "name": "source_failure_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "founder_weekly_review_operations_run_type_request_key_unique": {
+          "name": "founder_weekly_review_operations_run_type_request_key_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "request_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "founder_weekly_review_operations_company_run_created_at_idx": {
+          "name": "founder_weekly_review_operations_company_run_created_at_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "founder_weekly_review_operations_run_type_created_at_idx": {
+          "name": "founder_weekly_review_operations_run_type_created_at_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_founder_weekly_review_operations_run_id_pdr_ai_v2_founder_weekly_review_runs_id_fk": {
+          "name": "pdr_ai_v2_founder_weekly_review_operations_run_id_pdr_ai_v2_founder_weekly_review_runs_id_fk",
+          "tableFrom": "pdr_ai_v2_founder_weekly_review_operations",
+          "tableTo": "pdr_ai_v2_founder_weekly_review_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_founder_weekly_review_operations_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_founder_weekly_review_operations_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_founder_weekly_review_operations",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_founder_weekly_review_runs": {
+      "name": "pdr_ai_v2_founder_weekly_review_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_key": {
+          "name": "request_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporting_period_start": {
+          "name": "reporting_period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporting_period_end": {
+          "name": "reporting_period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "review_payload": {
+          "name": "review_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_schema_version": {
+          "name": "review_schema_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_snapshot": {
+          "name": "evidence_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_schema_version": {
+          "name": "evidence_schema_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_metadata": {
+          "name": "model_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_actor_id": {
+          "name": "created_by_actor_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failure_sequence": {
+          "name": "failure_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "generation_attempt": {
+          "name": "generation_attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "generation_claim_id": {
+          "name": "generation_claim_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation_job_id": {
+          "name": "generation_job_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation_started_at": {
+          "name": "generation_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "founder_weekly_review_runs_company_request_key_unique": {
+          "name": "founder_weekly_review_runs_company_request_key_unique",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "request_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "founder_weekly_review_runs_company_created_at_idx": {
+          "name": "founder_weekly_review_runs_company_created_at_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "founder_weekly_review_runs_company_status_created_at_idx": {
+          "name": "founder_weekly_review_runs_company_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "founder_weekly_review_runs_company_period_idx": {
+          "name": "founder_weekly_review_runs_company_period_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reporting_period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reporting_period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "founder_weekly_review_runs_claim_idx": {
+          "name": "founder_weekly_review_runs_claim_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generation_claim_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_founder_weekly_review_runs_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_founder_weekly_review_runs_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_founder_weekly_review_runs",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_call_notes_bookmarks": {
+      "name": "pdr_ai_v2_call_notes_bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "call_id": {
+          "name": "call_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "segment_id": {
+          "name": "segment_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "call_notes_bookmarks_call_created_idx": {
+          "name": "call_notes_bookmarks_call_created_idx",
+          "columns": [
+            {
+              "expression": "call_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_call_notes_bookmarks_call_id_pdr_ai_v2_call_notes_calls_id_fk": {
+          "name": "pdr_ai_v2_call_notes_bookmarks_call_id_pdr_ai_v2_call_notes_calls_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_bookmarks",
+          "tableTo": "pdr_ai_v2_call_notes_calls",
+          "columnsFrom": [
+            "call_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_bookmarks_segment_id_pdr_ai_v2_call_notes_transcript_segments_id_fk": {
+          "name": "pdr_ai_v2_call_notes_bookmarks_segment_id_pdr_ai_v2_call_notes_transcript_segments_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_bookmarks",
+          "tableTo": "pdr_ai_v2_call_notes_transcript_segments",
+          "columnsFrom": [
+            "segment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_bookmarks_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_call_notes_bookmarks_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_bookmarks",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_call_notes_calls": {
+      "name": "pdr_ai_v2_call_notes_calls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_occurrence_key": {
+          "name": "provider_occurrence_key",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'detected'"
+        },
+        "document_note_id": {
+          "name": "document_note_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note_owner_user_id": {
+          "name": "note_owner_user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note_visibility": {
+          "name": "note_visibility",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'company'"
+        },
+        "knowledge_included": {
+          "name": "knowledge_included",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "current_note_revision": {
+          "name": "current_note_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_message": {
+          "name": "failure_message",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "call_notes_calls_company_occurrence_unique": {
+          "name": "call_notes_calls_company_occurrence_unique",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_occurrence_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_calls_company_created_at_idx": {
+          "name": "call_notes_calls_company_created_at_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_calls_company_status_idx": {
+          "name": "call_notes_calls_company_status_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_calls_document_note_unique": {
+          "name": "call_notes_calls_document_note_unique",
+          "columns": [
+            {
+              "expression": "document_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_call_notes_calls_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_call_notes_calls_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_calls",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_call_notes_capture_attempts": {
+      "name": "pdr_ai_v2_call_notes_capture_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "capture_id": {
+          "name": "capture_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "call_id": {
+          "name": "call_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_attempt_key": {
+          "name": "provider_attempt_key",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_stream_key": {
+          "name": "provider_stream_key",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle": {
+          "name": "lifecycle",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connecting'"
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_owner": {
+          "name": "lease_owner",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_message": {
+          "name": "failure_message",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "call_notes_capture_attempts_capture_provider_key_unique": {
+          "name": "call_notes_capture_attempts_capture_provider_key_unique",
+          "columns": [
+            {
+              "expression": "capture_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_attempt_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_capture_attempts_capture_started_idx": {
+          "name": "call_notes_capture_attempts_capture_started_idx",
+          "columns": [
+            {
+              "expression": "capture_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_capture_attempts_lease_idx": {
+          "name": "call_notes_capture_attempts_lease_idx",
+          "columns": [
+            {
+              "expression": "lifecycle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_call_notes_capture_attempts_capture_id_pdr_ai_v2_call_notes_captures_id_fk": {
+          "name": "pdr_ai_v2_call_notes_capture_attempts_capture_id_pdr_ai_v2_call_notes_captures_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_capture_attempts",
+          "tableTo": "pdr_ai_v2_call_notes_captures",
+          "columnsFrom": [
+            "capture_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_capture_attempts_call_id_pdr_ai_v2_call_notes_calls_id_fk": {
+          "name": "pdr_ai_v2_call_notes_capture_attempts_call_id_pdr_ai_v2_call_notes_calls_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_capture_attempts",
+          "tableTo": "pdr_ai_v2_call_notes_calls",
+          "columnsFrom": [
+            "call_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_capture_attempts_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_call_notes_capture_attempts_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_capture_attempts",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_call_notes_captures": {
+      "name": "pdr_ai_v2_call_notes_captures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "call_id": {
+          "name": "call_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capture_user_connection_id": {
+          "name": "capture_user_connection_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capture_user_provider_key": {
+          "name": "capture_user_provider_key",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "desired_mode": {
+          "name": "desired_mode",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "lifecycle": {
+          "name": "lifecycle",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connecting'"
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_attempt_id": {
+          "name": "active_attempt_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "call_notes_captures_call_unique": {
+          "name": "call_notes_captures_call_unique",
+          "columns": [
+            {
+              "expression": "call_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_captures_company_lifecycle_idx": {
+          "name": "call_notes_captures_company_lifecycle_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lifecycle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_call_notes_captures_call_id_pdr_ai_v2_call_notes_calls_id_fk": {
+          "name": "pdr_ai_v2_call_notes_captures_call_id_pdr_ai_v2_call_notes_calls_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_captures",
+          "tableTo": "pdr_ai_v2_call_notes_calls",
+          "columnsFrom": [
+            "call_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_captures_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_call_notes_captures_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_captures",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_captures_capture_user_connection_id_pdr_ai_v2_call_notes_zoom_connections_id_fk": {
+          "name": "pdr_ai_v2_call_notes_captures_capture_user_connection_id_pdr_ai_v2_call_notes_zoom_connections_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_captures",
+          "tableTo": "pdr_ai_v2_call_notes_zoom_connections",
+          "columnsFrom": [
+            "capture_user_connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_call_notes_enrichment_runs": {
+      "name": "pdr_ai_v2_call_notes_enrichment_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "call_id": {
+          "name": "call_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_note_revision": {
+          "name": "base_note_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transcript_fingerprint": {
+          "name": "transcript_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "original_output": {
+          "name": "original_output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "editable_proposal": {
+          "name": "editable_proposal",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_metadata": {
+          "name": "model_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "call_notes_enrichment_runs_call_created_idx": {
+          "name": "call_notes_enrichment_runs_call_created_idx",
+          "columns": [
+            {
+              "expression": "call_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_enrichment_runs_company_status_idx": {
+          "name": "call_notes_enrichment_runs_company_status_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_call_notes_enrichment_runs_call_id_pdr_ai_v2_call_notes_calls_id_fk": {
+          "name": "pdr_ai_v2_call_notes_enrichment_runs_call_id_pdr_ai_v2_call_notes_calls_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_enrichment_runs",
+          "tableTo": "pdr_ai_v2_call_notes_calls",
+          "columnsFrom": [
+            "call_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_enrichment_runs_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_call_notes_enrichment_runs_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_enrichment_runs",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_call_notes_gaps": {
+      "name": "pdr_ai_v2_call_notes_gaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "call_id": {
+          "name": "call_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capture_id": {
+          "name": "capture_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "call_notes_gaps_call_started_idx": {
+          "name": "call_notes_gaps_call_started_idx",
+          "columns": [
+            {
+              "expression": "call_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_call_notes_gaps_call_id_pdr_ai_v2_call_notes_calls_id_fk": {
+          "name": "pdr_ai_v2_call_notes_gaps_call_id_pdr_ai_v2_call_notes_calls_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_gaps",
+          "tableTo": "pdr_ai_v2_call_notes_calls",
+          "columnsFrom": [
+            "call_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_gaps_capture_id_pdr_ai_v2_call_notes_captures_id_fk": {
+          "name": "pdr_ai_v2_call_notes_gaps_capture_id_pdr_ai_v2_call_notes_captures_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_gaps",
+          "tableTo": "pdr_ai_v2_call_notes_captures",
+          "columnsFrom": [
+            "capture_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_gaps_attempt_id_pdr_ai_v2_call_notes_capture_attempts_id_fk": {
+          "name": "pdr_ai_v2_call_notes_gaps_attempt_id_pdr_ai_v2_call_notes_capture_attempts_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_gaps",
+          "tableTo": "pdr_ai_v2_call_notes_capture_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_gaps_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_call_notes_gaps_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_gaps",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_call_notes_note_revisions": {
+      "name": "pdr_ai_v2_call_notes_note_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "call_id": {
+          "name": "call_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_note_id": {
+          "name": "document_note_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrichment_run_id": {
+          "name": "enrichment_run_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_markdown": {
+          "name": "content_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_rich": {
+          "name": "content_rich",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "call_notes_note_revisions_call_revision_unique": {
+          "name": "call_notes_note_revisions_call_revision_unique",
+          "columns": [
+            {
+              "expression": "call_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revision",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_note_revisions_document_note_idx": {
+          "name": "call_notes_note_revisions_document_note_idx",
+          "columns": [
+            {
+              "expression": "document_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_call_notes_note_revisions_call_id_pdr_ai_v2_call_notes_calls_id_fk": {
+          "name": "pdr_ai_v2_call_notes_note_revisions_call_id_pdr_ai_v2_call_notes_calls_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_note_revisions",
+          "tableTo": "pdr_ai_v2_call_notes_calls",
+          "columnsFrom": [
+            "call_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_note_revisions_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_call_notes_note_revisions_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_note_revisions",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_note_revisions_enrichment_run_id_pdr_ai_v2_call_notes_enrichment_runs_id_fk": {
+          "name": "pdr_ai_v2_call_notes_note_revisions_enrichment_run_id_pdr_ai_v2_call_notes_enrichment_runs_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_note_revisions",
+          "tableTo": "pdr_ai_v2_call_notes_enrichment_runs",
+          "columnsFrom": [
+            "enrichment_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_call_notes_participants": {
+      "name": "pdr_ai_v2_call_notes_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "call_id": {
+          "name": "call_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_participant_key": {
+          "name": "provider_participant_key",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_session_key": {
+          "name": "provider_session_key",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "left_at": {
+          "name": "left_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "call_notes_participants_attempt_key_idx": {
+          "name": "call_notes_participants_attempt_key_idx",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_participant_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_participants_call_observed_idx": {
+          "name": "call_notes_participants_call_observed_idx",
+          "columns": [
+            {
+              "expression": "call_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_call_notes_participants_call_id_pdr_ai_v2_call_notes_calls_id_fk": {
+          "name": "pdr_ai_v2_call_notes_participants_call_id_pdr_ai_v2_call_notes_calls_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_participants",
+          "tableTo": "pdr_ai_v2_call_notes_calls",
+          "columnsFrom": [
+            "call_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_participants_attempt_id_pdr_ai_v2_call_notes_capture_attempts_id_fk": {
+          "name": "pdr_ai_v2_call_notes_participants_attempt_id_pdr_ai_v2_call_notes_capture_attempts_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_participants",
+          "tableTo": "pdr_ai_v2_call_notes_capture_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_participants_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_call_notes_participants_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_participants",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_call_notes_transcript_segments": {
+      "name": "pdr_ai_v2_call_notes_transcript_segments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "call_id": {
+          "name": "call_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_event_key": {
+          "name": "provider_event_key",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_packet_hash": {
+          "name": "source_packet_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "speaker_name": {
+          "name": "speaker_name",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_start_ms": {
+          "name": "provider_start_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_end_ms": {
+          "name": "provider_end_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receive_order": {
+          "name": "receive_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "call_notes_segments_attempt_packet_unique": {
+          "name": "call_notes_segments_attempt_packet_unique",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_packet_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_segments_call_order_idx": {
+          "name": "call_notes_segments_call_order_idx",
+          "columns": [
+            {
+              "expression": "call_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_start_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "receive_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_segments_company_received_idx": {
+          "name": "call_notes_segments_company_received_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_call_notes_transcript_segments_call_id_pdr_ai_v2_call_notes_calls_id_fk": {
+          "name": "pdr_ai_v2_call_notes_transcript_segments_call_id_pdr_ai_v2_call_notes_calls_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_transcript_segments",
+          "tableTo": "pdr_ai_v2_call_notes_calls",
+          "columnsFrom": [
+            "call_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_transcript_segments_attempt_id_pdr_ai_v2_call_notes_capture_attempts_id_fk": {
+          "name": "pdr_ai_v2_call_notes_transcript_segments_attempt_id_pdr_ai_v2_call_notes_capture_attempts_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_transcript_segments",
+          "tableTo": "pdr_ai_v2_call_notes_capture_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_transcript_segments_participant_id_pdr_ai_v2_call_notes_participants_id_fk": {
+          "name": "pdr_ai_v2_call_notes_transcript_segments_participant_id_pdr_ai_v2_call_notes_participants_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_transcript_segments",
+          "tableTo": "pdr_ai_v2_call_notes_participants",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_transcript_segments_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_call_notes_transcript_segments_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_transcript_segments",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_call_notes_work_items": {
+      "name": "pdr_ai_v2_call_notes_work_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "call_id": {
+          "name": "call_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_id": {
+          "name": "capture_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_owner": {
+          "name": "lease_owner",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "call_notes_work_items_company_kind_key_unique": {
+          "name": "call_notes_work_items_company_kind_key_unique",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_work_items_claim_idx": {
+          "name": "call_notes_work_items_claim_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_work_items_call_created_idx": {
+          "name": "call_notes_work_items_call_created_idx",
+          "columns": [
+            {
+              "expression": "call_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_call_notes_work_items_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_call_notes_work_items_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_work_items",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_work_items_call_id_pdr_ai_v2_call_notes_calls_id_fk": {
+          "name": "pdr_ai_v2_call_notes_work_items_call_id_pdr_ai_v2_call_notes_calls_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_work_items",
+          "tableTo": "pdr_ai_v2_call_notes_calls",
+          "columnsFrom": [
+            "call_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_work_items_capture_id_pdr_ai_v2_call_notes_captures_id_fk": {
+          "name": "pdr_ai_v2_call_notes_work_items_capture_id_pdr_ai_v2_call_notes_captures_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_work_items",
+          "tableTo": "pdr_ai_v2_call_notes_captures",
+          "columnsFrom": [
+            "capture_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_call_notes_zoom_connections": {
+      "name": "pdr_ai_v2_call_notes_zoom_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zoom_account_id": {
+          "name": "zoom_account_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zoom_user_id": {
+          "name": "zoom_user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_access_token": {
+          "name": "encrypted_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_refresh_token": {
+          "name": "encrypted_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "call_notes_zoom_connections_company_user_unique": {
+          "name": "call_notes_zoom_connections_company_user_unique",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_zoom_connections_company_zoom_user_unique": {
+          "name": "call_notes_zoom_connections_company_zoom_user_unique",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "zoom_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_call_notes_zoom_connections_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_call_notes_zoom_connections_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_zoom_connections",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/20260820055456_snapshot.json
+++ b/apps/web/drizzle/meta/20260820055456_snapshot.json
@@ -1,0 +1,6741 @@
+{
+  "id": "e34d3987-c168-4e08-80c5-6a010a203dba",
+  "prevId": "73c342d4-bb26-4c14-bda8-a68bdb0be74d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.pdr_ai_v2_agent_ai_chatbot_chat": {
+      "name": "pdr_ai_v2_agent_ai_chatbot_chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "agent_mode": {
+          "name": "agent_mode",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'interactive'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "ai_style": {
+          "name": "ai_style",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'concise'"
+        },
+        "ai_persona": {
+          "name": "ai_persona",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'general'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_agent_ai_chatbot_document": {
+      "name": "pdr_ai_v2_agent_ai_chatbot_document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pdr_ai_v2_agent_ai_chatbot_document_chat_id_pdr_ai_v2_agent_ai_chatbot_chat_id_fk": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_document_chat_id_pdr_ai_v2_agent_ai_chatbot_chat_id_fk",
+          "tableFrom": "pdr_ai_v2_agent_ai_chatbot_document",
+          "tableTo": "pdr_ai_v2_agent_ai_chatbot_chat",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_agent_ai_chatbot_document_task_id_pdr_ai_v2_agent_ai_chatbot_task_id_fk": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_document_task_id_pdr_ai_v2_agent_ai_chatbot_task_id_fk",
+          "tableFrom": "pdr_ai_v2_agent_ai_chatbot_document",
+          "tableTo": "pdr_ai_v2_agent_ai_chatbot_task",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "pdr_ai_v2_agent_ai_chatbot_document_id_created_at_pk": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_document_id_created_at_pk",
+          "columns": [
+            "id",
+            "created_at"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_agent_ai_chatbot_execution_step": {
+      "name": "pdr_ai_v2_agent_ai_chatbot_execution_step",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_number": {
+          "name": "step_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_type": {
+          "name": "step_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_execution_step_task_step_idx": {
+          "name": "agent_execution_step_task_step_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "step_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_agent_ai_chatbot_execution_step_task_id_pdr_ai_v2_agent_ai_chatbot_task_id_fk": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_execution_step_task_id_pdr_ai_v2_agent_ai_chatbot_task_id_fk",
+          "tableFrom": "pdr_ai_v2_agent_ai_chatbot_execution_step",
+          "tableTo": "pdr_ai_v2_agent_ai_chatbot_task",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_agent_ai_chatbot_memory": {
+      "name": "pdr_ai_v2_agent_ai_chatbot_memory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_type": {
+          "name": "memory_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importance": {
+          "name": "importance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "accessed_at": {
+          "name": "accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_memory_chat_idx": {
+          "name": "agent_memory_chat_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_memory_chat_type_idx": {
+          "name": "agent_memory_chat_type_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "memory_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_agent_ai_chatbot_memory_chat_id_pdr_ai_v2_agent_ai_chatbot_chat_id_fk": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_memory_chat_id_pdr_ai_v2_agent_ai_chatbot_chat_id_fk",
+          "tableFrom": "pdr_ai_v2_agent_ai_chatbot_memory",
+          "tableTo": "pdr_ai_v2_agent_ai_chatbot_chat",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_agent_ai_chatbot_message": {
+      "name": "pdr_ai_v2_agent_ai_chatbot_message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_type": {
+          "name": "message_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "parent_message_id": {
+          "name": "parent_message_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pdr_ai_v2_agent_ai_chatbot_message_chat_id_pdr_ai_v2_agent_ai_chatbot_chat_id_fk": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_message_chat_id_pdr_ai_v2_agent_ai_chatbot_chat_id_fk",
+          "tableFrom": "pdr_ai_v2_agent_ai_chatbot_message",
+          "tableTo": "pdr_ai_v2_agent_ai_chatbot_chat",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_agent_ai_chatbot_suggestion": {
+      "name": "pdr_ai_v2_agent_ai_chatbot_suggestion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_created_at": {
+          "name": "document_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_text": {
+          "name": "original_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_text": {
+          "name": "suggested_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_resolved": {
+          "name": "is_resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pdr_ai_v2_agent_ai_chatbot_suggestion_document_id_document_created_at_pdr_ai_v2_agent_ai_chatbot_document_id_created_at_fk": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_suggestion_document_id_document_created_at_pdr_ai_v2_agent_ai_chatbot_document_id_created_at_fk",
+          "tableFrom": "pdr_ai_v2_agent_ai_chatbot_suggestion",
+          "tableTo": "pdr_ai_v2_agent_ai_chatbot_document",
+          "columnsFrom": [
+            "document_id",
+            "document_created_at"
+          ],
+          "columnsTo": [
+            "id",
+            "created_at"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_agent_ai_chatbot_task": {
+      "name": "pdr_ai_v2_agent_ai_chatbot_task",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pdr_ai_v2_agent_ai_chatbot_task_chat_id_pdr_ai_v2_agent_ai_chatbot_chat_id_fk": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_task_chat_id_pdr_ai_v2_agent_ai_chatbot_chat_id_fk",
+          "tableFrom": "pdr_ai_v2_agent_ai_chatbot_task",
+          "tableTo": "pdr_ai_v2_agent_ai_chatbot_chat",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_agent_ai_chatbot_tool_call": {
+      "name": "pdr_ai_v2_agent_ai_chatbot_tool_call",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_input": {
+          "name": "tool_input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_output": {
+          "name": "tool_output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_time_ms": {
+          "name": "execution_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pdr_ai_v2_agent_ai_chatbot_tool_call_message_id_pdr_ai_v2_agent_ai_chatbot_message_id_fk": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_tool_call_message_id_pdr_ai_v2_agent_ai_chatbot_message_id_fk",
+          "tableFrom": "pdr_ai_v2_agent_ai_chatbot_tool_call",
+          "tableTo": "pdr_ai_v2_agent_ai_chatbot_message",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_agent_ai_chatbot_tool_call_task_id_pdr_ai_v2_agent_ai_chatbot_task_id_fk": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_tool_call_task_id_pdr_ai_v2_agent_ai_chatbot_task_id_fk",
+          "tableFrom": "pdr_ai_v2_agent_ai_chatbot_tool_call",
+          "tableTo": "pdr_ai_v2_agent_ai_chatbot_task",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_agent_ai_chatbot_tool_registry": {
+      "name": "pdr_ai_v2_agent_ai_chatbot_tool_registry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema": {
+          "name": "schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "required_permissions": {
+          "name": "required_permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit": {
+          "name": "rate_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pdr_ai_v2_agent_ai_chatbot_tool_registry_name_unique": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_tool_registry_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_agent_ai_chatbot_vote": {
+      "name": "pdr_ai_v2_agent_ai_chatbot_vote",
+      "schema": "",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_upvoted": {
+          "name": "is_upvoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pdr_ai_v2_agent_ai_chatbot_vote_chat_id_pdr_ai_v2_agent_ai_chatbot_chat_id_fk": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_vote_chat_id_pdr_ai_v2_agent_ai_chatbot_chat_id_fk",
+          "tableFrom": "pdr_ai_v2_agent_ai_chatbot_vote",
+          "tableTo": "pdr_ai_v2_agent_ai_chatbot_chat",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_agent_ai_chatbot_vote_message_id_pdr_ai_v2_agent_ai_chatbot_message_id_fk": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_vote_message_id_pdr_ai_v2_agent_ai_chatbot_message_id_fk",
+          "tableFrom": "pdr_ai_v2_agent_ai_chatbot_vote",
+          "tableTo": "pdr_ai_v2_agent_ai_chatbot_message",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "pdr_ai_v2_agent_ai_chatbot_vote_chat_id_message_id_pk": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_vote_chat_id_message_id_pk",
+          "columns": [
+            "chat_id",
+            "message_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_collab_agent_persona": {
+      "name": "pdr_ai_v2_collab_agent_persona",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route": {
+          "name": "route",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature_x100": {
+          "name": "temperature_x100",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_turn_chars": {
+          "name": "max_turn_chars",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accent": {
+          "name": "accent",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "collab_persona_company_key_idx": {
+          "name": "collab_persona_company_key_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_collab_agent_persona_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_collab_agent_persona_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_collab_agent_persona",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_collab_channel": {
+      "name": "pdr_ai_v2_collab_channel",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "collab_channel_company_slug_idx": {
+          "name": "collab_channel_company_slug_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collab_channel_company_idx": {
+          "name": "collab_channel_company_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_collab_channel_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_collab_channel_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_collab_channel",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_collab_meeting": {
+      "name": "pdr_ai_v2_collab_meeting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agenda": {
+          "name": "agenda",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "participants": {
+          "name": "participants",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "turn_policy": {
+          "name": "turn_policy",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'round_robin'"
+        },
+        "moderator_persona_id": {
+          "name": "moderator_persona_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_turns": {
+          "name": "max_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 12
+        },
+        "completion_marker": {
+          "name": "completion_marker",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "turn_index": {
+          "name": "turn_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_speaker_id": {
+          "name": "next_speaker_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "controller": {
+          "name": "controller",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_mirror_enabled": {
+          "name": "slack_mirror_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "slack_use_agent_identity": {
+          "name": "slack_use_agent_identity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "collab_meeting_company_idx": {
+          "name": "collab_meeting_company_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collab_meeting_channel_idx": {
+          "name": "collab_meeting_channel_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_collab_meeting_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_collab_meeting_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_collab_meeting",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_collab_meeting_channel_id_pdr_ai_v2_collab_channel_id_fk": {
+          "name": "pdr_ai_v2_collab_meeting_channel_id_pdr_ai_v2_collab_channel_id_fk",
+          "tableFrom": "pdr_ai_v2_collab_meeting",
+          "tableTo": "pdr_ai_v2_collab_channel",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_collab_message": {
+      "name": "pdr_ai_v2_collab_message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_kind": {
+          "name": "author_kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "on_behalf_of_persona_id": {
+          "name": "on_behalf_of_persona_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'chat'"
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_ts": {
+          "name": "slack_ts",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "collab_message_channel_seq_idx": {
+          "name": "collab_message_channel_seq_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collab_message_channel_created_idx": {
+          "name": "collab_message_channel_created_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_collab_message_channel_id_pdr_ai_v2_collab_channel_id_fk": {
+          "name": "pdr_ai_v2_collab_message_channel_id_pdr_ai_v2_collab_channel_id_fk",
+          "tableFrom": "pdr_ai_v2_collab_message",
+          "tableTo": "pdr_ai_v2_collab_channel",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_collab_node": {
+      "name": "pdr_ai_v2_collab_node",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "persona_ids": {
+          "name": "persona_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_remote_address": {
+          "name": "last_remote_address",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "collab_node_company_idx": {
+          "name": "collab_node_company_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_collab_node_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_collab_node_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_collab_node",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_token_accounts": {
+      "name": "pdr_ai_v2_token_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_tokens": {
+          "name": "balance_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lifetime_tokens_purchased": {
+          "name": "lifetime_tokens_purchased",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lifetime_tokens_granted": {
+          "name": "lifetime_tokens_granted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lifetime_tokens_used": {
+          "name": "lifetime_tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "token_accounts_company_id_idx": {
+          "name": "token_accounts_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_token_accounts_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_token_accounts_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_token_accounts",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_token_grants": {
+      "name": "pdr_ai_v2_token_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grant_type": {
+          "name": "grant_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "token_grants_company_id_idx": {
+          "name": "token_grants_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_token_grants_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_token_grants_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_token_grants",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_token_transactions": {
+      "name": "pdr_ai_v2_token_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_after": {
+          "name": "balance_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "token_tx_company_created_idx": {
+          "name": "token_tx_company_created_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "token_tx_company_service_idx": {
+          "name": "token_tx_company_service_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "service",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_token_transactions_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_token_transactions_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_token_transactions",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_token_usage_daily": {
+      "name": "pdr_ai_v2_token_usage_daily",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_count": {
+          "name": "operation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tokens_used": {
+          "name": "tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "token_usage_daily_company_date_service_idx": {
+          "name": "token_usage_daily_company_date_service_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "service",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_token_usage_daily_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_token_usage_daily_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_token_usage_daily",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_chat_history": {
+      "name": "pdr_ai_v2_chat_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_title": {
+          "name": "document_title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query_type": {
+          "name": "query_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'simple'"
+        },
+        "pages": {
+          "name": "pages",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "chat_history_user_id_idx": {
+          "name": "chat_history_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_history_user_id_created_at_idx": {
+          "name": "chat_history_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_history_document_id_idx": {
+          "name": "chat_history_document_id_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_chat_history_document_id_pdr_ai_v2_document_id_fk": {
+          "name": "pdr_ai_v2_chat_history_document_id_pdr_ai_v2_document_id_fk",
+          "tableFrom": "pdr_ai_v2_chat_history",
+          "tableTo": "pdr_ai_v2_document",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_document_reference_resolutions": {
+      "name": "pdr_ai_v2_document_reference_resolutions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_name": {
+          "name": "reference_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_in_document_id": {
+          "name": "resolved_in_document_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_details": {
+          "name": "resolution_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_reference_resolutions_company_ref_idx": {
+          "name": "document_reference_resolutions_company_ref_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_document_reference_resolutions_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_document_reference_resolutions_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_document_reference_resolutions",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_document_views": {
+      "name": "pdr_ai_v2_document_views",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "document_views_document_id_idx": {
+          "name": "document_views_document_id_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_views_company_id_idx": {
+          "name": "document_views_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_views_user_id_idx": {
+          "name": "document_views_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_views_company_id_viewed_at_idx": {
+          "name": "document_views_company_id_viewed_at_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "viewed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_document_views_document_id_pdr_ai_v2_document_id_fk": {
+          "name": "pdr_ai_v2_document_views_document_id_pdr_ai_v2_document_id_fk",
+          "tableFrom": "pdr_ai_v2_document_views",
+          "tableTo": "pdr_ai_v2_document",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_document_views_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_document_views_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_document_views",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_generated_documents": {
+      "name": "pdr_ai_v2_generated_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "citations": {
+          "name": "citations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "generated_documents_user_id_idx": {
+          "name": "generated_documents_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "generated_documents_company_id_idx": {
+          "name": "generated_documents_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "generated_documents_company_user_idx": {
+          "name": "generated_documents_company_user_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_generated_documents_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_generated_documents_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_generated_documents",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_predictive_document_analysis_results": {
+      "name": "pdr_ai_v2_predictive_document_analysis_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis_type": {
+          "name": "analysis_type",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "include_related_docs": {
+          "name": "include_related_docs",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "result_json": {
+          "name": "result_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "predictive_analysis_document_id_idx": {
+          "name": "predictive_analysis_document_id_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_predictive_document_analysis_results_document_id_pdr_ai_v2_document_id_fk": {
+          "name": "pdr_ai_v2_predictive_document_analysis_results_document_id_pdr_ai_v2_document_id_fk",
+          "tableFrom": "pdr_ai_v2_predictive_document_analysis_results",
+          "tableTo": "pdr_ai_v2_document",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_document_note_embeddings": {
+      "name": "pdr_ai_v2_document_note_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "note_id": {
+          "name": "note_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_short": {
+          "name": "embedding_short",
+          "type": "vector(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "doc_note_emb_note_id_idx": {
+          "name": "doc_note_emb_note_id_idx",
+          "columns": [
+            {
+              "expression": "note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doc_note_emb_user_id_idx": {
+          "name": "doc_note_emb_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doc_note_emb_document_id_idx": {
+          "name": "doc_note_emb_document_id_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doc_note_emb_company_id_idx": {
+          "name": "doc_note_emb_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doc_note_emb_embedding_short_idx": {
+          "name": "doc_note_emb_embedding_short_idx",
+          "columns": [
+            {
+              "expression": "embedding_short",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {
+            "m": 16,
+            "ef_construction": 64
+          }
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_document_notes": {
+      "name": "pdr_ai_v2_document_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_rich": {
+          "name": "content_rich",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_markdown": {
+          "name": "content_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anchor": {
+          "name": "anchor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anchor_status": {
+          "name": "anchor_status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'resolved'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "document_notes_user_idx": {
+          "name": "document_notes_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_notes_document_idx": {
+          "name": "document_notes_document_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_notes_company_idx": {
+          "name": "document_notes_company_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_notes_version_idx": {
+          "name": "document_notes_version_idx",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_notes_anchor_status_idx": {
+          "name": "document_notes_anchor_status_idx",
+          "columns": [
+            {
+              "expression": "anchor_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_note_links": {
+      "name": "pdr_ai_v2_note_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_note_id": {
+          "name": "source_note_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_note_id": {
+          "name": "target_note_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_document_id": {
+          "name": "target_document_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_title": {
+          "name": "target_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "note_links_source_idx": {
+          "name": "note_links_source_idx",
+          "columns": [
+            {
+              "expression": "source_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "note_links_target_note_idx": {
+          "name": "note_links_target_note_idx",
+          "columns": [
+            {
+              "expression": "target_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "note_links_target_document_idx": {
+          "name": "note_links_target_document_idx",
+          "columns": [
+            {
+              "expression": "target_document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "note_links_company_title_idx": {
+          "name": "note_links_company_title_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_invite_codes": {
+      "name": "pdr_ai_v2_invite_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "invite_codes_code_idx": {
+          "name": "invite_codes_code_idx",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invite_codes_company_id_idx": {
+          "name": "invite_codes_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_invite_codes_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_invite_codes_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_invite_codes",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pdr_ai_v2_invite_codes_code_unique": {
+          "name": "pdr_ai_v2_invite_codes_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_user_company_memberships": {
+      "name": "pdr_ai_v2_user_company_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "user_company_memberships_user_company_unique": {
+          "name": "user_company_memberships_user_company_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_company_memberships_user_id_idx": {
+          "name": "user_company_memberships_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_company_memberships_company_id_idx": {
+          "name": "user_company_memberships_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_user_company_memberships_user_id_pdr_ai_v2_users_id_fk": {
+          "name": "pdr_ai_v2_user_company_memberships_user_id_pdr_ai_v2_users_id_fk",
+          "tableFrom": "pdr_ai_v2_user_company_memberships",
+          "tableTo": "pdr_ai_v2_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_user_company_memberships_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_user_company_memberships_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_user_company_memberships",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_users": {
+      "name": "pdr_ai_v2_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_company_id_idx": {
+          "name": "users_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_user_id_idx": {
+          "name": "users_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_users_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_users_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_users",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pdr_ai_v2_users_userId_unique": {
+          "name": "pdr_ai_v2_users_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_trend_search_jobs": {
+      "name": "pdr_ai_v2_trend_search_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_context": {
+          "name": "company_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "categories": {
+          "name": "categories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "results": {
+          "name": "results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "trend_search_jobs_company_id_idx": {
+          "name": "trend_search_jobs_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trend_search_jobs_status_idx": {
+          "name": "trend_search_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trend_search_jobs_company_status_idx": {
+          "name": "trend_search_jobs_company_status_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_trend_search_jobs_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_trend_search_jobs_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_trend_search_jobs",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_trend_search_cache": {
+      "name": "pdr_ai_v2_trend_search_cache",
+      "schema": "",
+      "columns": {
+        "cache_key": {
+          "name": "cache_key",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_client_prospector_jobs": {
+      "name": "pdr_ai_v2_client_prospector_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_context": {
+          "name": "company_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_lat": {
+          "name": "location_lat",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_lng": {
+          "name": "location_lng",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "radius": {
+          "name": "radius",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5000
+        },
+        "categories": {
+          "name": "categories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "results": {
+          "name": "results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "client_prospector_jobs_company_id_idx": {
+          "name": "client_prospector_jobs_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "client_prospector_jobs_status_idx": {
+          "name": "client_prospector_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "client_prospector_jobs_company_status_idx": {
+          "name": "client_prospector_jobs_company_status_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_client_prospector_jobs_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_client_prospector_jobs_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_client_prospector_jobs",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_company_metadata": {
+      "name": "pdr_ai_v2_company_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0.0'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_extraction_document_id": {
+          "name": "last_extraction_document_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "company_metadata_company_id_unique": {
+          "name": "company_metadata_company_id_unique",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_company_metadata_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_company_metadata_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_company_metadata",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_company_metadata_last_extraction_document_id_pdr_ai_v2_document_id_fk": {
+          "name": "pdr_ai_v2_company_metadata_last_extraction_document_id_pdr_ai_v2_document_id_fk",
+          "tableFrom": "pdr_ai_v2_company_metadata",
+          "tableTo": "pdr_ai_v2_document",
+          "columnsFrom": [
+            "last_extraction_document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_company_metadata_history": {
+      "name": "pdr_ai_v2_company_metadata_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "diff": {
+          "name": "diff",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by": {
+          "name": "changed_by",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "company_metadata_history_company_id_idx": {
+          "name": "company_metadata_history_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "company_metadata_history_document_id_idx": {
+          "name": "company_metadata_history_document_id_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "company_metadata_history_created_at_idx": {
+          "name": "company_metadata_history_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "company_metadata_history_change_type_idx": {
+          "name": "company_metadata_history_change_type_idx",
+          "columns": [
+            {
+              "expression": "change_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_company_metadata_history_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_company_metadata_history_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_company_metadata_history",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_company_metadata_history_document_id_pdr_ai_v2_document_id_fk": {
+          "name": "pdr_ai_v2_company_metadata_history_document_id_pdr_ai_v2_document_id_fk",
+          "tableFrom": "pdr_ai_v2_company_metadata_history",
+          "tableTo": "pdr_ai_v2_document",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_marketing_content_history": {
+      "name": "pdr_ai_v2_marketing_content_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'post'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impressions": {
+          "name": "impressions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "engagements": {
+          "name": "engagements",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clicks": {
+          "name": "clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mch_company_id_idx": {
+          "name": "mch_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mch_platform_idx": {
+          "name": "mch_platform_idx",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_founder_weekly_review_operations": {
+      "name": "pdr_ai_v2_founder_weekly_review_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_type": {
+          "name": "operation_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_key": {
+          "name": "request_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_failure_sequence": {
+          "name": "source_failure_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "founder_weekly_review_operations_run_type_request_key_unique": {
+          "name": "founder_weekly_review_operations_run_type_request_key_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "request_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "founder_weekly_review_operations_company_run_created_at_idx": {
+          "name": "founder_weekly_review_operations_company_run_created_at_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "founder_weekly_review_operations_run_type_created_at_idx": {
+          "name": "founder_weekly_review_operations_run_type_created_at_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_founder_weekly_review_operations_run_id_pdr_ai_v2_founder_weekly_review_runs_id_fk": {
+          "name": "pdr_ai_v2_founder_weekly_review_operations_run_id_pdr_ai_v2_founder_weekly_review_runs_id_fk",
+          "tableFrom": "pdr_ai_v2_founder_weekly_review_operations",
+          "tableTo": "pdr_ai_v2_founder_weekly_review_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_founder_weekly_review_operations_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_founder_weekly_review_operations_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_founder_weekly_review_operations",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_founder_weekly_review_runs": {
+      "name": "pdr_ai_v2_founder_weekly_review_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_key": {
+          "name": "request_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporting_period_start": {
+          "name": "reporting_period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporting_period_end": {
+          "name": "reporting_period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "review_payload": {
+          "name": "review_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_schema_version": {
+          "name": "review_schema_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_snapshot": {
+          "name": "evidence_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_schema_version": {
+          "name": "evidence_schema_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_metadata": {
+          "name": "model_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_actor_id": {
+          "name": "created_by_actor_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failure_sequence": {
+          "name": "failure_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "generation_attempt": {
+          "name": "generation_attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "generation_claim_id": {
+          "name": "generation_claim_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation_job_id": {
+          "name": "generation_job_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation_started_at": {
+          "name": "generation_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "founder_weekly_review_runs_company_request_key_unique": {
+          "name": "founder_weekly_review_runs_company_request_key_unique",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "request_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "founder_weekly_review_runs_company_created_at_idx": {
+          "name": "founder_weekly_review_runs_company_created_at_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "founder_weekly_review_runs_company_status_created_at_idx": {
+          "name": "founder_weekly_review_runs_company_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "founder_weekly_review_runs_company_period_idx": {
+          "name": "founder_weekly_review_runs_company_period_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reporting_period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reporting_period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "founder_weekly_review_runs_claim_idx": {
+          "name": "founder_weekly_review_runs_claim_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generation_claim_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_founder_weekly_review_runs_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_founder_weekly_review_runs_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_founder_weekly_review_runs",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_call_notes_bookmarks": {
+      "name": "pdr_ai_v2_call_notes_bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "call_id": {
+          "name": "call_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "segment_id": {
+          "name": "segment_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "call_notes_bookmarks_call_created_idx": {
+          "name": "call_notes_bookmarks_call_created_idx",
+          "columns": [
+            {
+              "expression": "call_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_call_notes_bookmarks_call_id_pdr_ai_v2_call_notes_calls_id_fk": {
+          "name": "pdr_ai_v2_call_notes_bookmarks_call_id_pdr_ai_v2_call_notes_calls_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_bookmarks",
+          "tableTo": "pdr_ai_v2_call_notes_calls",
+          "columnsFrom": [
+            "call_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_bookmarks_segment_id_pdr_ai_v2_call_notes_transcript_segments_id_fk": {
+          "name": "pdr_ai_v2_call_notes_bookmarks_segment_id_pdr_ai_v2_call_notes_transcript_segments_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_bookmarks",
+          "tableTo": "pdr_ai_v2_call_notes_transcript_segments",
+          "columnsFrom": [
+            "segment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_bookmarks_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_call_notes_bookmarks_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_bookmarks",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_call_notes_calls": {
+      "name": "pdr_ai_v2_call_notes_calls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_occurrence_key": {
+          "name": "provider_occurrence_key",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'detected'"
+        },
+        "document_note_id": {
+          "name": "document_note_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note_owner_user_id": {
+          "name": "note_owner_user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note_visibility": {
+          "name": "note_visibility",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'company'"
+        },
+        "knowledge_included": {
+          "name": "knowledge_included",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "current_note_revision": {
+          "name": "current_note_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_message": {
+          "name": "failure_message",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "call_notes_calls_company_occurrence_unique": {
+          "name": "call_notes_calls_company_occurrence_unique",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_occurrence_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_calls_company_created_at_idx": {
+          "name": "call_notes_calls_company_created_at_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_calls_company_status_idx": {
+          "name": "call_notes_calls_company_status_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_calls_document_note_unique": {
+          "name": "call_notes_calls_document_note_unique",
+          "columns": [
+            {
+              "expression": "document_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_call_notes_calls_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_call_notes_calls_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_calls",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_call_notes_capture_attempts": {
+      "name": "pdr_ai_v2_call_notes_capture_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "capture_id": {
+          "name": "capture_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "call_id": {
+          "name": "call_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_attempt_key": {
+          "name": "provider_attempt_key",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_stream_key": {
+          "name": "provider_stream_key",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle": {
+          "name": "lifecycle",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connecting'"
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_owner": {
+          "name": "lease_owner",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_message": {
+          "name": "failure_message",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "call_notes_capture_attempts_capture_provider_key_unique": {
+          "name": "call_notes_capture_attempts_capture_provider_key_unique",
+          "columns": [
+            {
+              "expression": "capture_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_attempt_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_capture_attempts_one_active_unique": {
+          "name": "call_notes_capture_attempts_one_active_unique",
+          "columns": [
+            {
+              "expression": "capture_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pdr_ai_v2_call_notes_capture_attempts\".\"lifecycle\" in ('connecting', 'live', 'reconnecting')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_capture_attempts_capture_started_idx": {
+          "name": "call_notes_capture_attempts_capture_started_idx",
+          "columns": [
+            {
+              "expression": "capture_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_capture_attempts_lease_idx": {
+          "name": "call_notes_capture_attempts_lease_idx",
+          "columns": [
+            {
+              "expression": "lifecycle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_call_notes_capture_attempts_capture_id_pdr_ai_v2_call_notes_captures_id_fk": {
+          "name": "pdr_ai_v2_call_notes_capture_attempts_capture_id_pdr_ai_v2_call_notes_captures_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_capture_attempts",
+          "tableTo": "pdr_ai_v2_call_notes_captures",
+          "columnsFrom": [
+            "capture_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_capture_attempts_call_id_pdr_ai_v2_call_notes_calls_id_fk": {
+          "name": "pdr_ai_v2_call_notes_capture_attempts_call_id_pdr_ai_v2_call_notes_calls_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_capture_attempts",
+          "tableTo": "pdr_ai_v2_call_notes_calls",
+          "columnsFrom": [
+            "call_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_capture_attempts_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_call_notes_capture_attempts_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_capture_attempts",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_call_notes_captures": {
+      "name": "pdr_ai_v2_call_notes_captures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "call_id": {
+          "name": "call_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capture_user_connection_id": {
+          "name": "capture_user_connection_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capture_user_provider_key": {
+          "name": "capture_user_provider_key",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "desired_mode": {
+          "name": "desired_mode",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "lifecycle": {
+          "name": "lifecycle",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connecting'"
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_attempt_id": {
+          "name": "active_attempt_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "call_notes_captures_call_unique": {
+          "name": "call_notes_captures_call_unique",
+          "columns": [
+            {
+              "expression": "call_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_captures_company_lifecycle_idx": {
+          "name": "call_notes_captures_company_lifecycle_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lifecycle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_call_notes_captures_call_id_pdr_ai_v2_call_notes_calls_id_fk": {
+          "name": "pdr_ai_v2_call_notes_captures_call_id_pdr_ai_v2_call_notes_calls_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_captures",
+          "tableTo": "pdr_ai_v2_call_notes_calls",
+          "columnsFrom": [
+            "call_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_captures_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_call_notes_captures_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_captures",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_captures_capture_user_connection_id_pdr_ai_v2_call_notes_zoom_connections_id_fk": {
+          "name": "pdr_ai_v2_call_notes_captures_capture_user_connection_id_pdr_ai_v2_call_notes_zoom_connections_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_captures",
+          "tableTo": "pdr_ai_v2_call_notes_zoom_connections",
+          "columnsFrom": [
+            "capture_user_connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_call_notes_enrichment_runs": {
+      "name": "pdr_ai_v2_call_notes_enrichment_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "call_id": {
+          "name": "call_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_note_revision": {
+          "name": "base_note_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transcript_fingerprint": {
+          "name": "transcript_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "original_output": {
+          "name": "original_output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "editable_proposal": {
+          "name": "editable_proposal",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_metadata": {
+          "name": "model_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "call_notes_enrichment_runs_call_created_idx": {
+          "name": "call_notes_enrichment_runs_call_created_idx",
+          "columns": [
+            {
+              "expression": "call_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_enrichment_runs_company_status_idx": {
+          "name": "call_notes_enrichment_runs_company_status_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_enrichment_runs_one_active_unique": {
+          "name": "call_notes_enrichment_runs_one_active_unique",
+          "columns": [
+            {
+              "expression": "call_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pdr_ai_v2_call_notes_enrichment_runs\".\"status\" in ('queued', 'generating', 'ready')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_call_notes_enrichment_runs_call_id_pdr_ai_v2_call_notes_calls_id_fk": {
+          "name": "pdr_ai_v2_call_notes_enrichment_runs_call_id_pdr_ai_v2_call_notes_calls_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_enrichment_runs",
+          "tableTo": "pdr_ai_v2_call_notes_calls",
+          "columnsFrom": [
+            "call_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_enrichment_runs_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_call_notes_enrichment_runs_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_enrichment_runs",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_call_notes_gaps": {
+      "name": "pdr_ai_v2_call_notes_gaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "call_id": {
+          "name": "call_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capture_id": {
+          "name": "capture_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "call_notes_gaps_call_started_idx": {
+          "name": "call_notes_gaps_call_started_idx",
+          "columns": [
+            {
+              "expression": "call_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_call_notes_gaps_call_id_pdr_ai_v2_call_notes_calls_id_fk": {
+          "name": "pdr_ai_v2_call_notes_gaps_call_id_pdr_ai_v2_call_notes_calls_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_gaps",
+          "tableTo": "pdr_ai_v2_call_notes_calls",
+          "columnsFrom": [
+            "call_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_gaps_capture_id_pdr_ai_v2_call_notes_captures_id_fk": {
+          "name": "pdr_ai_v2_call_notes_gaps_capture_id_pdr_ai_v2_call_notes_captures_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_gaps",
+          "tableTo": "pdr_ai_v2_call_notes_captures",
+          "columnsFrom": [
+            "capture_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_gaps_attempt_id_pdr_ai_v2_call_notes_capture_attempts_id_fk": {
+          "name": "pdr_ai_v2_call_notes_gaps_attempt_id_pdr_ai_v2_call_notes_capture_attempts_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_gaps",
+          "tableTo": "pdr_ai_v2_call_notes_capture_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_gaps_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_call_notes_gaps_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_gaps",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_call_notes_note_revisions": {
+      "name": "pdr_ai_v2_call_notes_note_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "call_id": {
+          "name": "call_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_note_id": {
+          "name": "document_note_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrichment_run_id": {
+          "name": "enrichment_run_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_markdown": {
+          "name": "content_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_rich": {
+          "name": "content_rich",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "call_notes_note_revisions_call_revision_unique": {
+          "name": "call_notes_note_revisions_call_revision_unique",
+          "columns": [
+            {
+              "expression": "call_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revision",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_note_revisions_document_note_idx": {
+          "name": "call_notes_note_revisions_document_note_idx",
+          "columns": [
+            {
+              "expression": "document_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_call_notes_note_revisions_call_id_pdr_ai_v2_call_notes_calls_id_fk": {
+          "name": "pdr_ai_v2_call_notes_note_revisions_call_id_pdr_ai_v2_call_notes_calls_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_note_revisions",
+          "tableTo": "pdr_ai_v2_call_notes_calls",
+          "columnsFrom": [
+            "call_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_note_revisions_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_call_notes_note_revisions_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_note_revisions",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_note_revisions_enrichment_run_id_pdr_ai_v2_call_notes_enrichment_runs_id_fk": {
+          "name": "pdr_ai_v2_call_notes_note_revisions_enrichment_run_id_pdr_ai_v2_call_notes_enrichment_runs_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_note_revisions",
+          "tableTo": "pdr_ai_v2_call_notes_enrichment_runs",
+          "columnsFrom": [
+            "enrichment_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_call_notes_participants": {
+      "name": "pdr_ai_v2_call_notes_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "call_id": {
+          "name": "call_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_participant_key": {
+          "name": "provider_participant_key",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_session_key": {
+          "name": "provider_session_key",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "left_at": {
+          "name": "left_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "call_notes_participants_attempt_key_idx": {
+          "name": "call_notes_participants_attempt_key_idx",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_participant_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_participants_call_observed_idx": {
+          "name": "call_notes_participants_call_observed_idx",
+          "columns": [
+            {
+              "expression": "call_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_call_notes_participants_call_id_pdr_ai_v2_call_notes_calls_id_fk": {
+          "name": "pdr_ai_v2_call_notes_participants_call_id_pdr_ai_v2_call_notes_calls_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_participants",
+          "tableTo": "pdr_ai_v2_call_notes_calls",
+          "columnsFrom": [
+            "call_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_participants_attempt_id_pdr_ai_v2_call_notes_capture_attempts_id_fk": {
+          "name": "pdr_ai_v2_call_notes_participants_attempt_id_pdr_ai_v2_call_notes_capture_attempts_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_participants",
+          "tableTo": "pdr_ai_v2_call_notes_capture_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_participants_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_call_notes_participants_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_participants",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_call_notes_transcript_segments": {
+      "name": "pdr_ai_v2_call_notes_transcript_segments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "call_id": {
+          "name": "call_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_event_key": {
+          "name": "provider_event_key",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_packet_hash": {
+          "name": "source_packet_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "speaker_name": {
+          "name": "speaker_name",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_start_ms": {
+          "name": "provider_start_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_end_ms": {
+          "name": "provider_end_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receive_order": {
+          "name": "receive_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "call_notes_segments_attempt_packet_unique": {
+          "name": "call_notes_segments_attempt_packet_unique",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_packet_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_segments_call_order_idx": {
+          "name": "call_notes_segments_call_order_idx",
+          "columns": [
+            {
+              "expression": "call_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_start_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "receive_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_segments_company_received_idx": {
+          "name": "call_notes_segments_company_received_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_call_notes_transcript_segments_call_id_pdr_ai_v2_call_notes_calls_id_fk": {
+          "name": "pdr_ai_v2_call_notes_transcript_segments_call_id_pdr_ai_v2_call_notes_calls_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_transcript_segments",
+          "tableTo": "pdr_ai_v2_call_notes_calls",
+          "columnsFrom": [
+            "call_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_transcript_segments_attempt_id_pdr_ai_v2_call_notes_capture_attempts_id_fk": {
+          "name": "pdr_ai_v2_call_notes_transcript_segments_attempt_id_pdr_ai_v2_call_notes_capture_attempts_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_transcript_segments",
+          "tableTo": "pdr_ai_v2_call_notes_capture_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_transcript_segments_participant_id_pdr_ai_v2_call_notes_participants_id_fk": {
+          "name": "pdr_ai_v2_call_notes_transcript_segments_participant_id_pdr_ai_v2_call_notes_participants_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_transcript_segments",
+          "tableTo": "pdr_ai_v2_call_notes_participants",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_transcript_segments_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_call_notes_transcript_segments_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_transcript_segments",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_call_notes_work_items": {
+      "name": "pdr_ai_v2_call_notes_work_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "call_id": {
+          "name": "call_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_id": {
+          "name": "capture_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_owner": {
+          "name": "lease_owner",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "call_notes_work_items_company_kind_key_unique": {
+          "name": "call_notes_work_items_company_kind_key_unique",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_work_items_claim_idx": {
+          "name": "call_notes_work_items_claim_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_work_items_call_created_idx": {
+          "name": "call_notes_work_items_call_created_idx",
+          "columns": [
+            {
+              "expression": "call_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_call_notes_work_items_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_call_notes_work_items_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_work_items",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_work_items_call_id_pdr_ai_v2_call_notes_calls_id_fk": {
+          "name": "pdr_ai_v2_call_notes_work_items_call_id_pdr_ai_v2_call_notes_calls_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_work_items",
+          "tableTo": "pdr_ai_v2_call_notes_calls",
+          "columnsFrom": [
+            "call_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_work_items_capture_id_pdr_ai_v2_call_notes_captures_id_fk": {
+          "name": "pdr_ai_v2_call_notes_work_items_capture_id_pdr_ai_v2_call_notes_captures_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_work_items",
+          "tableTo": "pdr_ai_v2_call_notes_captures",
+          "columnsFrom": [
+            "capture_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_call_notes_zoom_connections": {
+      "name": "pdr_ai_v2_call_notes_zoom_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zoom_account_id": {
+          "name": "zoom_account_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zoom_user_id": {
+          "name": "zoom_user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_access_token": {
+          "name": "encrypted_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_refresh_token": {
+          "name": "encrypted_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "call_notes_zoom_connections_company_user_unique": {
+          "name": "call_notes_zoom_connections_company_user_unique",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_zoom_connections_company_zoom_user_unique": {
+          "name": "call_notes_zoom_connections_company_zoom_user_unique",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "zoom_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_call_notes_zoom_connections_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_call_notes_zoom_connections_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_zoom_connections",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/20260820055726_snapshot.json
+++ b/apps/web/drizzle/meta/20260820055726_snapshot.json
@@ -1,0 +1,6741 @@
+{
+  "id": "b05797f7-91d7-4b6b-9a4d-b5447e7db0e2",
+  "prevId": "e34d3987-c168-4e08-80c5-6a010a203dba",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.pdr_ai_v2_agent_ai_chatbot_chat": {
+      "name": "pdr_ai_v2_agent_ai_chatbot_chat",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "agent_mode": {
+          "name": "agent_mode",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'interactive'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "ai_style": {
+          "name": "ai_style",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'concise'"
+        },
+        "ai_persona": {
+          "name": "ai_persona",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'general'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_agent_ai_chatbot_document": {
+      "name": "pdr_ai_v2_agent_ai_chatbot_document",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pdr_ai_v2_agent_ai_chatbot_document_chat_id_pdr_ai_v2_agent_ai_chatbot_chat_id_fk": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_document_chat_id_pdr_ai_v2_agent_ai_chatbot_chat_id_fk",
+          "tableFrom": "pdr_ai_v2_agent_ai_chatbot_document",
+          "tableTo": "pdr_ai_v2_agent_ai_chatbot_chat",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_agent_ai_chatbot_document_task_id_pdr_ai_v2_agent_ai_chatbot_task_id_fk": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_document_task_id_pdr_ai_v2_agent_ai_chatbot_task_id_fk",
+          "tableFrom": "pdr_ai_v2_agent_ai_chatbot_document",
+          "tableTo": "pdr_ai_v2_agent_ai_chatbot_task",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "pdr_ai_v2_agent_ai_chatbot_document_id_created_at_pk": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_document_id_created_at_pk",
+          "columns": [
+            "id",
+            "created_at"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_agent_ai_chatbot_execution_step": {
+      "name": "pdr_ai_v2_agent_ai_chatbot_execution_step",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_number": {
+          "name": "step_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "step_type": {
+          "name": "step_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reasoning": {
+          "name": "reasoning",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input": {
+          "name": "input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_execution_step_task_step_idx": {
+          "name": "agent_execution_step_task_step_idx",
+          "columns": [
+            {
+              "expression": "task_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "step_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_agent_ai_chatbot_execution_step_task_id_pdr_ai_v2_agent_ai_chatbot_task_id_fk": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_execution_step_task_id_pdr_ai_v2_agent_ai_chatbot_task_id_fk",
+          "tableFrom": "pdr_ai_v2_agent_ai_chatbot_execution_step",
+          "tableTo": "pdr_ai_v2_agent_ai_chatbot_task",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_agent_ai_chatbot_memory": {
+      "name": "pdr_ai_v2_agent_ai_chatbot_memory",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_type": {
+          "name": "memory_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "importance": {
+          "name": "importance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "accessed_at": {
+          "name": "accessed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agent_memory_chat_idx": {
+          "name": "agent_memory_chat_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "agent_memory_chat_type_idx": {
+          "name": "agent_memory_chat_type_idx",
+          "columns": [
+            {
+              "expression": "chat_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "memory_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_agent_ai_chatbot_memory_chat_id_pdr_ai_v2_agent_ai_chatbot_chat_id_fk": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_memory_chat_id_pdr_ai_v2_agent_ai_chatbot_chat_id_fk",
+          "tableFrom": "pdr_ai_v2_agent_ai_chatbot_memory",
+          "tableTo": "pdr_ai_v2_agent_ai_chatbot_chat",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_agent_ai_chatbot_message": {
+      "name": "pdr_ai_v2_agent_ai_chatbot_message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_type": {
+          "name": "message_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'text'"
+        },
+        "parent_message_id": {
+          "name": "parent_message_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pdr_ai_v2_agent_ai_chatbot_message_chat_id_pdr_ai_v2_agent_ai_chatbot_chat_id_fk": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_message_chat_id_pdr_ai_v2_agent_ai_chatbot_chat_id_fk",
+          "tableFrom": "pdr_ai_v2_agent_ai_chatbot_message",
+          "tableTo": "pdr_ai_v2_agent_ai_chatbot_chat",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_agent_ai_chatbot_suggestion": {
+      "name": "pdr_ai_v2_agent_ai_chatbot_suggestion",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_created_at": {
+          "name": "document_created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_text": {
+          "name": "original_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_text": {
+          "name": "suggested_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_resolved": {
+          "name": "is_resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pdr_ai_v2_agent_ai_chatbot_suggestion_document_id_document_created_at_pdr_ai_v2_agent_ai_chatbot_document_id_created_at_fk": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_suggestion_document_id_document_created_at_pdr_ai_v2_agent_ai_chatbot_document_id_created_at_fk",
+          "tableFrom": "pdr_ai_v2_agent_ai_chatbot_suggestion",
+          "tableTo": "pdr_ai_v2_agent_ai_chatbot_document",
+          "columnsFrom": [
+            "document_id",
+            "document_created_at"
+          ],
+          "columnsTo": [
+            "id",
+            "created_at"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_agent_ai_chatbot_task": {
+      "name": "pdr_ai_v2_agent_ai_chatbot_task",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "result": {
+          "name": "result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pdr_ai_v2_agent_ai_chatbot_task_chat_id_pdr_ai_v2_agent_ai_chatbot_chat_id_fk": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_task_chat_id_pdr_ai_v2_agent_ai_chatbot_chat_id_fk",
+          "tableFrom": "pdr_ai_v2_agent_ai_chatbot_task",
+          "tableTo": "pdr_ai_v2_agent_ai_chatbot_chat",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_agent_ai_chatbot_tool_call": {
+      "name": "pdr_ai_v2_agent_ai_chatbot_tool_call",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tool_name": {
+          "name": "tool_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_input": {
+          "name": "tool_input",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tool_output": {
+          "name": "tool_output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "execution_time_ms": {
+          "name": "execution_time_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pdr_ai_v2_agent_ai_chatbot_tool_call_message_id_pdr_ai_v2_agent_ai_chatbot_message_id_fk": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_tool_call_message_id_pdr_ai_v2_agent_ai_chatbot_message_id_fk",
+          "tableFrom": "pdr_ai_v2_agent_ai_chatbot_tool_call",
+          "tableTo": "pdr_ai_v2_agent_ai_chatbot_message",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_agent_ai_chatbot_tool_call_task_id_pdr_ai_v2_agent_ai_chatbot_task_id_fk": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_tool_call_task_id_pdr_ai_v2_agent_ai_chatbot_task_id_fk",
+          "tableFrom": "pdr_ai_v2_agent_ai_chatbot_tool_call",
+          "tableTo": "pdr_ai_v2_agent_ai_chatbot_task",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_agent_ai_chatbot_tool_registry": {
+      "name": "pdr_ai_v2_agent_ai_chatbot_tool_registry",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema": {
+          "name": "schema",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_enabled": {
+          "name": "is_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "required_permissions": {
+          "name": "required_permissions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rate_limit": {
+          "name": "rate_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pdr_ai_v2_agent_ai_chatbot_tool_registry_name_unique": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_tool_registry_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_agent_ai_chatbot_vote": {
+      "name": "pdr_ai_v2_agent_ai_chatbot_vote",
+      "schema": "",
+      "columns": {
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_upvoted": {
+          "name": "is_upvoted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pdr_ai_v2_agent_ai_chatbot_vote_chat_id_pdr_ai_v2_agent_ai_chatbot_chat_id_fk": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_vote_chat_id_pdr_ai_v2_agent_ai_chatbot_chat_id_fk",
+          "tableFrom": "pdr_ai_v2_agent_ai_chatbot_vote",
+          "tableTo": "pdr_ai_v2_agent_ai_chatbot_chat",
+          "columnsFrom": [
+            "chat_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_agent_ai_chatbot_vote_message_id_pdr_ai_v2_agent_ai_chatbot_message_id_fk": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_vote_message_id_pdr_ai_v2_agent_ai_chatbot_message_id_fk",
+          "tableFrom": "pdr_ai_v2_agent_ai_chatbot_vote",
+          "tableTo": "pdr_ai_v2_agent_ai_chatbot_message",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "pdr_ai_v2_agent_ai_chatbot_vote_chat_id_message_id_pk": {
+          "name": "pdr_ai_v2_agent_ai_chatbot_vote_chat_id_message_id_pk",
+          "columns": [
+            "chat_id",
+            "message_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_collab_agent_persona": {
+      "name": "pdr_ai_v2_collab_agent_persona",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "system_prompt": {
+          "name": "system_prompt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "node_id": {
+          "name": "node_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "route": {
+          "name": "route",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "temperature_x100": {
+          "name": "temperature_x100",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_turn_chars": {
+          "name": "max_turn_chars",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "accent": {
+          "name": "accent",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "collab_persona_company_key_idx": {
+          "name": "collab_persona_company_key_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_collab_agent_persona_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_collab_agent_persona_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_collab_agent_persona",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_collab_channel": {
+      "name": "pdr_ai_v2_collab_channel",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(96)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "topic": {
+          "name": "topic",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "archived": {
+          "name": "archived",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "collab_channel_company_slug_idx": {
+          "name": "collab_channel_company_slug_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collab_channel_company_idx": {
+          "name": "collab_channel_company_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_collab_channel_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_collab_channel_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_collab_channel",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_collab_meeting": {
+      "name": "pdr_ai_v2_collab_meeting",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "objective": {
+          "name": "objective",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agenda": {
+          "name": "agenda",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "participants": {
+          "name": "participants",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "turn_policy": {
+          "name": "turn_policy",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'round_robin'"
+        },
+        "moderator_persona_id": {
+          "name": "moderator_persona_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_turns": {
+          "name": "max_turns",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 12
+        },
+        "completion_marker": {
+          "name": "completion_marker",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'scheduled'"
+        },
+        "turn_index": {
+          "name": "turn_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "next_speaker_id": {
+          "name": "next_speaker_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "controller": {
+          "name": "controller",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_channel_id": {
+          "name": "slack_channel_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_mirror_enabled": {
+          "name": "slack_mirror_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "slack_use_agent_identity": {
+          "name": "slack_use_agent_identity",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "collab_meeting_company_idx": {
+          "name": "collab_meeting_company_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collab_meeting_channel_idx": {
+          "name": "collab_meeting_channel_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_collab_meeting_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_collab_meeting_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_collab_meeting",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_collab_meeting_channel_id_pdr_ai_v2_collab_channel_id_fk": {
+          "name": "pdr_ai_v2_collab_meeting_channel_id_pdr_ai_v2_collab_channel_id_fk",
+          "tableFrom": "pdr_ai_v2_collab_meeting",
+          "tableTo": "pdr_ai_v2_collab_channel",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_collab_message": {
+      "name": "pdr_ai_v2_collab_message",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_kind": {
+          "name": "author_kind",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_name": {
+          "name": "author_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "on_behalf_of_persona_id": {
+          "name": "on_behalf_of_persona_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'chat'"
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slack_ts": {
+          "name": "slack_ts",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "collab_message_channel_seq_idx": {
+          "name": "collab_message_channel_seq_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "seq",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collab_message_channel_created_idx": {
+          "name": "collab_message_channel_created_idx",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_collab_message_channel_id_pdr_ai_v2_collab_channel_id_fk": {
+          "name": "pdr_ai_v2_collab_message_channel_id_pdr_ai_v2_collab_channel_id_fk",
+          "tableFrom": "pdr_ai_v2_collab_message",
+          "tableTo": "pdr_ai_v2_collab_channel",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_collab_node": {
+      "name": "pdr_ai_v2_collab_node",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label": {
+          "name": "label",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "persona_ids": {
+          "name": "persona_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_remote_address": {
+          "name": "last_remote_address",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "collab_node_company_idx": {
+          "name": "collab_node_company_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_collab_node_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_collab_node_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_collab_node",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_token_accounts": {
+      "name": "pdr_ai_v2_token_accounts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_tokens": {
+          "name": "balance_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lifetime_tokens_purchased": {
+          "name": "lifetime_tokens_purchased",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lifetime_tokens_granted": {
+          "name": "lifetime_tokens_granted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "lifetime_tokens_used": {
+          "name": "lifetime_tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "token_accounts_company_id_idx": {
+          "name": "token_accounts_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_token_accounts_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_token_accounts_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_token_accounts",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_token_grants": {
+      "name": "pdr_ai_v2_token_grants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "grant_type": {
+          "name": "grant_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "granted_by": {
+          "name": "granted_by",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "token_grants_company_id_idx": {
+          "name": "token_grants_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_token_grants_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_token_grants_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_token_grants",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_token_transactions": {
+      "name": "pdr_ai_v2_token_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_after": {
+          "name": "balance_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reference_id": {
+          "name": "reference_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "token_tx_company_created_idx": {
+          "name": "token_tx_company_created_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "token_tx_company_service_idx": {
+          "name": "token_tx_company_service_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "service",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_token_transactions_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_token_transactions_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_token_transactions",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_token_usage_daily": {
+      "name": "pdr_ai_v2_token_usage_daily",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "service": {
+          "name": "service",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_count": {
+          "name": "operation_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "tokens_used": {
+          "name": "tokens_used",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "token_usage_daily_company_date_service_idx": {
+          "name": "token_usage_daily_company_date_service_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "service",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_token_usage_daily_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_token_usage_daily_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_token_usage_daily",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_chat_history": {
+      "name": "pdr_ai_v2_chat_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_title": {
+          "name": "document_title",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "chat_id": {
+          "name": "chat_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "query_type": {
+          "name": "query_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'simple'"
+        },
+        "pages": {
+          "name": "pages",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "chat_history_user_id_idx": {
+          "name": "chat_history_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_history_user_id_created_at_idx": {
+          "name": "chat_history_user_id_created_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "chat_history_document_id_idx": {
+          "name": "chat_history_document_id_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_chat_history_document_id_pdr_ai_v2_document_id_fk": {
+          "name": "pdr_ai_v2_chat_history_document_id_pdr_ai_v2_document_id_fk",
+          "tableFrom": "pdr_ai_v2_chat_history",
+          "tableTo": "pdr_ai_v2_document",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_document_reference_resolutions": {
+      "name": "pdr_ai_v2_document_reference_resolutions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_name": {
+          "name": "reference_name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_in_document_id": {
+          "name": "resolved_in_document_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolution_details": {
+          "name": "resolution_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "document_reference_resolutions_company_ref_idx": {
+          "name": "document_reference_resolutions_company_ref_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_document_reference_resolutions_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_document_reference_resolutions_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_document_reference_resolutions",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_document_views": {
+      "name": "pdr_ai_v2_document_views",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "viewed_at": {
+          "name": "viewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "document_views_document_id_idx": {
+          "name": "document_views_document_id_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_views_company_id_idx": {
+          "name": "document_views_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_views_user_id_idx": {
+          "name": "document_views_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_views_company_id_viewed_at_idx": {
+          "name": "document_views_company_id_viewed_at_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "viewed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_document_views_document_id_pdr_ai_v2_document_id_fk": {
+          "name": "pdr_ai_v2_document_views_document_id_pdr_ai_v2_document_id_fk",
+          "tableFrom": "pdr_ai_v2_document_views",
+          "tableTo": "pdr_ai_v2_document",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_document_views_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_document_views_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_document_views",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_generated_documents": {
+      "name": "pdr_ai_v2_generated_documents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "citations": {
+          "name": "citations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "generated_documents_user_id_idx": {
+          "name": "generated_documents_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "generated_documents_company_id_idx": {
+          "name": "generated_documents_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "generated_documents_company_user_idx": {
+          "name": "generated_documents_company_user_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_generated_documents_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_generated_documents_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_generated_documents",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_predictive_document_analysis_results": {
+      "name": "pdr_ai_v2_predictive_document_analysis_results",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "analysis_type": {
+          "name": "analysis_type",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "include_related_docs": {
+          "name": "include_related_docs",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "result_json": {
+          "name": "result_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "predictive_analysis_document_id_idx": {
+          "name": "predictive_analysis_document_id_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_predictive_document_analysis_results_document_id_pdr_ai_v2_document_id_fk": {
+          "name": "pdr_ai_v2_predictive_document_analysis_results_document_id_pdr_ai_v2_document_id_fk",
+          "tableFrom": "pdr_ai_v2_predictive_document_analysis_results",
+          "tableTo": "pdr_ai_v2_document",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_document_note_embeddings": {
+      "name": "pdr_ai_v2_document_note_embeddings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "note_id": {
+          "name": "note_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "vector(1536)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embedding_short": {
+          "name": "embedding_short",
+          "type": "vector(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_version": {
+          "name": "model_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "doc_note_emb_note_id_idx": {
+          "name": "doc_note_emb_note_id_idx",
+          "columns": [
+            {
+              "expression": "note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doc_note_emb_user_id_idx": {
+          "name": "doc_note_emb_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doc_note_emb_document_id_idx": {
+          "name": "doc_note_emb_document_id_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doc_note_emb_company_id_idx": {
+          "name": "doc_note_emb_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "doc_note_emb_embedding_short_idx": {
+          "name": "doc_note_emb_embedding_short_idx",
+          "columns": [
+            {
+              "expression": "embedding_short",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last",
+              "opclass": "vector_cosine_ops"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "hnsw",
+          "with": {
+            "m": 16,
+            "ef_construction": 64
+          }
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_document_notes": {
+      "name": "pdr_ai_v2_document_notes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version_id": {
+          "name": "version_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_rich": {
+          "name": "content_rich",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_markdown": {
+          "name": "content_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anchor": {
+          "name": "anchor",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "anchor_status": {
+          "name": "anchor_status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'resolved'"
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "document_notes_user_idx": {
+          "name": "document_notes_user_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_notes_document_idx": {
+          "name": "document_notes_document_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_notes_company_idx": {
+          "name": "document_notes_company_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_notes_version_idx": {
+          "name": "document_notes_version_idx",
+          "columns": [
+            {
+              "expression": "version_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "document_notes_anchor_status_idx": {
+          "name": "document_notes_anchor_status_idx",
+          "columns": [
+            {
+              "expression": "anchor_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_note_links": {
+      "name": "pdr_ai_v2_note_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_note_id": {
+          "name": "source_note_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_note_id": {
+          "name": "target_note_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_document_id": {
+          "name": "target_document_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "target_title": {
+          "name": "target_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "note_links_source_idx": {
+          "name": "note_links_source_idx",
+          "columns": [
+            {
+              "expression": "source_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "note_links_target_note_idx": {
+          "name": "note_links_target_note_idx",
+          "columns": [
+            {
+              "expression": "target_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "note_links_target_document_idx": {
+          "name": "note_links_target_document_idx",
+          "columns": [
+            {
+              "expression": "target_document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "note_links_company_title_idx": {
+          "name": "note_links_company_title_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_invite_codes": {
+      "name": "pdr_ai_v2_invite_codes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "invite_codes_code_idx": {
+          "name": "invite_codes_code_idx",
+          "columns": [
+            {
+              "expression": "code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invite_codes_company_id_idx": {
+          "name": "invite_codes_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_invite_codes_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_invite_codes_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_invite_codes",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pdr_ai_v2_invite_codes_code_unique": {
+          "name": "pdr_ai_v2_invite_codes_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_user_company_memberships": {
+      "name": "pdr_ai_v2_user_company_memberships",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_opened_at": {
+          "name": "last_opened_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "user_company_memberships_user_company_unique": {
+          "name": "user_company_memberships_user_company_unique",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_company_memberships_user_id_idx": {
+          "name": "user_company_memberships_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_company_memberships_company_id_idx": {
+          "name": "user_company_memberships_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_user_company_memberships_user_id_pdr_ai_v2_users_id_fk": {
+          "name": "pdr_ai_v2_user_company_memberships_user_id_pdr_ai_v2_users_id_fk",
+          "tableFrom": "pdr_ai_v2_user_company_memberships",
+          "tableTo": "pdr_ai_v2_users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_user_company_memberships_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_user_company_memberships_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_user_company_memberships",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_users": {
+      "name": "pdr_ai_v2_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "userId": {
+          "name": "userId",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "users_company_id_idx": {
+          "name": "users_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "users_user_id_idx": {
+          "name": "users_user_id_idx",
+          "columns": [
+            {
+              "expression": "userId",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_users_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_users_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_users",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "pdr_ai_v2_users_userId_unique": {
+          "name": "pdr_ai_v2_users_userId_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "userId"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_trend_search_jobs": {
+      "name": "pdr_ai_v2_trend_search_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_context": {
+          "name": "company_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "categories": {
+          "name": "categories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "results": {
+          "name": "results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "trend_search_jobs_company_id_idx": {
+          "name": "trend_search_jobs_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trend_search_jobs_status_idx": {
+          "name": "trend_search_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trend_search_jobs_company_status_idx": {
+          "name": "trend_search_jobs_company_status_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_trend_search_jobs_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_trend_search_jobs_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_trend_search_jobs",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_trend_search_cache": {
+      "name": "pdr_ai_v2_trend_search_cache",
+      "schema": "",
+      "columns": {
+        "cache_key": {
+          "name": "cache_key",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "output": {
+          "name": "output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_client_prospector_jobs": {
+      "name": "pdr_ai_v2_client_prospector_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(256)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "query": {
+          "name": "query",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_context": {
+          "name": "company_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_lat": {
+          "name": "location_lat",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "location_lng": {
+          "name": "location_lng",
+          "type": "double precision",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "radius": {
+          "name": "radius",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 5000
+        },
+        "categories": {
+          "name": "categories",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "results": {
+          "name": "results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "client_prospector_jobs_company_id_idx": {
+          "name": "client_prospector_jobs_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "client_prospector_jobs_status_idx": {
+          "name": "client_prospector_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "client_prospector_jobs_company_status_idx": {
+          "name": "client_prospector_jobs_company_status_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_client_prospector_jobs_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_client_prospector_jobs_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_client_prospector_jobs",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_company_metadata": {
+      "name": "pdr_ai_v2_company_metadata",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "schema_version": {
+          "name": "schema_version",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'1.0.0'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_extraction_document_id": {
+          "name": "last_extraction_document_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "company_metadata_company_id_unique": {
+          "name": "company_metadata_company_id_unique",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_company_metadata_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_company_metadata_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_company_metadata",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_company_metadata_last_extraction_document_id_pdr_ai_v2_document_id_fk": {
+          "name": "pdr_ai_v2_company_metadata_last_extraction_document_id_pdr_ai_v2_document_id_fk",
+          "tableFrom": "pdr_ai_v2_company_metadata",
+          "tableTo": "pdr_ai_v2_document",
+          "columnsFrom": [
+            "last_extraction_document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_company_metadata_history": {
+      "name": "pdr_ai_v2_company_metadata_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_id": {
+          "name": "document_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "change_type": {
+          "name": "change_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "diff": {
+          "name": "diff",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "changed_by": {
+          "name": "changed_by",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "company_metadata_history_company_id_idx": {
+          "name": "company_metadata_history_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "company_metadata_history_document_id_idx": {
+          "name": "company_metadata_history_document_id_idx",
+          "columns": [
+            {
+              "expression": "document_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "company_metadata_history_created_at_idx": {
+          "name": "company_metadata_history_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "company_metadata_history_change_type_idx": {
+          "name": "company_metadata_history_change_type_idx",
+          "columns": [
+            {
+              "expression": "change_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_company_metadata_history_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_company_metadata_history_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_company_metadata_history",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_company_metadata_history_document_id_pdr_ai_v2_document_id_fk": {
+          "name": "pdr_ai_v2_company_metadata_history_document_id_pdr_ai_v2_document_id_fk",
+          "tableFrom": "pdr_ai_v2_company_metadata_history",
+          "tableTo": "pdr_ai_v2_document",
+          "columnsFrom": [
+            "document_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_marketing_content_history": {
+      "name": "pdr_ai_v2_marketing_content_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigserial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "angle": {
+          "name": "angle",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'post'"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "impressions": {
+          "name": "impressions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "engagements": {
+          "name": "engagements",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clicks": {
+          "name": "clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "mch_company_id_idx": {
+          "name": "mch_company_id_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mch_platform_idx": {
+          "name": "mch_platform_idx",
+          "columns": [
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_founder_weekly_review_operations": {
+      "name": "pdr_ai_v2_founder_weekly_review_operations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation_type": {
+          "name": "operation_type",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_key": {
+          "name": "request_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_failure_sequence": {
+          "name": "source_failure_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "founder_weekly_review_operations_run_type_request_key_unique": {
+          "name": "founder_weekly_review_operations_run_type_request_key_unique",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "request_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "founder_weekly_review_operations_company_run_created_at_idx": {
+          "name": "founder_weekly_review_operations_company_run_created_at_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "founder_weekly_review_operations_run_type_created_at_idx": {
+          "name": "founder_weekly_review_operations_run_type_created_at_idx",
+          "columns": [
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_founder_weekly_review_operations_run_id_pdr_ai_v2_founder_weekly_review_runs_id_fk": {
+          "name": "pdr_ai_v2_founder_weekly_review_operations_run_id_pdr_ai_v2_founder_weekly_review_runs_id_fk",
+          "tableFrom": "pdr_ai_v2_founder_weekly_review_operations",
+          "tableTo": "pdr_ai_v2_founder_weekly_review_runs",
+          "columnsFrom": [
+            "run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_founder_weekly_review_operations_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_founder_weekly_review_operations_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_founder_weekly_review_operations",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_founder_weekly_review_runs": {
+      "name": "pdr_ai_v2_founder_weekly_review_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "request_key": {
+          "name": "request_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporting_period_start": {
+          "name": "reporting_period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporting_period_end": {
+          "name": "reporting_period_end",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "review_payload": {
+          "name": "review_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "review_schema_version": {
+          "name": "review_schema_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_snapshot": {
+          "name": "evidence_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "evidence_schema_version": {
+          "name": "evidence_schema_version",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_metadata": {
+          "name": "model_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by_actor_id": {
+          "name": "created_by_actor_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failure_sequence": {
+          "name": "failure_sequence",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "generation_attempt": {
+          "name": "generation_attempt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "generation_claim_id": {
+          "name": "generation_claim_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation_job_id": {
+          "name": "generation_job_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queued_at": {
+          "name": "queued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generation_started_at": {
+          "name": "generation_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "founder_weekly_review_runs_company_request_key_unique": {
+          "name": "founder_weekly_review_runs_company_request_key_unique",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "request_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "founder_weekly_review_runs_company_created_at_idx": {
+          "name": "founder_weekly_review_runs_company_created_at_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "founder_weekly_review_runs_company_status_created_at_idx": {
+          "name": "founder_weekly_review_runs_company_status_created_at_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "founder_weekly_review_runs_company_period_idx": {
+          "name": "founder_weekly_review_runs_company_period_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reporting_period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "reporting_period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "founder_weekly_review_runs_claim_idx": {
+          "name": "founder_weekly_review_runs_claim_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generation_claim_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_founder_weekly_review_runs_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_founder_weekly_review_runs_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_founder_weekly_review_runs",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_call_notes_bookmarks": {
+      "name": "pdr_ai_v2_call_notes_bookmarks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "call_id": {
+          "name": "call_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "segment_id": {
+          "name": "segment_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "comment": {
+          "name": "comment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "call_notes_bookmarks_call_created_idx": {
+          "name": "call_notes_bookmarks_call_created_idx",
+          "columns": [
+            {
+              "expression": "call_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_call_notes_bookmarks_call_id_pdr_ai_v2_call_notes_calls_id_fk": {
+          "name": "pdr_ai_v2_call_notes_bookmarks_call_id_pdr_ai_v2_call_notes_calls_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_bookmarks",
+          "tableTo": "pdr_ai_v2_call_notes_calls",
+          "columnsFrom": [
+            "call_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_bookmarks_segment_id_pdr_ai_v2_call_notes_transcript_segments_id_fk": {
+          "name": "pdr_ai_v2_call_notes_bookmarks_segment_id_pdr_ai_v2_call_notes_transcript_segments_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_bookmarks",
+          "tableTo": "pdr_ai_v2_call_notes_transcript_segments",
+          "columnsFrom": [
+            "segment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_bookmarks_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_call_notes_bookmarks_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_bookmarks",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_call_notes_calls": {
+      "name": "pdr_ai_v2_call_notes_calls",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_occurrence_key": {
+          "name": "provider_occurrence_key",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "document_note_id": {
+          "name": "document_note_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note_owner_user_id": {
+          "name": "note_owner_user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note_visibility": {
+          "name": "note_visibility",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'company'"
+        },
+        "knowledge_included": {
+          "name": "knowledge_included",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "current_note_revision": {
+          "name": "current_note_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_message": {
+          "name": "failure_message",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "call_notes_calls_company_occurrence_unique": {
+          "name": "call_notes_calls_company_occurrence_unique",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_occurrence_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_calls_company_created_at_idx": {
+          "name": "call_notes_calls_company_created_at_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_calls_company_status_idx": {
+          "name": "call_notes_calls_company_status_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_calls_document_note_unique": {
+          "name": "call_notes_calls_document_note_unique",
+          "columns": [
+            {
+              "expression": "document_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_call_notes_calls_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_call_notes_calls_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_calls",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_call_notes_capture_attempts": {
+      "name": "pdr_ai_v2_call_notes_capture_attempts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "capture_id": {
+          "name": "capture_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "call_id": {
+          "name": "call_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_attempt_key": {
+          "name": "provider_attempt_key",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_stream_key": {
+          "name": "provider_stream_key",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lifecycle": {
+          "name": "lifecycle",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connecting'"
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_owner": {
+          "name": "lease_owner",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_code": {
+          "name": "failure_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "failure_message": {
+          "name": "failure_message",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "call_notes_capture_attempts_capture_provider_key_unique": {
+          "name": "call_notes_capture_attempts_capture_provider_key_unique",
+          "columns": [
+            {
+              "expression": "capture_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_attempt_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_capture_attempts_one_active_unique": {
+          "name": "call_notes_capture_attempts_one_active_unique",
+          "columns": [
+            {
+              "expression": "capture_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pdr_ai_v2_call_notes_capture_attempts\".\"lifecycle\" in ('connecting', 'live', 'reconnecting')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_capture_attempts_capture_started_idx": {
+          "name": "call_notes_capture_attempts_capture_started_idx",
+          "columns": [
+            {
+              "expression": "capture_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_capture_attempts_lease_idx": {
+          "name": "call_notes_capture_attempts_lease_idx",
+          "columns": [
+            {
+              "expression": "lifecycle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_call_notes_capture_attempts_capture_id_pdr_ai_v2_call_notes_captures_id_fk": {
+          "name": "pdr_ai_v2_call_notes_capture_attempts_capture_id_pdr_ai_v2_call_notes_captures_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_capture_attempts",
+          "tableTo": "pdr_ai_v2_call_notes_captures",
+          "columnsFrom": [
+            "capture_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_capture_attempts_call_id_pdr_ai_v2_call_notes_calls_id_fk": {
+          "name": "pdr_ai_v2_call_notes_capture_attempts_call_id_pdr_ai_v2_call_notes_calls_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_capture_attempts",
+          "tableTo": "pdr_ai_v2_call_notes_calls",
+          "columnsFrom": [
+            "call_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_capture_attempts_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_call_notes_capture_attempts_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_capture_attempts",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_call_notes_captures": {
+      "name": "pdr_ai_v2_call_notes_captures",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "call_id": {
+          "name": "call_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capture_user_connection_id": {
+          "name": "capture_user_connection_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capture_user_provider_key": {
+          "name": "capture_user_provider_key",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "desired_mode": {
+          "name": "desired_mode",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "lifecycle": {
+          "name": "lifecycle",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'connecting'"
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_attempt_id": {
+          "name": "active_attempt_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "call_notes_captures_call_unique": {
+          "name": "call_notes_captures_call_unique",
+          "columns": [
+            {
+              "expression": "call_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_captures_company_lifecycle_idx": {
+          "name": "call_notes_captures_company_lifecycle_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lifecycle",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_call_notes_captures_call_id_pdr_ai_v2_call_notes_calls_id_fk": {
+          "name": "pdr_ai_v2_call_notes_captures_call_id_pdr_ai_v2_call_notes_calls_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_captures",
+          "tableTo": "pdr_ai_v2_call_notes_calls",
+          "columnsFrom": [
+            "call_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_captures_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_call_notes_captures_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_captures",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_captures_capture_user_connection_id_pdr_ai_v2_call_notes_zoom_connections_id_fk": {
+          "name": "pdr_ai_v2_call_notes_captures_capture_user_connection_id_pdr_ai_v2_call_notes_zoom_connections_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_captures",
+          "tableTo": "pdr_ai_v2_call_notes_zoom_connections",
+          "columnsFrom": [
+            "capture_user_connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_call_notes_enrichment_runs": {
+      "name": "pdr_ai_v2_call_notes_enrichment_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "call_id": {
+          "name": "call_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "requested_by_user_id": {
+          "name": "requested_by_user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "base_note_revision": {
+          "name": "base_note_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transcript_fingerprint": {
+          "name": "transcript_fingerprint",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'queued'"
+        },
+        "original_output": {
+          "name": "original_output",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "editable_proposal": {
+          "name": "editable_proposal",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "model_metadata": {
+          "name": "model_metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_by_user_id": {
+          "name": "resolved_by_user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "call_notes_enrichment_runs_call_created_idx": {
+          "name": "call_notes_enrichment_runs_call_created_idx",
+          "columns": [
+            {
+              "expression": "call_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_enrichment_runs_company_status_idx": {
+          "name": "call_notes_enrichment_runs_company_status_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_enrichment_runs_one_active_unique": {
+          "name": "call_notes_enrichment_runs_one_active_unique",
+          "columns": [
+            {
+              "expression": "call_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pdr_ai_v2_call_notes_enrichment_runs\".\"status\" in ('queued', 'generating', 'ready')",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_call_notes_enrichment_runs_call_id_pdr_ai_v2_call_notes_calls_id_fk": {
+          "name": "pdr_ai_v2_call_notes_enrichment_runs_call_id_pdr_ai_v2_call_notes_calls_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_enrichment_runs",
+          "tableTo": "pdr_ai_v2_call_notes_calls",
+          "columnsFrom": [
+            "call_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_enrichment_runs_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_call_notes_enrichment_runs_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_enrichment_runs",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_call_notes_gaps": {
+      "name": "pdr_ai_v2_call_notes_gaps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "call_id": {
+          "name": "call_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "capture_id": {
+          "name": "capture_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "call_notes_gaps_call_started_idx": {
+          "name": "call_notes_gaps_call_started_idx",
+          "columns": [
+            {
+              "expression": "call_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_call_notes_gaps_call_id_pdr_ai_v2_call_notes_calls_id_fk": {
+          "name": "pdr_ai_v2_call_notes_gaps_call_id_pdr_ai_v2_call_notes_calls_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_gaps",
+          "tableTo": "pdr_ai_v2_call_notes_calls",
+          "columnsFrom": [
+            "call_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_gaps_capture_id_pdr_ai_v2_call_notes_captures_id_fk": {
+          "name": "pdr_ai_v2_call_notes_gaps_capture_id_pdr_ai_v2_call_notes_captures_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_gaps",
+          "tableTo": "pdr_ai_v2_call_notes_captures",
+          "columnsFrom": [
+            "capture_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_gaps_attempt_id_pdr_ai_v2_call_notes_capture_attempts_id_fk": {
+          "name": "pdr_ai_v2_call_notes_gaps_attempt_id_pdr_ai_v2_call_notes_capture_attempts_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_gaps",
+          "tableTo": "pdr_ai_v2_call_notes_capture_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_gaps_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_call_notes_gaps_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_gaps",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_call_notes_note_revisions": {
+      "name": "pdr_ai_v2_call_notes_note_revisions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "call_id": {
+          "name": "call_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "document_note_id": {
+          "name": "document_note_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revision": {
+          "name": "revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "origin": {
+          "name": "origin",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enrichment_run_id": {
+          "name": "enrichment_run_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_markdown": {
+          "name": "content_markdown",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_rich": {
+          "name": "content_rich",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_user_id": {
+          "name": "created_by_user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "call_notes_note_revisions_call_revision_unique": {
+          "name": "call_notes_note_revisions_call_revision_unique",
+          "columns": [
+            {
+              "expression": "call_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "revision",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_note_revisions_document_note_idx": {
+          "name": "call_notes_note_revisions_document_note_idx",
+          "columns": [
+            {
+              "expression": "document_note_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_call_notes_note_revisions_call_id_pdr_ai_v2_call_notes_calls_id_fk": {
+          "name": "pdr_ai_v2_call_notes_note_revisions_call_id_pdr_ai_v2_call_notes_calls_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_note_revisions",
+          "tableTo": "pdr_ai_v2_call_notes_calls",
+          "columnsFrom": [
+            "call_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_note_revisions_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_call_notes_note_revisions_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_note_revisions",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_note_revisions_enrichment_run_id_pdr_ai_v2_call_notes_enrichment_runs_id_fk": {
+          "name": "pdr_ai_v2_call_notes_note_revisions_enrichment_run_id_pdr_ai_v2_call_notes_enrichment_runs_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_note_revisions",
+          "tableTo": "pdr_ai_v2_call_notes_enrichment_runs",
+          "columnsFrom": [
+            "enrichment_run_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_call_notes_participants": {
+      "name": "pdr_ai_v2_call_notes_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "call_id": {
+          "name": "call_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_participant_key": {
+          "name": "provider_participant_key",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_session_key": {
+          "name": "provider_session_key",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "observed_at": {
+          "name": "observed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "left_at": {
+          "name": "left_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "call_notes_participants_attempt_key_idx": {
+          "name": "call_notes_participants_attempt_key_idx",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_participant_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_participants_call_observed_idx": {
+          "name": "call_notes_participants_call_observed_idx",
+          "columns": [
+            {
+              "expression": "call_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "observed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_call_notes_participants_call_id_pdr_ai_v2_call_notes_calls_id_fk": {
+          "name": "pdr_ai_v2_call_notes_participants_call_id_pdr_ai_v2_call_notes_calls_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_participants",
+          "tableTo": "pdr_ai_v2_call_notes_calls",
+          "columnsFrom": [
+            "call_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_participants_attempt_id_pdr_ai_v2_call_notes_capture_attempts_id_fk": {
+          "name": "pdr_ai_v2_call_notes_participants_attempt_id_pdr_ai_v2_call_notes_capture_attempts_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_participants",
+          "tableTo": "pdr_ai_v2_call_notes_capture_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_participants_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_call_notes_participants_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_participants",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_call_notes_transcript_segments": {
+      "name": "pdr_ai_v2_call_notes_transcript_segments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "call_id": {
+          "name": "call_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempt_id": {
+          "name": "attempt_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "participant_id": {
+          "name": "participant_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_event_key": {
+          "name": "provider_event_key",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_packet_hash": {
+          "name": "source_packet_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_kind": {
+          "name": "source_kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "speaker_name": {
+          "name": "speaker_name",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_start_ms": {
+          "name": "provider_start_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_end_ms": {
+          "name": "provider_end_ms",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "received_at": {
+          "name": "received_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "receive_order": {
+          "name": "receive_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "text": {
+          "name": "text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "language": {
+          "name": "language",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "call_notes_segments_attempt_packet_unique": {
+          "name": "call_notes_segments_attempt_packet_unique",
+          "columns": [
+            {
+              "expression": "attempt_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_packet_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_segments_call_order_idx": {
+          "name": "call_notes_segments_call_order_idx",
+          "columns": [
+            {
+              "expression": "call_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_start_ms",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "receive_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_segments_company_received_idx": {
+          "name": "call_notes_segments_company_received_idx",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "received_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_call_notes_transcript_segments_call_id_pdr_ai_v2_call_notes_calls_id_fk": {
+          "name": "pdr_ai_v2_call_notes_transcript_segments_call_id_pdr_ai_v2_call_notes_calls_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_transcript_segments",
+          "tableTo": "pdr_ai_v2_call_notes_calls",
+          "columnsFrom": [
+            "call_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_transcript_segments_attempt_id_pdr_ai_v2_call_notes_capture_attempts_id_fk": {
+          "name": "pdr_ai_v2_call_notes_transcript_segments_attempt_id_pdr_ai_v2_call_notes_capture_attempts_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_transcript_segments",
+          "tableTo": "pdr_ai_v2_call_notes_capture_attempts",
+          "columnsFrom": [
+            "attempt_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_transcript_segments_participant_id_pdr_ai_v2_call_notes_participants_id_fk": {
+          "name": "pdr_ai_v2_call_notes_transcript_segments_participant_id_pdr_ai_v2_call_notes_participants_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_transcript_segments",
+          "tableTo": "pdr_ai_v2_call_notes_participants",
+          "columnsFrom": [
+            "participant_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_transcript_segments_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_call_notes_transcript_segments_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_transcript_segments",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_call_notes_work_items": {
+      "name": "pdr_ai_v2_call_notes_work_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "call_id": {
+          "name": "call_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "capture_id": {
+          "name": "capture_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "varchar(32)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "idempotency_key": {
+          "name": "idempotency_key",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "lease_token": {
+          "name": "lease_token",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_owner": {
+          "name": "lease_owner",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lease_expires_at": {
+          "name": "lease_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_code": {
+          "name": "error_code",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "available_at": {
+          "name": "available_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "call_notes_work_items_company_kind_key_unique": {
+          "name": "call_notes_work_items_company_kind_key_unique",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "kind",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "idempotency_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_work_items_claim_idx": {
+          "name": "call_notes_work_items_claim_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "available_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "lease_expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_work_items_call_created_idx": {
+          "name": "call_notes_work_items_call_created_idx",
+          "columns": [
+            {
+              "expression": "call_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_call_notes_work_items_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_call_notes_work_items_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_work_items",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_work_items_call_id_pdr_ai_v2_call_notes_calls_id_fk": {
+          "name": "pdr_ai_v2_call_notes_work_items_call_id_pdr_ai_v2_call_notes_calls_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_work_items",
+          "tableTo": "pdr_ai_v2_call_notes_calls",
+          "columnsFrom": [
+            "call_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pdr_ai_v2_call_notes_work_items_capture_id_pdr_ai_v2_call_notes_captures_id_fk": {
+          "name": "pdr_ai_v2_call_notes_work_items_capture_id_pdr_ai_v2_call_notes_captures_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_work_items",
+          "tableTo": "pdr_ai_v2_call_notes_captures",
+          "columnsFrom": [
+            "capture_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pdr_ai_v2_call_notes_zoom_connections": {
+      "name": "pdr_ai_v2_call_notes_zoom_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "company_id": {
+          "name": "company_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zoom_account_id": {
+          "name": "zoom_account_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "zoom_user_id": {
+          "name": "zoom_user_id",
+          "type": "varchar(256)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_access_token": {
+          "name": "encrypted_access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_refresh_token": {
+          "name": "encrypted_refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(24)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "call_notes_zoom_connections_company_user_unique": {
+          "name": "call_notes_zoom_connections_company_user_unique",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "call_notes_zoom_connections_company_zoom_user_unique": {
+          "name": "call_notes_zoom_connections_company_zoom_user_unique",
+          "columns": [
+            {
+              "expression": "company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "zoom_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pdr_ai_v2_call_notes_zoom_connections_company_id_pdr_ai_v2_company_id_fk": {
+          "name": "pdr_ai_v2_call_notes_zoom_connections_company_id_pdr_ai_v2_company_id_fk",
+          "tableFrom": "pdr_ai_v2_call_notes_zoom_connections",
+          "tableTo": "pdr_ai_v2_company",
+          "columnsFrom": [
+            "company_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/web/drizzle/meta/_journal.json
+++ b/apps/web/drizzle/meta/_journal.json
@@ -36,6 +36,27 @@
       "when": 1786683913812,
       "tag": "20260814050513_email_pipeline",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1787188199398,
+      "tag": "20260820010959_simple_khan",
+      "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1787205296532,
+      "tag": "20260820055456_deep_veda",
+      "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1787205446269,
+      "tag": "20260820055726_famous_titanium_man",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/web/scripts/call-notes-kimi-smoke-adapter.ts
+++ b/apps/web/scripts/call-notes-kimi-smoke-adapter.ts
@@ -1,0 +1,127 @@
+/**
+ * Developer-only Kimi adapter for the opt-in Call Notes live smoke.
+ * This file intentionally does not participate in production dependency
+ * injection or the configured reasoning route.
+ */
+
+import { HumanMessage, SystemMessage } from "@langchain/core/messages";
+import {
+    createChatModelsConfig,
+    invokeStructured,
+    resolveChatModel,
+    type ResolvedChatModel,
+} from "@launchstack/core/llm";
+import {
+    EnrichedNoteProposalSchema,
+    EnrichmentInputSchema,
+    EnrichmentResultSchema,
+    type EnrichmentInput,
+    type EnrichmentModel,
+    type EnrichmentResult,
+} from "@launchstack/features/call-notes";
+
+import {
+    buildCallNotesEnrichmentPrompt,
+    CALL_NOTES_ENRICHMENT_PROMPT_VERSION,
+    CALL_NOTES_ENRICHMENT_SYSTEM_PROMPT,
+} from "../src/server/call-notes/enrichment-prompts";
+import { validateEnrichmentProvenance } from "../src/server/call-notes/enrichment-validation";
+
+export const KIMI_SMOKE_DEFAULT_BASE_URL = "https://api.moonshot.ai/v1" as const;
+export const KIMI_SMOKE_DEFAULT_MODEL = "kimi-k2.6" as const;
+
+export interface KimiSmokeConfig {
+    baseUrl: string;
+    apiKey: string;
+    model: string;
+}
+
+function nonEmpty(value: string | undefined): string | undefined {
+    const trimmed = value?.trim();
+    if (!trimmed) return undefined;
+    return trimmed;
+}
+
+export function readKimiSmokeConfig(environment: NodeJS.ProcessEnv = process.env): KimiSmokeConfig {
+    const apiKey = nonEmpty(environment.KIMI_API_KEY);
+    if (!apiKey) {
+        throw new Error("KIMI_API_KEY is required for the Kimi smoke.");
+    }
+
+    return {
+        baseUrl: nonEmpty(environment.KIMI_BASE_URL) ?? KIMI_SMOKE_DEFAULT_BASE_URL,
+        apiKey,
+        model: nonEmpty(environment.KIMI_MODEL) ?? KIMI_SMOKE_DEFAULT_MODEL,
+    };
+}
+
+function createKimiChatConfig(config: KimiSmokeConfig) {
+    const yaml = `version: 1
+models:
+  kimi:
+    id: ${JSON.stringify(config.model)}
+    behavior:
+      input: [text]
+      reasoning:
+        mode: always
+      nativeStructuredOutput: []
+      parameters:
+        temperature: supported
+        systemMessages: supported
+        streaming: unsupported
+        maxOutputTokens: supported
+routes:
+  default: kimi
+  reasoning: kimi
+`;
+
+    return createChatModelsConfig({
+        yaml,
+        endpoint: { baseUrl: config.baseUrl, apiKey: config.apiKey },
+        sourceLabel: "developer Kimi Call Notes smoke configuration",
+    });
+}
+
+export class KimiSmokeEnrichmentModel implements EnrichmentModel {
+    readonly providerLabel = "kimi-smoke" as const;
+    readonly modelId: string;
+    readonly structuredOutputPath = "validated JSON fallback" as const;
+    private readonly resolved: ResolvedChatModel;
+    private _providerRequestAttempted = false;
+
+    constructor(config: KimiSmokeConfig) {
+        this.resolved = resolveChatModel({
+            route: "reasoning",
+            config: createKimiChatConfig(config),
+        });
+        this.modelId = this.resolved.modelId;
+    }
+
+    get providerRequestAttempted(): boolean {
+        return this._providerRequestAttempted;
+    }
+
+    async generate(rawInput: EnrichmentInput): Promise<EnrichmentResult> {
+        const input = EnrichmentInputSchema.parse(rawInput);
+        this._providerRequestAttempted = true;
+
+        const proposal = await invokeStructured(
+            this.resolved,
+            EnrichedNoteProposalSchema,
+            [
+                new SystemMessage(CALL_NOTES_ENRICHMENT_SYSTEM_PROMPT),
+                new HumanMessage(buildCallNotesEnrichmentPrompt(input)),
+            ],
+            { name: "call_notes_enrichment_v1" }
+        );
+        const validatedProposal = validateEnrichmentProvenance(input, proposal);
+
+        return EnrichmentResultSchema.parse({
+            proposal: validatedProposal,
+            modelMetadata: {
+                model: this.modelId,
+                promptVersion: CALL_NOTES_ENRICHMENT_PROMPT_VERSION,
+            },
+        });
+    }
+}

--- a/apps/web/scripts/run-call-notes-enrichment-smoke.ts
+++ b/apps/web/scripts/run-call-notes-enrichment-smoke.ts
@@ -1,0 +1,279 @@
+#!/usr/bin/env tsx
+
+/**
+ * LIVE / OPT-IN Call Notes A1 configured-model smoke.
+ *
+ * This script invokes the configured reasoning model once through the same
+ * adapter used by the A1 enrichment core. It never imports persistence,
+ * lifecycle, KnowledgeNoteSink, or embedding code.
+ *
+ * Run from apps/web with:
+ *   CALL_NOTES_ENRICHMENT_SMOKE=1 pnpm exec tsx scripts/run-call-notes-enrichment-smoke.ts
+ */
+
+import "dotenv/config";
+import { performance } from "node:perf_hooks";
+import { fileURLToPath } from "node:url";
+
+import { pickNativeStructuredMode, StructuredOutputError } from "@launchstack/core/llm";
+import {
+    CALL_NOTES_ENRICHMENT_SCHEMA_VERSION,
+    EnrichedNoteProposalSchema,
+    EnrichmentInputSchema,
+    EnrichmentResultSchema,
+    type EnrichmentInput,
+    type EnrichmentResult,
+} from "@launchstack/features/call-notes";
+import { ZodError } from "zod";
+
+import { EnrichmentProvenanceValidationError } from "../src/server/call-notes/enrichment-validation";
+
+const SMOKE_OPT_IN = "CALL_NOTES_ENRICHMENT_SMOKE";
+
+export function createCallNotesSmokeInput(): EnrichmentInput {
+    return EnrichmentInputSchema.parse({
+        schemaVersion: CALL_NOTES_ENRICHMENT_SCHEMA_VERSION,
+        callId: "call-smoke-2026-08-21",
+        transcriptFingerprint: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        transcript: [
+            {
+                id: "segment-owner-1",
+                attemptId: "attempt-smoke-1",
+                participantId: "participant-owner",
+                speakerName: "Alex Founder",
+                providerStartMs: 60_000,
+                providerEndMs: 66_000,
+                receivedAt: "2026-08-21T09:01:06.000Z",
+                receiveOrder: 1,
+                text: "We agreed that the onboarding checklist is the next launch blocker.",
+                language: "en",
+            },
+            {
+                id: "segment-guest-1",
+                attemptId: "attempt-smoke-1",
+                participantId: "participant-guest",
+                speakerName: "Maya Customer",
+                providerStartMs: 72_000,
+                providerEndMs: 79_000,
+                receivedAt: "2026-08-21T09:01:19.000Z",
+                receiveOrder: 2,
+                text: "A short walkthrough would help our team complete onboarding before September.",
+                language: "en",
+            },
+            {
+                id: "segment-owner-2",
+                attemptId: "attempt-smoke-1",
+                participantId: "participant-owner",
+                speakerName: "Alex Founder",
+                providerStartMs: 300_000,
+                providerEndMs: 307_000,
+                receivedAt: "2026-08-21T09:05:07.000Z",
+                receiveOrder: 3,
+                text: "I will send the revised onboarding checklist by Friday.",
+                language: "en",
+            },
+            {
+                id: "segment-guest-2",
+                attemptId: "attempt-smoke-1",
+                participantId: "participant-guest",
+                speakerName: "Maya Customer",
+                providerStartMs: 315_000,
+                providerEndMs: 321_000,
+                receivedAt: "2026-08-21T09:05:21.000Z",
+                receiveOrder: 4,
+                text: "That checklist and a short walkthrough should unblock our team.",
+                language: "en",
+            },
+        ],
+        gaps: [
+            {
+                id: "gap-smoke-pause",
+                attemptId: "attempt-smoke-1",
+                kind: "user_paused",
+                startedAt: "2026-08-21T09:02:00.000Z",
+                endedAt: "2026-08-21T09:04:00.000Z",
+            },
+        ],
+        bookmarks: [
+            {
+                id: "bookmark-smoke-decision",
+                segmentId: "segment-owner-1",
+                comment:
+                    "Please preserve the agreed onboarding blocker and connect it to the next action.",
+                createdAt: "2026-08-21T09:01:30.000Z",
+            },
+        ],
+        note: {
+            documentNoteId: 42021,
+            ownerUserId: "user-smoke-owner",
+            visibility: "company",
+            knowledgeIncluded: false,
+            revision: 4,
+            title: "Customer onboarding review",
+            contentMarkdown:
+                "- Reduce onboarding time before September.\n- Follow up on the checklist and walkthrough.",
+            contentRich: { type: "doc", content: [] },
+            saveState: "saved",
+        },
+    });
+}
+
+function oneLine(value: string, maxLength = 360): string {
+    const normalized = value.replace(/\s+/g, " ").trim();
+    return normalized.length <= maxLength
+        ? normalized
+        : `${normalized.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
+function errorCategory(error: unknown): string {
+    if (error instanceof EnrichmentProvenanceValidationError) return "semantic provenance failure";
+    if (error instanceof StructuredOutputError) return "structured-output failure";
+    if (error instanceof ZodError) return "Zod validation failure";
+
+    const name = error instanceof Error ? error.name : "";
+    if (/Configuration|RouteUnavailable|ChatRequest/.test(name)) return "route/config failure";
+    return "provider/API failure";
+}
+
+function printReport(lines: readonly string[]): void {
+    console.log(["CALL NOTES A1 CONFIGURED-MODEL SMOKE", ...lines].join("\n"));
+}
+
+function printSuccess(
+    result: EnrichmentResult,
+    modelId: string,
+    structuredPath: string,
+    elapsedMs: number
+): void {
+    const proposal = EnrichedNoteProposalSchema.parse(result.proposal);
+    const citations = proposal.bookmarkPassages.flatMap(passage => passage.citations);
+    printReport([
+        "status: PASS",
+        "route: reasoning",
+        `resolvedModelId: ${modelId}`,
+        "provider/operator metadata: not exposed",
+        `promptVersion: ${result.modelMetadata.promptVersion}`,
+        `structuredOutputPath: ${structuredPath}`,
+        "structuredProposalValidation: PASS",
+        "semanticProvenanceValidation: PASS",
+        "finalEnrichmentResultValidation: PASS",
+        `summary: ${oneLine(proposal.summary)}`,
+        `actionItemCount: ${proposal.actionItems.length}`,
+        `decisionOrKeyPointCount: ${proposal.chronologicalSections.length}`,
+        `bookmarkCitationCount: ${citations.length}`,
+        `bookmarkCitationIds: ${citations.map(citation => citation.bookmarkId).join(", ") || "none"}`,
+        `elapsedMs: ${Math.round(elapsedMs)}`,
+    ]);
+}
+
+async function loadSmokeRuntime() {
+    const enrichmentModel = await import("../src/server/call-notes/enrichment-model");
+    const models = await import("../src/lib/models");
+    const environment = await import("../src/env");
+    const endpoint = await import("../src/server/chat-endpoint");
+
+    return {
+        ConfiguredCallNotesEnrichmentModel: enrichmentModel.ConfiguredCallNotesEnrichmentModel,
+        CALL_NOTES_ENRICHMENT_ROUTE: enrichmentModel.CALL_NOTES_ENRICHMENT_ROUTE,
+        resolveConfiguredChatModel: models.resolveConfiguredChatModel,
+        env: environment.env,
+        resolveChatEndpoint: endpoint.resolveChatEndpoint,
+    };
+}
+
+async function runSmoke(): Promise<void> {
+    if (process.env[SMOKE_OPT_IN] !== "1") {
+        printReport([
+            "status: NOT RUN",
+            `opt-in required: set ${SMOKE_OPT_IN}=1 to authorize the single live invocation`,
+        ]);
+        process.exitCode = 2;
+        return;
+    }
+
+    const input = createCallNotesSmokeInput();
+    const startedAt = performance.now();
+
+    let runtime: Awaited<ReturnType<typeof loadSmokeRuntime>>;
+    try {
+        runtime = await loadSmokeRuntime();
+    } catch (error) {
+        printReport([
+            "status: FAIL",
+            `errorCategory: ${errorCategory(error)}`,
+            "route: reasoning",
+            "resolvedModelId: unavailable",
+            "no model invocation was attempted",
+        ]);
+        process.exitCode = 1;
+        return;
+    }
+
+    const {
+        ConfiguredCallNotesEnrichmentModel,
+        CALL_NOTES_ENRICHMENT_ROUTE,
+        resolveConfiguredChatModel,
+        env,
+        resolveChatEndpoint,
+    } = runtime;
+
+    let resolved: ReturnType<typeof resolveConfiguredChatModel>;
+    try {
+        resolved = resolveConfiguredChatModel({ route: CALL_NOTES_ENRICHMENT_ROUTE });
+    } catch (error) {
+        printReport([
+            "status: FAIL",
+            `errorCategory: ${errorCategory(error)}`,
+            `route: ${CALL_NOTES_ENRICHMENT_ROUTE}`,
+            "resolvedModelId: unavailable",
+            "no model invocation was attempted",
+        ]);
+        process.exitCode = 1;
+        return;
+    }
+
+    const nativeMode = pickNativeStructuredMode(resolved.behavior.nativeStructuredOutput);
+    const structuredPath =
+        nativeMode === "json-schema"
+            ? "validated JSON fallback (optional/defaulted schema compatibility guard)"
+            : nativeMode
+              ? `${nativeMode} native structured output`
+              : "validated JSON fallback";
+
+    const endpoint = resolveChatEndpoint(env.server);
+    if (!endpoint.apiKey && endpoint.baseUrl.includes("generativelanguage.googleapis.com")) {
+        printReport([
+            "status: FAIL",
+            "errorCategory: route/config failure",
+            `route: ${CALL_NOTES_ENRICHMENT_ROUTE}`,
+            `resolvedModelId: ${resolved.modelId}`,
+            "configuration: default Gemini endpoint selected but no chat credential is configured",
+            "required configuration: GOOGLE_AI_API_KEY, or CHAT_BASE_URL together with CHAT_API_KEY",
+            "no model invocation was attempted",
+        ]);
+        process.exitCode = 1;
+        return;
+    }
+
+    try {
+        // Exactly one A1 generation call. invokeStructured may perform its one
+        // built-in repair attempt; this script never retries the operation.
+        const result = await new ConfiguredCallNotesEnrichmentModel().generate(input);
+        EnrichmentResultSchema.parse(result);
+        printSuccess(result, resolved.modelId, structuredPath, performance.now() - startedAt);
+    } catch (error) {
+        printReport([
+            "status: FAIL",
+            `errorCategory: ${errorCategory(error)}`,
+            `route: ${CALL_NOTES_ENRICHMENT_ROUTE}`,
+            `resolvedModelId: ${resolved.modelId}`,
+            `elapsedMs: ${Math.round(performance.now() - startedAt)}`,
+            "no retry was attempted by the smoke script",
+        ]);
+        process.exitCode = 1;
+    }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+    await runSmoke();
+}

--- a/apps/web/scripts/run-call-notes-kimi-smoke.ts
+++ b/apps/web/scripts/run-call-notes-kimi-smoke.ts
@@ -1,0 +1,294 @@
+#!/usr/bin/env tsx
+
+/**
+ * LIVE / OPT-IN developer Kimi Call Notes smoke.
+ *
+ * This uses an in-memory model configuration and the existing OpenAI-compatible
+ * transport. It never changes the production reasoning route or writes app
+ * state. Run from apps/web with:
+ *
+ *   CALL_NOTES_KIMI_SMOKE=1 pnpm exec tsx scripts/run-call-notes-kimi-smoke.ts
+ */
+
+import "dotenv/config";
+import { performance } from "node:perf_hooks";
+import { fileURLToPath } from "node:url";
+
+import { StructuredOutputError } from "@launchstack/core/llm";
+import {
+    EnrichedNoteProposalSchema,
+    EnrichmentResultSchema,
+} from "@launchstack/features/call-notes";
+import { ZodError } from "zod";
+
+import { EnrichmentProvenanceValidationError } from "../src/server/call-notes/enrichment-validation";
+import { createCallNotesSmokeInput } from "./run-call-notes-enrichment-smoke";
+import {
+    KimiSmokeEnrichmentModel,
+    readKimiSmokeConfig,
+    type KimiSmokeConfig,
+} from "./call-notes-kimi-smoke-adapter";
+
+const KIMI_SMOKE_OPT_IN = "CALL_NOTES_KIMI_SMOKE";
+
+function safeBaseUrl(value: string): string {
+    try {
+        const url = new URL(value);
+        return `${url.origin}${url.pathname}`.replace(/\/$/, "");
+    } catch {
+        return "invalid-url";
+    }
+}
+
+export interface SafeKimiDiagnostic {
+    errorClass: string;
+    httpStatus?: number;
+    providerErrorType?: string;
+    providerErrorCode?: string;
+    providerErrorMessage?: string;
+    requestUrl: string;
+    responsePhase: "before_http_response" | "after_http_response" | "unknown";
+}
+
+type UnknownRecord = Record<string, unknown>;
+
+function asRecord(value: unknown): UnknownRecord | undefined {
+    return typeof value === "object" && value !== null ? (value as UnknownRecord) : undefined;
+}
+
+function firstRecord(...values: unknown[]): UnknownRecord | undefined {
+    return values.map(asRecord).find((value): value is UnknownRecord => value !== undefined);
+}
+
+function safeText(value: unknown, maxLength = 500): string | undefined {
+    if (typeof value !== "string" || value.length === 0) return undefined;
+    const redacted = value
+        .replace(
+            /(["']?(?:authorization|bearer|api[_ -]?key|token|secret)["']?)\s*[:=]\s*["']?[^\s,;"'}]+/gi,
+            "$1=[redacted]"
+        )
+        .replace(/\b(?:sk|key|token|secret)[-_][A-Za-z0-9._~-]{8,}\b/gi, "[redacted]");
+    return redacted.length <= maxLength ? redacted : `${redacted.slice(0, maxLength - 1)}…`;
+}
+
+function numberField(...values: unknown[]): number | undefined {
+    for (const value of values) {
+        if (typeof value === "number" && Number.isInteger(value)) return value;
+        if (typeof value === "string" && /^\d{3}$/.test(value)) return Number(value);
+    }
+    return undefined;
+}
+
+function safeRequestUrl(baseUrl: string): string {
+    try {
+        const url = new URL(baseUrl);
+        return `${url.origin}${url.pathname.replace(/\/$/, "")}/chat/completions`;
+    } catch {
+        return "invalid-url/chat/completions";
+    }
+}
+
+function diagnosticText(diagnostic: SafeKimiDiagnostic): string {
+    return [
+        diagnostic.providerErrorType,
+        diagnostic.providerErrorCode,
+        diagnostic.providerErrorMessage,
+        diagnostic.errorClass,
+    ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+}
+
+export function normalizeKimiDiagnostic(
+    error: unknown,
+    config: KimiSmokeConfig
+): SafeKimiDiagnostic {
+    const root = asRecord(error);
+    const cause = asRecord(root?.cause);
+    const response = firstRecord(root?.response, cause?.response);
+    const body = firstRecord(root?.body, cause?.body, response?.body);
+    const providerError = firstRecord(root?.error, cause?.error, body?.error);
+    const errorClass =
+        error instanceof Error && error.constructor.name !== "Error"
+            ? error.constructor.name
+            : error instanceof Error
+              ? error.name
+              : typeof error;
+    const httpStatus = numberField(
+        root?.status,
+        root?.statusCode,
+        cause?.status,
+        cause?.statusCode,
+        response?.status,
+        providerError?.status
+    );
+    const providerErrorType = safeText(providerError?.type ?? root?.type ?? cause?.type, 120);
+    const providerErrorCode = safeText(providerError?.code ?? root?.code ?? cause?.code, 120);
+    const providerErrorMessage = safeText(
+        providerError?.message ?? body?.message ?? root?.message ?? cause?.message
+    );
+    const text = [providerErrorType, providerErrorCode, providerErrorMessage]
+        .filter(Boolean)
+        .join(" ");
+
+    return {
+        errorClass,
+        ...(httpStatus === undefined ? {} : { httpStatus }),
+        ...(providerErrorType === undefined ? {} : { providerErrorType }),
+        ...(providerErrorCode === undefined ? {} : { providerErrorCode }),
+        ...(providerErrorMessage === undefined ? {} : { providerErrorMessage }),
+        requestUrl: safeRequestUrl(config.baseUrl),
+        responsePhase:
+            httpStatus !== undefined || providerError || response
+                ? "after_http_response"
+                : /fetch failed|econn|enotfound|etimedout|socket hang up|timeout|timed ?out|network/i.test(
+                        text
+                    )
+                  ? "before_http_response"
+                  : "unknown",
+    };
+}
+
+export function classifyKimiFailure(error: unknown, diagnostic: SafeKimiDiagnostic): string {
+    if (error instanceof EnrichmentProvenanceValidationError) return "semantic_provenance";
+    if (error instanceof StructuredOutputError) return "structured_output";
+    if (error instanceof ZodError) return "schema_validation";
+
+    const text = diagnosticText(diagnostic);
+    const status = diagnostic.httpStatus;
+    if (
+        status === 401 ||
+        status === 403 ||
+        /authentication|unauthorized|invalid api key|credential/.test(text)
+    ) {
+        return "credential/authentication";
+    }
+    if (
+        status === 402 ||
+        /billing|insufficient balance|insufficient funds|payment required/.test(text)
+    ) {
+        return "quota/billing";
+    }
+    if (status === 429) return /quota|balance|billing/.test(text) ? "quota/billing" : "rate_limit";
+    if (status === 404 && /model|deployment|engine/.test(text)) return "model_not_found";
+    if (
+        /model[_ -]?not[_ -]?found|unknown model|does not exist|no such model|invalid model/.test(
+            text
+        )
+    ) {
+        return "model_not_found";
+    }
+    if (diagnostic.responsePhase === "before_http_response") return "network";
+    if (status !== undefined && status >= 500) return "provider_internal";
+    if (status === 400) {
+        return /response[_ -]?format|json schema|structured|tool/.test(text)
+            ? "transport_compatibility"
+            : "invalid_request";
+    }
+    if (/response[_ -]?format|json schema|structured|tool calling/.test(text)) {
+        return "transport_compatibility";
+    }
+    if (status !== undefined && status >= 400) return "endpoint";
+    return "unknown";
+}
+
+function report(lines: readonly string[]): void {
+    console.log(["CALL NOTES A3 KIMI SMOKE", ...lines].join("\n"));
+}
+
+async function run(): Promise<void> {
+    if (process.env[KIMI_SMOKE_OPT_IN] !== "1") {
+        report([
+            "status: NOT RUN",
+            `opt-in required: set ${KIMI_SMOKE_OPT_IN}=1 to authorize the single live Kimi attempt`,
+        ]);
+        process.exitCode = 2;
+        return;
+    }
+
+    let config;
+    try {
+        config = readKimiSmokeConfig();
+    } catch {
+        report([
+            "status: FAIL",
+            "provider: Kimi / Moonshot",
+            "endpoint: https://api.moonshot.ai/v1",
+            "model: unavailable",
+            `failureClass: credential/authentication`,
+            "actualLiveRequest: false",
+            "no provider request was attempted",
+        ]);
+        process.exitCode = 1;
+        return;
+    }
+
+    const adapter = new KimiSmokeEnrichmentModel(config);
+    const input = createCallNotesSmokeInput();
+    const startedAt = performance.now();
+
+    try {
+        // Exactly one adapter generation attempt. The shared structured-output
+        // layer may perform its one built-in repair request; this script never
+        // retries the generation operation.
+        const result = await adapter.generate(input);
+        const finalResult = EnrichmentResultSchema.parse(result);
+        const proposal = EnrichedNoteProposalSchema.parse(finalResult.proposal);
+        const citations = proposal.bookmarkPassages.flatMap(passage => passage.citations);
+
+        report([
+            "status: PASS",
+            "provider: Kimi / Moonshot",
+            `endpoint: ${safeBaseUrl(config.baseUrl)}`,
+            `model: ${config.model}`,
+            `actualLiveRequest: ${adapter.providerRequestAttempted}`,
+            "invocationPath: EnrichmentInput -> production A1 prompt -> developer Kimi adapter -> shared structured output -> provenance validator -> EnrichmentResult",
+            `structuredOutputPath: ${adapter.structuredOutputPath}`,
+            `promptVersion: ${finalResult.modelMetadata.promptVersion}`,
+            "provider/operator metadata: kimi-smoke (local output label only; not persisted)",
+            "structuredProposalValidation: PASS",
+            "semanticProvenanceValidation: PASS",
+            "finalEnrichmentResultValidation: PASS",
+            `proposalSummary: ${proposal.summary.replace(/\s+/g, " ").trim().slice(0, 360)}`,
+            `actionItems: ${proposal.actionItems.length}`,
+            `keyDecisionsOrPoints: ${proposal.chronologicalSections.length}`,
+            `bookmarkCitations: ${citations.length} (${citations.map(citation => citation.bookmarkId).join(", ") || "none"})`,
+            `elapsedMs: ${Math.round(performance.now() - startedAt)}`,
+            "persistenceMutation: false",
+        ]);
+    } catch (error) {
+        const diagnostic = normalizeKimiDiagnostic(error, config);
+        report([
+            "status: FAIL",
+            "provider: Kimi / Moonshot",
+            `endpoint: ${safeBaseUrl(config.baseUrl)}`,
+            `model: ${config.model}`,
+            `actualLiveRequest: ${adapter.providerRequestAttempted}`,
+            `failureClass: ${classifyKimiFailure(error, diagnostic)}`,
+            `elapsedMs: ${Math.round(performance.now() - startedAt)}`,
+            `errorClass: ${diagnostic.errorClass}`,
+            ...(diagnostic.httpStatus === undefined
+                ? []
+                : [`httpStatus: ${diagnostic.httpStatus}`]),
+            ...(diagnostic.providerErrorType === undefined
+                ? []
+                : [`providerErrorType: ${diagnostic.providerErrorType}`]),
+            ...(diagnostic.providerErrorCode === undefined
+                ? []
+                : [`providerErrorCode: ${diagnostic.providerErrorCode}`]),
+            ...(diagnostic.providerErrorMessage === undefined
+                ? []
+                : [`providerErrorMessage: ${diagnostic.providerErrorMessage}`]),
+            `requestUrl: ${diagnostic.requestUrl}`,
+            `responsePhase: ${diagnostic.responsePhase}`,
+            "no retry was attempted by the smoke script",
+            "persistenceMutation: false",
+        ]);
+        process.exitCode = 1;
+    }
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+    await run();
+}

--- a/apps/web/src/app/api/agents/documentQ&A/AskMyNotes/route.ts
+++ b/apps/web/src/app/api/agents/documentQ&A/AskMyNotes/route.ts
@@ -7,17 +7,12 @@
  */
 
 import { NextResponse } from "next/server";
-import { OpenAIEmbeddings } from "@langchain/openai";
 import { HumanMessage, SystemMessage } from "@langchain/core/messages";
 import { withRateLimit } from "~/lib/rate-limit-middleware";
 import { RateLimitPresets } from "~/lib/rate-limiter";
 import { resolveConfiguredChatModel } from "~/lib/models";
 import { createUserNotesRetriever } from "~/lib/tools/rag/retrievers/notes-retriever";
-import {
-    EMBEDDING_DIM,
-    EMBEDDING_MODEL,
-    resolveEmbeddingConfig,
-} from "~/server/notes/embedding-config";
+import { resolveNoteEmbeddingRuntime } from "~/server/notes/embedding-config";
 import { normalizeModelContent } from "../services";
 import { requireWorkspaceContext } from "~/lib/require-workspace-context";
 
@@ -55,8 +50,8 @@ export async function POST(request: Request) {
             }
             const topK = Math.min(Math.max(body.topK ?? 8, 1), 25);
 
-            const { apiKey, baseURL } = resolveEmbeddingConfig();
-            if (!apiKey) {
+            const noteEmbeddingRuntime = resolveNoteEmbeddingRuntime();
+            if (!noteEmbeddingRuntime) {
                 return NextResponse.json(
                     {
                         success: false,
@@ -67,17 +62,10 @@ export async function POST(request: Request) {
                 );
             }
 
-            const embeddings = new OpenAIEmbeddings({
-                openAIApiKey: apiKey,
-                modelName: EMBEDDING_MODEL,
-                dimensions: EMBEDDING_DIM,
-                ...(baseURL ? { configuration: { baseURL } } : {}),
-            });
-
             const retriever = createUserNotesRetriever(
                 ctx.data.clerkUserId,
                 String(ctx.data.companyId),
-                embeddings,
+                noteEmbeddingRuntime.embeddings,
                 topK
             );
             const docs = await retriever.invoke(question);

--- a/apps/web/src/app/prototypes/call-notes/CallNotesPrototype.tsx
+++ b/apps/web/src/app/prototypes/call-notes/CallNotesPrototype.tsx
@@ -1,0 +1,1287 @@
+"use client";
+
+import {
+    Bookmark,
+    Check,
+    ChevronDown,
+    ChevronRight,
+    Clock3,
+    Eye,
+    EyeOff,
+    FileText,
+    Link2,
+    LockKeyhole,
+    Menu,
+    MoreHorizontal,
+    Pause,
+    Pencil,
+    Play,
+    Plus,
+    Radio,
+    RefreshCcw,
+    Search,
+    ShieldCheck,
+    Sparkles,
+    Users,
+    X,
+} from "lucide-react";
+import React, {
+    type FormEvent,
+    type ReactNode,
+    useCallback,
+    useEffect,
+    useRef,
+    useState,
+} from "react";
+import styles from "./call-notes-prototype.module.css";
+
+type Scenario = "detected" | "failure" | "review";
+type CaptureStatus = "idle" | "connecting" | "live" | "paused" | "failed" | "completed";
+type Visibility = "company" | "private";
+type TranscriptSegment = { id: string; speaker: string; timestamp: string; text: string };
+type GapMarker = { id: string; label: string; duration: string; afterSegmentId: string | null };
+type BookmarkRecord = { segmentId: string; comment: string };
+type CallRecord = {
+    id: string;
+    title: string;
+    providerTopic: string;
+    status: CaptureStatus;
+    outcome: "ready" | "partial" | "completed";
+    owner: string;
+    company: string;
+    note: string;
+    noteRevision: number;
+    visibility: Visibility;
+    segments: TranscriptSegment[];
+    gaps: GapMarker[];
+    bookmarks: BookmarkRecord[];
+    proposal: string;
+    enrichmentReady: boolean;
+};
+
+type Engine = {
+    call: CallRecord;
+    setCall: React.Dispatch<React.SetStateAction<CallRecord>>;
+    detectedNotice: boolean;
+    dismissDetected: () => void;
+    startDetected: () => void;
+    manualOpen: boolean;
+    openManualStart: () => void;
+    closeManualStart: () => void;
+    startManual: (value: string) => void;
+    manualError: string;
+    retryCapture: () => void;
+    deleteFailedCall: () => void;
+    noteDraft: string;
+    updateNote: (value: string) => void;
+    saveState: "saved" | "saving";
+    viewerMode: boolean;
+    setViewerMode: React.Dispatch<React.SetStateAction<boolean>>;
+    reviewOpen: boolean;
+    openReview: () => void;
+    acceptProposal: (proposal: string) => void;
+    rejectProposal: () => void;
+    toast: string;
+    setToast: React.Dispatch<React.SetStateAction<string>>;
+    bookmarkTarget: string | null;
+    openBookmark: (segmentId: string) => void;
+    closeBookmark: () => void;
+    saveBookmark: (comment: string) => void;
+    evidenceOpen: boolean;
+    evidenceTarget: TranscriptSegment | null;
+    openEvidence: (segmentId?: string) => void;
+    closeEvidence: () => void;
+    pauseCapture: () => void;
+    resumeCapture: () => void;
+};
+
+export type CallNotesPrototypeProps = { initialScenario?: Scenario };
+
+const DEFAULT_TOPIC = "Northstar pricing review";
+const FAILURE_MESSAGE =
+    "Could not start RTMS. Zoom did not make a live transcript stream available.";
+const BASE_SEGMENTS: TranscriptSegment[] = [
+    {
+        id: "s1",
+        speaker: "Maya Chen",
+        timestamp: "00:42",
+        text: "Thanks for making time. We want to understand where the first launch cohort needs more confidence.",
+    },
+    {
+        id: "s2",
+        speaker: "Jordan Ellis",
+        timestamp: "01:18",
+        text: "The workflow is clear, but pricing still feels hard to explain to an operations lead in one sentence.",
+    },
+    {
+        id: "s3",
+        speaker: "Maya Chen",
+        timestamp: "02:14",
+        text: "If we can keep the launch plan focused on one measurable outcome, our team can champion it internally.",
+    },
+    {
+        id: "s4",
+        speaker: "Priya Shah",
+        timestamp: "03:07",
+        text: "A short pilot with the current team would give us the evidence we need before broadening the rollout.",
+    },
+];
+const STREAM_SEGMENTS: TranscriptSegment[] = [
+    {
+        id: "s5",
+        speaker: "Jordan Ellis",
+        timestamp: "04:02",
+        text: "The other question is how much guidance the first workspace gets during setup.",
+    },
+    {
+        id: "s6",
+        speaker: "Maya Chen",
+        timestamp: "04:39",
+        text: "Let us make the success check visible on day one and revisit the wider rollout next week.",
+    },
+    {
+        id: "s7",
+        speaker: "Priya Shah",
+        timestamp: "05:21",
+        text: "That gives us a sensible path: one pilot, one outcome, then a shared decision.",
+    },
+];
+const REVIEW_NOTE =
+    "Launch the focused pricing pilot with the first cohort. Keep the onboarding promise concrete, name one success signal, and revisit expansion after the team has evidence from the first week.";
+const REVIEW_PROPOSAL =
+    "Launch a focused pricing pilot with the first cohort, anchored on a single measurable outcome. Keep the onboarding promise concrete, then use the first week of evidence to decide whether to expand. The team can champion the workflow when the success check is visible.";
+
+function createCall(scenario: Scenario): CallRecord {
+    const base = {
+        title: DEFAULT_TOPIC,
+        providerTopic: DEFAULT_TOPIC,
+        owner: "You",
+        company: "Northstar Labs",
+        noteRevision: 1,
+        visibility: "company" as const,
+        gaps: [] as GapMarker[],
+    };
+    if (scenario === "failure")
+        return {
+            ...base,
+            id: "call-failure",
+            status: "failed",
+            outcome: "ready",
+            note: "",
+            segments: [],
+            bookmarks: [],
+            proposal: "",
+            enrichmentReady: false,
+        };
+    if (scenario === "review")
+        return {
+            ...base,
+            id: "call-review",
+            status: "completed",
+            outcome: "completed",
+            note: REVIEW_NOTE,
+            noteRevision: 2,
+            segments: BASE_SEGMENTS,
+            bookmarks: [{ segmentId: "s3", comment: "Keep the exact customer wording." }],
+            proposal: REVIEW_PROPOSAL,
+            enrichmentReady: true,
+        };
+    return {
+        ...base,
+        id: "call-detected",
+        status: "idle",
+        outcome: "ready",
+        note: "",
+        segments: BASE_SEGMENTS.slice(0, 2),
+        bookmarks: [],
+        proposal: "",
+        enrichmentReady: false,
+    };
+}
+
+function useCallNotesEngine(scenario: Scenario): Engine {
+    const [call, setCall] = useState<CallRecord>(() => createCall(scenario));
+    const [detectedNotice, setDetectedNotice] = useState(scenario === "detected");
+    const [manualOpen, setManualOpen] = useState(false);
+    const [manualError, setManualError] = useState("");
+    const [retrying, setRetrying] = useState(false);
+    const [noteDraft, setNoteDraft] = useState(() => createCall(scenario).note);
+    const [saveState, setSaveState] = useState<"saved" | "saving">("saved");
+    const [viewerMode, setViewerMode] = useState(false);
+    const [reviewOpen, setReviewOpen] = useState(false);
+    const [toast, setToast] = useState("");
+    const [bookmarkTarget, setBookmarkTarget] = useState<string | null>(null);
+    const [evidenceOpen, setEvidenceOpen] = useState(false);
+    const [evidenceTarget, setEvidenceTarget] = useState<TranscriptSegment | null>(null);
+    const saveTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+    const connectTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+    const toastTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+    const showToast = useCallback((message: string) => {
+        setToast(message);
+        clearTimeout(toastTimerRef.current);
+        toastTimerRef.current = setTimeout(() => setToast(""), 2600);
+    }, []);
+    const clearConnectTimer = useCallback(() => {
+        clearTimeout(connectTimerRef.current);
+        connectTimerRef.current = undefined;
+    }, []);
+    const beginConnecting = useCallback(
+        (isRetry = false) => {
+            clearConnectTimer();
+            setManualError("");
+            setDetectedNotice(false);
+            setManualOpen(false);
+            setRetrying(isRetry);
+            setCall(current => ({ ...current, status: "connecting", outcome: "ready" }));
+        },
+        [clearConnectTimer]
+    );
+
+    useEffect(() => {
+        if (call.status !== "connecting") return;
+        clearConnectTimer();
+        connectTimerRef.current = setTimeout(
+            () => {
+                setCall(current => ({
+                    ...current,
+                    status: "live",
+                    segments: current.segments.length
+                        ? current.segments
+                        : BASE_SEGMENTS.slice(0, 2),
+                }));
+                setRetrying(false);
+            },
+            retrying ? 90 : 110
+        );
+        return clearConnectTimer;
+    }, [call.status, clearConnectTimer, retrying]);
+
+    useEffect(() => {
+        if (call.status !== "live") return;
+        const interval = setInterval(() => {
+            setCall(current => {
+                if (current.status !== "live") return current;
+                const next = STREAM_SEGMENTS.find(
+                    candidate => !current.segments.some(segment => segment.id === candidate.id)
+                );
+                return next ? { ...current, segments: [...current.segments, next] } : current;
+            });
+        }, 240);
+        return () => clearInterval(interval);
+    }, [call.status]);
+
+    useEffect(
+        () => () => {
+            clearConnectTimer();
+            clearTimeout(saveTimerRef.current);
+            clearTimeout(toastTimerRef.current);
+        },
+        [clearConnectTimer]
+    );
+
+    const updateNote = useCallback((value: string) => {
+        setNoteDraft(value);
+        setCall(current => ({ ...current, note: value }));
+        setSaveState("saving");
+        clearTimeout(saveTimerRef.current);
+        saveTimerRef.current = setTimeout(() => setSaveState("saved"), 360);
+    }, []);
+    const pauseCapture = useCallback(() => {
+        setCall(current =>
+            current.status !== "live"
+                ? current
+                : {
+                      ...current,
+                      status: "paused",
+                      outcome: "partial",
+                      gaps: [
+                          ...current.gaps,
+                          {
+                              id: `gap-${current.gaps.length + 1}`,
+                              label: "user-paused",
+                              duration: "00:08",
+                              afterSegmentId: current.segments.at(-1)?.id ?? null,
+                          },
+                      ],
+                  }
+        );
+        showToast("Paused · transcript gap retained");
+    }, [showToast]);
+    const resumeCapture = useCallback(() => {
+        setCall(current =>
+            current.status === "paused" ? { ...current, status: "live" } : current
+        );
+        showToast("Capture resumed");
+    }, [showToast]);
+    const startManual = useCallback(
+        (value: string) => {
+            const trimmed = value.trim();
+            const meetingId = trimmed.replace(/[\s-]/g, "");
+            if (!trimmed || (!/zoom\.us\//i.test(trimmed) && !/^\d{7,}$/.test(meetingId))) {
+                setManualError("Enter a Zoom join URL or meeting ID.");
+                return;
+            }
+            beginConnecting(false);
+        },
+        [beginConnecting]
+    );
+    const openEvidence = useCallback(
+        (segmentId?: string) => {
+            setEvidenceTarget(
+                call.segments.find(segment => segment.id === segmentId) ??
+                    call.segments[2] ??
+                    call.segments[0] ??
+                    null
+            );
+            setEvidenceOpen(true);
+        },
+        [call.segments]
+    );
+    const acceptProposal = useCallback(
+        (proposal: string) => {
+            setCall(current => ({
+                ...current,
+                proposal,
+                note: proposal,
+                noteRevision: current.noteRevision + 1,
+                enrichmentReady: false,
+            }));
+            setNoteDraft(proposal);
+            setReviewOpen(false);
+            showToast("Revision accepted");
+        },
+        [showToast]
+    );
+
+    useEffect(() => {
+        if (!evidenceOpen) return;
+        const close = (event: globalThis.KeyboardEvent) =>
+            event.key === "Escape" && setEvidenceOpen(false);
+        window.addEventListener("keydown", close);
+        return () => window.removeEventListener("keydown", close);
+    }, [evidenceOpen]);
+
+    return {
+        call,
+        setCall,
+        detectedNotice,
+        dismissDetected: () => setDetectedNotice(false),
+        startDetected: () => beginConnecting(false),
+        manualOpen,
+        openManualStart: () => {
+            setManualError("");
+            setManualOpen(true);
+        },
+        closeManualStart: () => {
+            setManualError("");
+            setManualOpen(false);
+        },
+        startManual,
+        manualError,
+        retryCapture: () => beginConnecting(true),
+        deleteFailedCall: () => {
+            setCall(current =>
+                current.status !== "failed" || current.note.trim()
+                    ? current
+                    : { ...current, id: "call-deleted", title: "No selected Call", status: "idle" }
+            );
+            showToast("Failed Call deleted");
+        },
+        noteDraft,
+        updateNote,
+        saveState,
+        viewerMode,
+        setViewerMode,
+        reviewOpen,
+        openReview: () => setReviewOpen(true),
+        acceptProposal,
+        rejectProposal: () => {
+            setReviewOpen(false);
+            showToast("Proposal rejected · current note preserved");
+        },
+        toast,
+        setToast,
+        bookmarkTarget,
+        openBookmark: setBookmarkTarget,
+        closeBookmark: () => setBookmarkTarget(null),
+        saveBookmark: (comment: string) => {
+            if (!bookmarkTarget) return;
+            setCall(current => ({
+                ...current,
+                bookmarks: [
+                    ...current.bookmarks.filter(item => item.segmentId !== bookmarkTarget),
+                    { segmentId: bookmarkTarget, comment: comment.trim() },
+                ],
+            }));
+            setBookmarkTarget(null);
+            showToast("Bookmark shared with company");
+        },
+        evidenceOpen,
+        evidenceTarget,
+        openEvidence,
+        closeEvidence: () => setEvidenceOpen(false),
+        pauseCapture,
+        resumeCapture,
+    };
+}
+
+function IconButton({
+    label,
+    children,
+    onClick,
+}: {
+    label: string;
+    children: ReactNode;
+    onClick?: () => void;
+}) {
+    return (
+        <button type="button" className={styles.iconButton} aria-label={label} onClick={onClick}>
+            {children}
+        </button>
+    );
+}
+
+function CaptureStatusBadge({ call }: { call: CallRecord }) {
+    const label =
+        call.status === "idle"
+            ? "Ready"
+            : `${call.status[0]!.toUpperCase()}${call.status.slice(1)}`;
+    return (
+        <span
+            className={`${styles.status} ${styles[`status_${call.status}`]}`}
+            role="status"
+            aria-label="Capture status"
+        >
+            <span className={styles.statusDot} aria-hidden="true" />
+            {label}
+            {call.outcome === "partial" ? (
+                <span className={styles.partialLabel}>Partial</span>
+            ) : null}
+        </span>
+    );
+}
+
+function CallsRail({
+    engine,
+    open,
+    onClose,
+}: {
+    engine: Engine;
+    open: boolean;
+    onClose: () => void;
+}) {
+    const { call } = engine;
+    const isActive =
+        call.status === "connecting" || call.status === "live" || call.status === "paused";
+    return (
+        <aside
+            className={`${styles.rail} ${open ? styles.railOpen : ""}`}
+            aria-label="Calls library"
+        >
+            <div className={styles.railBrand}>
+                <span className={styles.brandMark}>L</span>
+                <strong>LaunchStack</strong>
+                <IconButton label="Close Calls rail" onClick={onClose}>
+                    <X size={17} />
+                </IconButton>
+            </div>
+            <div className={styles.railTitle}>
+                <h1>Calls</h1>
+                <IconButton label="Start a new capture" onClick={engine.openManualStart}>
+                    <Plus size={17} />
+                </IconButton>
+            </div>
+            <label className={styles.search}>
+                <Search size={14} />
+                <input aria-label="Search Calls" placeholder="Search calls" />
+            </label>
+            <div className={styles.railList}>
+                {isActive ? (
+                    <section>
+                        <span className={styles.railLabel}>Live</span>
+                        <button
+                            type="button"
+                            className={`${styles.callItem} ${styles.callItemActive}`}
+                            onClick={onClose}
+                        >
+                            <span className={styles.liveMeta}>
+                                <span className={styles.liveDot} />
+                                {call.status === "paused"
+                                    ? "Paused"
+                                    : call.status === "connecting"
+                                      ? "Connecting"
+                                      : "Live"}
+                            </span>
+                            <strong>{call.title}</strong>
+                            <span>{call.owner} · now</span>
+                        </button>
+                    </section>
+                ) : null}
+                <section>
+                    <span className={styles.railLabel}>Recent</span>
+                    {call.id !== "call-deleted" && !isActive ? (
+                        <button
+                            type="button"
+                            className={`${styles.callItem} ${!isActive ? styles.callItemActive : ""}`}
+                            onClick={onClose}
+                        >
+                            <span>
+                                {call.status === "failed"
+                                    ? "Failed"
+                                    : call.status === "completed"
+                                      ? "Completed"
+                                      : "Today"}
+                            </span>
+                            <strong>{call.title}</strong>
+                            <span>{call.company}</span>
+                        </button>
+                    ) : null}
+                    <button type="button" className={styles.callItem}>
+                        <span>Yesterday</span>
+                        <strong>Q3 customer discovery</strong>
+                        <span>Northstar Labs</span>
+                    </button>
+                    <button type="button" className={styles.callItem}>
+                        <span>Aug 12</span>
+                        <strong>Weekly launch sync</strong>
+                        <span>LaunchStack</span>
+                    </button>
+                </section>
+            </div>
+            <button
+                type="button"
+                className={styles.railFooter}
+                onClick={() => engine.setViewerMode(value => !value)}
+            >
+                {engine.viewerMode ? <EyeOff size={15} /> : <Users size={15} />}
+                {engine.viewerMode ? "Exit teammate view" : "Preview as teammate"}
+            </button>
+        </aside>
+    );
+}
+
+function DetectedNotice({ engine }: { engine: Engine }) {
+    if (!engine.detectedNotice) return null;
+    return (
+        <section className={styles.notice} role="region" aria-label="Detected Zoom call">
+            <span className={styles.noticeIcon}>
+                <Radio size={15} />
+            </span>
+            <div>
+                <strong>Zoom call detected</strong>
+                <span>{engine.call.providerTopic}</span>
+            </div>
+            <button type="button" className={styles.primaryButton} onClick={engine.startDetected}>
+                Start capture
+            </button>
+            <button type="button" className={styles.textButton} onClick={engine.dismissDetected}>
+                Dismiss
+            </button>
+        </section>
+    );
+}
+
+function CaptureControls({ engine }: { engine: Engine }) {
+    const { call } = engine;
+    if (engine.viewerMode)
+        return (
+            <span className={styles.readOnly}>
+                <Eye size={13} /> Read only
+            </span>
+        );
+    if (call.status === "live")
+        return (
+            <button type="button" className={styles.controlButton} onClick={engine.pauseCapture}>
+                <Pause size={14} />
+                Pause
+            </button>
+        );
+    if (call.status === "paused")
+        return (
+            <button type="button" className={styles.primaryButton} onClick={engine.resumeCapture}>
+                <Play size={14} />
+                Resume
+            </button>
+        );
+    if (call.status === "connecting")
+        return (
+            <span className={styles.connecting}>
+                <Radio size={13} />
+                Connecting…
+            </span>
+        );
+    return (
+        <button type="button" className={styles.controlButton} onClick={engine.openManualStart}>
+            <Play size={14} />
+            Start
+        </button>
+    );
+}
+
+function CallNoteEditor({ engine }: { engine: Engine }) {
+    const editorRef = useRef<HTMLDivElement>(null);
+    const isOwner = !engine.viewerMode;
+    const noteVisible = engine.call.visibility === "company" || isOwner;
+    useEffect(() => {
+        if (editorRef.current && editorRef.current.textContent !== engine.noteDraft)
+            editorRef.current.textContent = engine.noteDraft;
+    }, [engine.call.noteRevision, engine.noteDraft]);
+
+    if (!noteVisible) {
+        return (
+            <div className={styles.privateNote}>
+                <LockKeyhole size={17} />
+                <strong>Private to the owner</strong>
+                <span>The company transcript remains available.</span>
+            </div>
+        );
+    }
+    return (
+        <div
+            ref={editorRef}
+            className={styles.noteEditor}
+            role="textbox"
+            aria-label="Call Note"
+            contentEditable={isOwner}
+            suppressContentEditableWarning
+            onInput={() => engine.updateNote(editorRef.current?.textContent ?? "")}
+            data-placeholder="Write notes here…"
+        />
+    );
+}
+
+function TranscriptSection({ engine }: { engine: Engine }) {
+    const [open, setOpen] = useState(false);
+    const [query, setQuery] = useState("");
+    const { call } = engine;
+    const normalizedQuery = query.trim().toLowerCase();
+    const visibleSegments = normalizedQuery
+        ? call.segments.filter(
+              segment =>
+                  segment.speaker.toLowerCase().includes(normalizedQuery) ||
+                  segment.text.toLowerCase().includes(normalizedQuery)
+          )
+        : call.segments;
+
+    return (
+        <section className={styles.transcript} aria-label="Company Transcript">
+            <div className={styles.transcriptHeader}>
+                <button
+                    type="button"
+                    className={styles.transcriptToggle}
+                    aria-label={`Transcript · ${open ? "collapse" : "expand"}`}
+                    aria-expanded={open}
+                    onClick={() => setOpen(value => !value)}
+                >
+                    <span className={styles.toggleIcon}>
+                        {open ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+                    </span>
+                    <span>
+                        <strong>Transcript</strong>
+                        <small>
+                            <ShieldCheck size={12} />
+                            {call.segments.length} segments · shared with {call.company}
+                        </small>
+                    </span>
+                </button>
+                {open ? (
+                    <label className={styles.transcriptSearch}>
+                        <Search size={14} />
+                        <input
+                            aria-label="Search transcript"
+                            placeholder="Search transcript"
+                            value={query}
+                            onChange={event => setQuery(event.target.value)}
+                        />
+                        {query ? (
+                            <button
+                                type="button"
+                                aria-label="Clear transcript search"
+                                onClick={() => setQuery("")}
+                            >
+                                <X size={13} />
+                            </button>
+                        ) : null}
+                    </label>
+                ) : call.outcome === "partial" ? (
+                    <span className={styles.gapSummary}>Capture paused · Partial</span>
+                ) : null}
+            </div>
+            {open ? (
+                <div className={styles.transcriptBody} aria-label="Transcript segments">
+                    {visibleSegments.length ? (
+                        visibleSegments.map(segment => {
+                            const bookmark = call.bookmarks.find(
+                                item => item.segmentId === segment.id
+                            );
+                            const gaps = call.gaps.filter(gap => gap.afterSegmentId === segment.id);
+                            return (
+                                <React.Fragment key={segment.id}>
+                                    <article className={styles.segment}>
+                                        <div className={styles.segmentMeta}>
+                                            <strong>{segment.speaker}</strong>
+                                            <span>{segment.timestamp}</span>
+                                        </div>
+                                        <p>{segment.text}</p>
+                                        {!engine.viewerMode ? (
+                                            <button
+                                                type="button"
+                                                className={`${styles.bookmarkButton} ${bookmark ? styles.bookmarkSaved : ""}`}
+                                                aria-label={`Bookmark segment ${segment.timestamp}`}
+                                                onClick={() => engine.openBookmark(segment.id)}
+                                            >
+                                                <Bookmark
+                                                    size={14}
+                                                    fill={bookmark ? "currentColor" : "none"}
+                                                />
+                                            </button>
+                                        ) : null}
+                                        {bookmark?.comment ? (
+                                            <span className={styles.bookmarkComment}>
+                                                {bookmark.comment}
+                                            </span>
+                                        ) : null}
+                                    </article>
+                                    {gaps.map(gap => (
+                                        <div className={styles.gap} key={gap.id}>
+                                            <Pause size={13} />
+                                            <strong>Capture paused</strong>
+                                            <span>{gap.duration} not transcribed</span>
+                                        </div>
+                                    ))}
+                                </React.Fragment>
+                            );
+                        })
+                    ) : (
+                        <div className={styles.transcriptEmpty}>
+                            {call.segments.length
+                                ? `No transcript matches “${query.trim()}”.`
+                                : "Transcript appears when Zoom connects."}
+                        </div>
+                    )}
+                </div>
+            ) : null}
+        </section>
+    );
+}
+
+function CallHeader({ engine, onMenu }: { engine: Engine; onMenu: () => void }) {
+    const { call } = engine;
+    const [renaming, setRenaming] = useState(false);
+    const [title, setTitle] = useState(call.title);
+    const save = () => {
+        const next = title.trim() || "Untitled call";
+        engine.setCall(current => ({ ...current, title: next }));
+        setTitle(next);
+        setRenaming(false);
+        engine.setToast("Call title updated");
+    };
+    return (
+        <header className={styles.panelHeader}>
+            <IconButton label="Open Calls rail" onClick={onMenu}>
+                <Menu size={18} />
+            </IconButton>
+            <CaptureStatusBadge call={call} />
+            <div className={styles.headerSpacer} />
+            <CaptureControls engine={engine} />
+            <IconButton label="More Call actions">
+                <MoreHorizontal size={18} />
+            </IconButton>
+            <div className={styles.titleBlock}>
+                <div className={styles.titleLine}>
+                    {renaming && !engine.viewerMode ? (
+                        <input
+                            aria-label="Call title"
+                            className={styles.titleInput}
+                            value={title}
+                            autoFocus
+                            onChange={event => setTitle(event.target.value)}
+                            onBlur={save}
+                            onKeyDown={event => event.key === "Enter" && save()}
+                        />
+                    ) : (
+                        <button
+                            type="button"
+                            className={styles.titleButton}
+                            aria-label={engine.viewerMode ? "Call title" : "Rename Call"}
+                            onClick={() => !engine.viewerMode && setRenaming(true)}
+                        >
+                            <h1>{call.title}</h1>
+                            {!engine.viewerMode ? <Pencil size={14} /> : null}
+                        </button>
+                    )}
+                </div>
+                <div className={styles.callMeta}>
+                    <span>
+                        <Clock3 size={13} />
+                        Today, 10:00 AM
+                    </span>
+                    <span>
+                        <Users size={13} />3 people
+                    </span>
+                    <span>
+                        <Link2 size={13} />
+                        Zoom
+                    </span>
+                </div>
+            </div>
+        </header>
+    );
+}
+
+function CallPanel({ engine, onMenu }: { engine: Engine; onMenu: () => void }) {
+    const { call } = engine;
+    const [noteView, setNoteView] = useState<"notes" | "enhanced">("notes");
+    const activeNoteView = engine.viewerMode ? "notes" : noteView;
+
+    if (call.id === "call-deleted") {
+        return (
+            <main className={styles.panel}>
+                <CallHeader engine={engine} onMenu={onMenu} />
+                <div className={styles.emptyPanel}>
+                    <FileText size={22} />
+                    <h2>Failed Call deleted</h2>
+                    <p>Select another Call or start a new capture.</p>
+                    <button
+                        type="button"
+                        className={styles.primaryButton}
+                        onClick={engine.openManualStart}
+                    >
+                        Start capture
+                    </button>
+                </div>
+            </main>
+        );
+    }
+    return (
+        <main className={styles.panel}>
+            <CallHeader engine={engine} onMenu={onMenu} />
+            <div className={styles.panelScroll}>
+                <div className={styles.panelContent}>
+                    <DetectedNotice engine={engine} />
+                    {call.status === "failed" ? (
+                        <section className={styles.failure} role="alert">
+                            <div>
+                                <strong>Capture failed</strong>
+                                <span>{FAILURE_MESSAGE}</span>
+                            </div>
+                            <button
+                                type="button"
+                                className={styles.controlButton}
+                                onClick={engine.retryCapture}
+                            >
+                                <RefreshCcw size={14} />
+                                Retry capture
+                            </button>
+                            {!call.note.trim() ? (
+                                <button
+                                    type="button"
+                                    className={styles.textButton}
+                                    onClick={engine.deleteFailedCall}
+                                >
+                                    Delete
+                                </button>
+                            ) : null}
+                        </section>
+                    ) : null}
+                    <section className={styles.note} aria-label="Call Note">
+                        <div className={styles.noteHeading}>
+                            <div
+                                className={styles.noteSwitcher}
+                                role="tablist"
+                                aria-label="Note views"
+                            >
+                                <button
+                                    type="button"
+                                    role="tab"
+                                    aria-selected={activeNoteView === "notes"}
+                                    className={`${styles.noteTab} ${activeNoteView === "notes" ? styles.noteTabActive : ""}`}
+                                    onClick={() => setNoteView("notes")}
+                                >
+                                    <FileText size={13} />
+                                    My notes
+                                </button>
+                                <button
+                                    type="button"
+                                    role="tab"
+                                    aria-selected={activeNoteView === "enhanced"}
+                                    className={`${styles.noteTab} ${activeNoteView === "enhanced" ? styles.noteTabActive : ""}`}
+                                    disabled={engine.viewerMode}
+                                    onClick={() => setNoteView("enhanced")}
+                                >
+                                    <Sparkles size={13} />
+                                    AI enhanced
+                                    {call.enrichmentReady ? (
+                                        <span
+                                            className={styles.readyDot}
+                                            aria-label="Enrichment ready"
+                                        />
+                                    ) : null}
+                                </button>
+                            </div>
+                            <small>
+                                {activeNoteView === "enhanced"
+                                    ? call.enrichmentReady
+                                        ? "Ready to review"
+                                        : "Available after capture"
+                                    : engine.viewerMode
+                                      ? "Read only"
+                                      : engine.saveState === "saving"
+                                        ? "Saving…"
+                                        : "Saved"}
+                            </small>
+                        </div>
+                        {activeNoteView === "notes" ? (
+                            <div role="tabpanel" aria-label="My notes">
+                                <CallNoteEditor engine={engine} />
+                            </div>
+                        ) : (
+                            <div
+                                className={styles.enhancedNote}
+                                role="tabpanel"
+                                aria-label="AI enhanced note"
+                            >
+                                {call.enrichmentReady ? (
+                                    <>
+                                        <div className={styles.enhancedHeader}>
+                                            <span>
+                                                <Sparkles size={15} />
+                                                <strong>AI-enhanced draft</strong>
+                                            </span>
+                                            <button
+                                                type="button"
+                                                className={styles.controlButton}
+                                                aria-label="Review enrichment"
+                                                onClick={engine.openReview}
+                                            >
+                                                Review suggestion
+                                            </button>
+                                        </div>
+                                        <p>{call.proposal}</p>
+                                    </>
+                                ) : (
+                                    <div className={styles.enhancedEmpty}>
+                                        <Sparkles size={18} />
+                                        <strong>AI enhancement starts after capture</strong>
+                                        <span>
+                                            The transcript and your notes stay separate until the
+                                            suggestion is ready.
+                                        </span>
+                                    </div>
+                                )}
+                            </div>
+                        )}
+                        <div className={styles.noteFooter}>
+                            {activeNoteView === "enhanced" ? (
+                                <>
+                                    <span>
+                                        <LockKeyhole size={13} />
+                                        Owner-only suggestion
+                                    </span>
+                                    <span>Grounded in transcript and bookmarks</span>
+                                </>
+                            ) : engine.viewerMode ? (
+                                <span>
+                                    <Eye size={13} />
+                                    {call.visibility === "company"
+                                        ? "Shared with company"
+                                        : "Private note"}
+                                </span>
+                            ) : (
+                                <label className={styles.visibility}>
+                                    <input
+                                        type="checkbox"
+                                        role="switch"
+                                        aria-label="Shared with company"
+                                        checked={call.visibility === "company"}
+                                        onChange={event =>
+                                            engine.setCall(current => ({
+                                                ...current,
+                                                visibility: event.target.checked
+                                                    ? "company"
+                                                    : "private",
+                                            }))
+                                        }
+                                    />
+                                    {call.visibility === "company" ? (
+                                        <Users size={13} />
+                                    ) : (
+                                        <LockKeyhole size={13} />
+                                    )}
+                                    {call.visibility === "company"
+                                        ? "Shared with company"
+                                        : "Private to you"}
+                                </label>
+                            )}
+                            {activeNoteView === "notes" ? (
+                                <span>Revision {call.noteRevision}</span>
+                            ) : null}
+                        </div>
+                    </section>
+                    <TranscriptSection engine={engine} />
+                </div>
+            </div>
+        </main>
+    );
+}
+
+function ManualStartDialog({ engine }: { engine: Engine }) {
+    const [value, setValue] = useState("");
+    if (!engine.manualOpen) return null;
+    const submit = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        engine.startManual(value);
+    };
+    return (
+        <div className={styles.overlay} role="presentation">
+            <section
+                className={styles.dialog}
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="manual-title"
+            >
+                <div className={styles.dialogHeader}>
+                    <div>
+                        <span>New capture</span>
+                        <h2 id="manual-title">Start a Zoom Call</h2>
+                    </div>
+                    <IconButton
+                        label="Close start capture dialog"
+                        onClick={engine.closeManualStart}
+                    >
+                        <X size={18} />
+                    </IconButton>
+                </div>
+                <form onSubmit={submit}>
+                    <label className={styles.field}>
+                        <span>Zoom URL or meeting ID</span>
+                        <input
+                            autoFocus
+                            value={value}
+                            onChange={event => setValue(event.target.value)}
+                            placeholder="zoom.us/j/…"
+                        />
+                    </label>
+                    {engine.manualError ? (
+                        <p className={styles.fieldError}>{engine.manualError}</p>
+                    ) : null}
+                    <div className={styles.dialogActions}>
+                        <button
+                            type="button"
+                            className={styles.textButton}
+                            onClick={engine.closeManualStart}
+                        >
+                            Cancel
+                        </button>
+                        <button type="submit" className={styles.primaryButton}>
+                            Start capture
+                        </button>
+                    </div>
+                </form>
+            </section>
+        </div>
+    );
+}
+
+function BookmarkDialog({ engine }: { engine: Engine }) {
+    const [comment, setComment] = useState("");
+    useEffect(() => {
+        if (engine.bookmarkTarget) setComment("");
+    }, [engine.bookmarkTarget]);
+    if (!engine.bookmarkTarget) return null;
+    const target = engine.call.segments.find(segment => segment.id === engine.bookmarkTarget);
+    return (
+        <div className={styles.overlay} role="presentation">
+            <section
+                className={styles.dialog}
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="bookmark-title"
+            >
+                <div className={styles.dialogHeader}>
+                    <div>
+                        <span>Transcript · {target?.timestamp}</span>
+                        <h2 id="bookmark-title">Add Bookmark</h2>
+                    </div>
+                    <IconButton label="Close bookmark dialog" onClick={engine.closeBookmark}>
+                        <X size={18} />
+                    </IconButton>
+                </div>
+                <blockquote>{target?.text}</blockquote>
+                <label className={styles.field}>
+                    <span>
+                        Bookmark comment <em>(optional)</em>
+                    </span>
+                    <textarea
+                        aria-label="Bookmark comment"
+                        value={comment}
+                        onChange={event => setComment(event.target.value)}
+                    />
+                </label>
+                <div className={styles.dialogActions}>
+                    <button
+                        type="button"
+                        className={styles.textButton}
+                        onClick={engine.closeBookmark}
+                    >
+                        Cancel
+                    </button>
+                    <button
+                        type="button"
+                        className={styles.primaryButton}
+                        onClick={() => engine.saveBookmark(comment)}
+                    >
+                        Save Bookmark
+                    </button>
+                </div>
+            </section>
+        </div>
+    );
+}
+
+function ReviewDialog({ engine }: { engine: Engine }) {
+    const [proposal, setProposal] = useState(engine.call.proposal);
+    useEffect(() => setProposal(engine.call.proposal), [engine.call.proposal]);
+    if (!engine.reviewOpen) return null;
+    const citation =
+        engine.call.segments.find(segment => segment.id === "s3") ?? engine.call.segments[0];
+    return (
+        <div className={styles.overlay} role="presentation">
+            <section
+                className={`${styles.dialog} ${styles.reviewDialog}`}
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="review-title"
+            >
+                <div className={styles.dialogHeader}>
+                    <div>
+                        <span>AI enrichment</span>
+                        <h2 id="review-title">Review the suggested note</h2>
+                    </div>
+                    <IconButton label="Close enrichment review" onClick={engine.rejectProposal}>
+                        <X size={18} />
+                    </IconButton>
+                </div>
+                <div className={styles.reviewGrid}>
+                    <section aria-label="Current Call Note">
+                        <span className={styles.reviewLabel}>
+                            <LockKeyhole size={12} />
+                            Current note
+                        </span>
+                        <p>{engine.call.note || "No note yet."}</p>
+                    </section>
+                    <section aria-label="Enriched Note Proposal">
+                        <span className={styles.reviewLabel}>
+                            <Sparkles size={12} />
+                            Suggested revision
+                        </span>
+                        <textarea
+                            aria-label="Enriched note proposal"
+                            value={proposal}
+                            onChange={event => setProposal(event.target.value)}
+                        />
+                        {citation ? (
+                            <button
+                                type="button"
+                                className={styles.citation}
+                                aria-label="Open transcript evidence"
+                                onClick={() => engine.openEvidence(citation.id)}
+                            >
+                                <Bookmark size={12} />
+                                Evidence · {citation.speaker}, {citation.timestamp}
+                            </button>
+                        ) : null}
+                    </section>
+                </div>
+                <div className={styles.dialogActions}>
+                    <button
+                        type="button"
+                        className={styles.textButton}
+                        onClick={engine.rejectProposal}
+                    >
+                        Keep current
+                    </button>
+                    <button
+                        type="button"
+                        className={styles.primaryButton}
+                        onClick={() => engine.acceptProposal(proposal)}
+                    >
+                        <Check size={14} />
+                        Accept proposal
+                    </button>
+                </div>
+            </section>
+        </div>
+    );
+}
+
+function EvidenceDialog({ engine }: { engine: Engine }) {
+    if (!engine.evidenceOpen) return null;
+    return (
+        <div className={styles.overlayTop} role="presentation">
+            <section
+                className={styles.dialog}
+                role="dialog"
+                aria-modal="true"
+                aria-labelledby="evidence-title"
+            >
+                <div className={styles.dialogHeader}>
+                    <div>
+                        <span>Bookmark evidence</span>
+                        <h2 id="evidence-title">Transcript evidence</h2>
+                    </div>
+                    <IconButton label="Close transcript evidence" onClick={engine.closeEvidence}>
+                        <X size={18} />
+                    </IconButton>
+                </div>
+                {engine.evidenceTarget ? (
+                    <blockquote>
+                        <strong>
+                            {engine.evidenceTarget.speaker} · {engine.evidenceTarget.timestamp}
+                        </strong>
+                        <p>{engine.evidenceTarget.text}</p>
+                    </blockquote>
+                ) : null}
+            </section>
+        </div>
+    );
+}
+
+export function CallNotesPrototype({ initialScenario }: CallNotesPrototypeProps = {}) {
+    const routeScenario =
+        initialScenario ??
+        (typeof window === "undefined"
+            ? undefined
+            : new URLSearchParams(window.location.search).get("scenario"));
+    const scenario: Scenario =
+        routeScenario === "failure" || routeScenario === "review" ? routeScenario : "detected";
+    const engine = useCallNotesEngine(scenario);
+    const [railOpen, setRailOpen] = useState(false);
+    return (
+        <div data-theme="light" className={`lsw-root ${styles.root}`}>
+            <CallsRail engine={engine} open={railOpen} onClose={() => setRailOpen(false)} />
+            {railOpen ? (
+                <button
+                    type="button"
+                    className={styles.railScrim}
+                    aria-label="Close Calls rail"
+                    onClick={() => setRailOpen(false)}
+                />
+            ) : null}
+            <CallPanel engine={engine} onMenu={() => setRailOpen(true)} />
+            <ManualStartDialog engine={engine} />
+            <BookmarkDialog engine={engine} />
+            <ReviewDialog engine={engine} />
+            <EvidenceDialog engine={engine} />
+            {engine.toast ? (
+                <div className={styles.toast} role="status" aria-live="polite">
+                    <Check size={14} />
+                    {engine.toast}
+                </div>
+            ) : null}
+        </div>
+    );
+}
+
+export default CallNotesPrototype;

--- a/apps/web/src/app/prototypes/call-notes/call-notes-prototype.module.css
+++ b/apps/web/src/app/prototypes/call-notes/call-notes-prototype.module.css
@@ -1,0 +1,1286 @@
+.root {
+    --call-rail: #f3f2ef;
+    --call-paper: #fff;
+    --call-canvas: #e9e8e4;
+    --call-ink: #252421;
+    --call-muted: #77746d;
+    --call-faint: #aaa69d;
+    --call-line: #e8e6e0;
+    --call-line-strong: #d9d6ce;
+    --call-accent: #6555d8;
+    --call-accent-soft: #f0edff;
+    --call-danger: #b5443c;
+    --call-danger-soft: #fff2f0;
+    --call-success: #2d7a54;
+    display: flex;
+    min-width: 0;
+    min-height: 100dvh;
+    overflow: hidden;
+    color: var(--call-ink);
+    background: var(--call-canvas);
+    font-family: var(--font-sans), ui-sans-serif, system-ui, sans-serif;
+    font-size: 14px;
+    line-height: 1.45;
+}
+
+.root :global(*) {
+    box-sizing: border-box;
+}
+
+.root button,
+.root input,
+.root textarea {
+    color: inherit;
+    font: inherit;
+}
+
+.root button {
+    border: 0;
+}
+
+.rail {
+    position: relative;
+    z-index: 20;
+    display: flex;
+    flex: 0 0 272px;
+    flex-direction: column;
+    width: 272px;
+    min-width: 0;
+    height: 100dvh;
+    overflow: hidden;
+    background: var(--call-rail);
+    border-right: 1px solid var(--call-line-strong);
+}
+
+.railBrand,
+.railTitle {
+    display: flex;
+    align-items: center;
+}
+
+.railBrand {
+    gap: 9px;
+    height: 56px;
+    padding: 0 18px;
+    font-size: 13px;
+}
+
+.railBrand .iconButton {
+    display: none;
+    margin-left: auto;
+}
+
+.brandMark {
+    display: grid;
+    place-items: center;
+    width: 22px;
+    height: 22px;
+    color: #fff;
+    background: var(--call-ink);
+    border-radius: 6px;
+    font-size: 11px;
+    font-weight: 750;
+}
+
+.railTitle {
+    justify-content: space-between;
+    padding: 18px 18px 12px;
+}
+
+.railTitle h1 {
+    margin: 0;
+    font-size: 22px;
+    font-weight: 680;
+    letter-spacing: -0.035em;
+}
+
+.iconButton,
+.controlButton,
+.primaryButton,
+.textButton,
+.bookmarkButton,
+.citation {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    border-radius: 7px;
+    cursor: pointer;
+    transition:
+        background 140ms ease,
+        border-color 140ms ease,
+        color 140ms ease;
+}
+
+.iconButton {
+    width: 30px;
+    height: 30px;
+    padding: 0;
+    background: transparent;
+}
+
+.iconButton:hover,
+.textButton:hover {
+    background: rgb(0 0 0 / 0.055);
+}
+
+.search {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 0 14px 16px;
+    padding: 7px 10px;
+    color: var(--call-muted);
+    background: rgb(255 255 255 / 0.52);
+    border: 1px solid transparent;
+    border-radius: 7px;
+}
+
+.search:focus-within {
+    background: #fff;
+    border-color: var(--call-line-strong);
+}
+
+.search input {
+    width: 100%;
+    min-width: 0;
+    padding: 0;
+    background: transparent;
+    border: 0;
+    outline: 0;
+}
+
+.search input::placeholder {
+    color: var(--call-faint);
+}
+
+.railList {
+    flex: 1;
+    min-height: 0;
+    padding: 0 10px;
+    overflow: auto;
+}
+
+.railList section + section {
+    margin-top: 24px;
+}
+
+.railLabel {
+    display: block;
+    padding: 0 8px 7px;
+    color: var(--call-faint);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.09em;
+    text-transform: uppercase;
+}
+
+.callItem {
+    display: grid;
+    width: 100%;
+    padding: 10px 10px 11px;
+    text-align: left;
+    background: transparent;
+    border-radius: 8px;
+    cursor: pointer;
+}
+
+.callItem:hover {
+    background: rgb(255 255 255 / 0.55);
+}
+
+.callItemActive {
+    background: #fff;
+    box-shadow: 0 1px 2px rgb(37 36 33 / 0.06);
+}
+
+.callItemActive:hover {
+    background: #fff;
+}
+
+.callItem strong {
+    overflow: hidden;
+    margin: 2px 0 3px;
+    font-size: 13px;
+    font-weight: 620;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.callItem span {
+    overflow: hidden;
+    color: var(--call-muted);
+    font-size: 11px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.liveMeta {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    color: var(--call-success) !important;
+    font-weight: 650;
+}
+
+.liveDot,
+.statusDot {
+    display: inline-block;
+    width: 6px;
+    height: 6px;
+    background: currentColor;
+    border-radius: 999px;
+}
+
+.liveDot {
+    box-shadow: 0 0 0 3px rgb(45 122 84 / 0.12);
+}
+
+.railFooter {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 10px;
+    padding: 10px;
+    color: var(--call-muted);
+    text-align: left;
+    background: transparent;
+    border-top: 1px solid var(--call-line);
+    cursor: pointer;
+}
+
+.railFooter:hover {
+    color: var(--call-ink);
+}
+
+.railScrim {
+    display: none;
+}
+
+.panel {
+    display: flex;
+    flex: 1 1 auto;
+    flex-direction: column;
+    min-width: 0;
+    height: 100dvh;
+    overflow: hidden;
+    background: var(--call-paper);
+}
+
+.panelHeader {
+    display: grid;
+    grid-template-columns: auto 1fr auto auto;
+    align-items: center;
+    gap: 8px;
+    min-height: 72px;
+    padding: 16px 28px;
+    border-bottom: 1px solid var(--call-line);
+}
+
+.panelHeader > .iconButton:first-child {
+    display: none;
+}
+
+.headerSpacer {
+    min-width: 0;
+}
+
+.status {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    width: max-content;
+    color: var(--call-muted);
+    font-size: 11px;
+    font-weight: 650;
+}
+
+.status_live,
+.status_connecting {
+    color: var(--call-success);
+}
+
+.status_connecting .statusDot {
+    animation: pulse 1.25s ease-in-out infinite;
+}
+
+.status_paused {
+    color: #9b6b12;
+}
+
+.status_failed {
+    color: var(--call-danger);
+}
+
+.status_completed {
+    color: var(--call-muted);
+}
+
+.partialLabel {
+    padding-left: 7px;
+    border-left: 1px solid currentColor;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+}
+
+.controlButton,
+.primaryButton,
+.textButton {
+    min-height: 30px;
+    padding: 6px 10px;
+    font-size: 12px;
+    font-weight: 620;
+}
+
+.controlButton {
+    background: #fff;
+    border: 1px solid var(--call-line-strong) !important;
+}
+
+.controlButton:hover {
+    background: #f8f7f4;
+}
+
+.primaryButton {
+    color: #fff !important;
+    background: var(--call-ink);
+}
+
+.primaryButton:hover {
+    background: #3a3935;
+}
+
+.textButton {
+    color: var(--call-muted);
+    background: transparent;
+}
+
+.connecting,
+.readOnly {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    color: var(--call-muted);
+    font-size: 12px;
+}
+
+.titleBlock {
+    grid-column: 1 / -1;
+    min-width: 0;
+    padding-top: 13px;
+}
+
+.titleLine {
+    display: flex;
+    align-items: center;
+    min-width: 0;
+}
+
+.titleButton {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+    padding: 0;
+    background: transparent;
+    cursor: pointer;
+}
+
+.titleButton svg {
+    flex: none;
+    color: var(--call-faint);
+    opacity: 0;
+    transition: opacity 120ms ease;
+}
+
+.titleButton:hover svg,
+.titleButton:focus-visible svg {
+    opacity: 1;
+}
+
+.titleButton h1,
+.titleInput {
+    min-width: 0;
+    margin: 0;
+    font-size: clamp(22px, 3vw, 28px);
+    font-weight: 660;
+    letter-spacing: -0.04em;
+    line-height: 1.15;
+}
+
+.titleInput {
+    width: min(640px, 100%);
+    padding: 0 0 3px;
+    background: transparent;
+    border: 0;
+    border-bottom: 1px solid var(--call-ink);
+    outline: 0;
+}
+
+.callMeta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 15px;
+    margin-top: 9px;
+    color: var(--call-muted);
+    font-size: 11px;
+}
+
+.callMeta span {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+}
+
+.panelScroll {
+    flex: 1;
+    min-height: 0;
+    overflow: auto;
+}
+
+.panelContent {
+    width: min(860px, calc(100% - 64px));
+    margin: 0 auto;
+    padding: 28px 0 72px;
+}
+
+.notice,
+.failure {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto auto;
+    align-items: center;
+    gap: 11px;
+    margin-bottom: 18px;
+    padding: 10px 12px;
+    border: 1px solid var(--call-line);
+    border-radius: 9px;
+}
+
+.notice {
+    background: #fbfaf7;
+}
+
+.noticeIcon {
+    display: grid;
+    place-items: center;
+    width: 28px;
+    height: 28px;
+    color: var(--call-accent);
+    background: var(--call-accent-soft);
+    border-radius: 7px;
+}
+
+.notice div,
+.failure div {
+    display: grid;
+    min-width: 0;
+}
+
+.notice strong,
+.failure strong {
+    font-size: 12px;
+    font-weight: 660;
+}
+
+.notice div span,
+.failure div span {
+    overflow: hidden;
+    color: var(--call-muted);
+    font-size: 11px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.failure {
+    color: var(--call-danger);
+    background: var(--call-danger-soft);
+    border-color: #f0d6d2;
+}
+
+.note {
+    min-height: 330px;
+    padding: 24px 0 0;
+}
+
+.noteHeading,
+.noteFooter {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.noteHeading {
+    gap: 18px;
+    min-height: 47px;
+    padding-bottom: 12px;
+    border-bottom: 1px solid var(--call-line);
+}
+
+.noteHeading small,
+.noteFooter {
+    color: var(--call-faint);
+    font-size: 11px;
+}
+
+.noteHeading small {
+    flex: none;
+}
+
+.noteSwitcher {
+    display: inline-flex;
+    gap: 2px;
+    padding: 3px;
+    background: #f1f0ed;
+    border-radius: 9px;
+}
+
+.noteTab {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    min-height: 30px;
+    padding: 6px 10px;
+    color: var(--call-muted);
+    background: transparent;
+    border-radius: 7px;
+    cursor: pointer;
+    font-size: 11px;
+    font-weight: 620;
+}
+
+.noteTab:hover:not(:disabled) {
+    color: var(--call-ink);
+}
+
+.noteTabActive {
+    color: var(--call-ink);
+    background: #fff;
+    box-shadow: 0 1px 2px rgb(37 36 33 / 0.08);
+}
+
+.noteTab:disabled {
+    cursor: default;
+    opacity: 0.55;
+}
+
+.readyDot {
+    width: 5px;
+    height: 5px;
+    background: var(--call-accent);
+    border-radius: 999px;
+    box-shadow: 0 0 0 3px rgb(101 85 216 / 0.1);
+}
+
+.enhancedNote {
+    min-height: 260px;
+    padding: 25px 2px 36px;
+}
+
+.enhancedHeader {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    margin-bottom: 22px;
+}
+
+.enhancedHeader > span {
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    color: var(--call-accent);
+    font-size: 12px;
+}
+
+.enhancedNote p {
+    max-width: 700px;
+    margin: 0;
+    color: #3f3d38;
+    font-family: var(--font-serif), Georgia, serif;
+    font-size: 18px;
+    line-height: 1.68;
+}
+
+.enhancedEmpty {
+    display: grid;
+    justify-items: start;
+    gap: 7px;
+    padding-top: 5px;
+    color: var(--call-muted);
+}
+
+.enhancedEmpty svg {
+    color: var(--call-accent);
+}
+
+.enhancedEmpty span {
+    max-width: 430px;
+    font-size: 12px;
+}
+
+.noteEditor {
+    min-height: 260px;
+    padding: 25px 2px 36px;
+    outline: 0;
+    font-family: var(--font-serif), Georgia, serif;
+    font-size: 18px;
+    line-height: 1.68;
+    white-space: pre-wrap;
+}
+
+.noteEditor:empty::before {
+    color: #aaa79f;
+    content: attr(data-placeholder);
+    pointer-events: none;
+}
+
+.noteEditor:focus {
+    caret-color: var(--call-accent);
+}
+
+.privateNote {
+    display: grid;
+    justify-items: start;
+    gap: 6px;
+    min-height: 260px;
+    padding: 30px 2px;
+    color: var(--call-muted);
+}
+
+.privateNote span {
+    font-size: 12px;
+}
+
+.noteFooter {
+    gap: 14px;
+    min-height: 42px;
+    border-top: 1px solid var(--call-line);
+}
+
+.noteFooter > span {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.visibility {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 7px;
+    color: var(--call-muted);
+    border-radius: 6px;
+    cursor: pointer;
+}
+
+.visibility:hover {
+    color: var(--call-ink);
+    background: #f7f6f3;
+}
+
+.visibility input {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    opacity: 0;
+}
+
+.transcript {
+    margin-top: 16px;
+    overflow: hidden;
+    background: #fbfaf8;
+    border: 1px solid var(--call-line-strong);
+    border-radius: 12px;
+}
+
+.transcriptHeader {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 12px;
+    min-height: 68px;
+    padding: 8px 12px 8px 5px;
+}
+
+.transcriptToggle {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+    padding: 9px;
+    text-align: left;
+    background: transparent;
+    border-radius: 8px;
+    cursor: pointer;
+}
+
+.transcriptToggle:hover {
+    background: rgb(37 36 33 / 0.035);
+}
+
+.transcriptToggle:hover .toggleIcon {
+    color: var(--call-ink);
+}
+
+.toggleIcon {
+    display: grid;
+    place-items: center;
+    color: var(--call-faint);
+}
+
+.transcriptToggle > span:nth-child(2) {
+    display: grid;
+    gap: 2px;
+    min-width: 0;
+}
+
+.transcriptToggle strong {
+    font-size: 12px;
+    font-weight: 660;
+}
+
+.transcriptToggle small {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+    overflow: hidden;
+    color: var(--call-muted);
+    font-size: 11px;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.transcriptSearch {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    width: min(240px, 32vw);
+    padding: 7px 9px;
+    color: var(--call-muted);
+    background: #fff;
+    border: 1px solid var(--call-line-strong);
+    border-radius: 8px;
+}
+
+.transcriptSearch:focus-within {
+    border-color: var(--call-accent);
+    box-shadow: 0 0 0 3px rgb(101 85 216 / 0.08);
+}
+
+.transcriptSearch input {
+    width: 100%;
+    min-width: 0;
+    padding: 0;
+    background: transparent;
+    border: 0;
+    outline: 0;
+    font-size: 11px;
+}
+
+.transcriptSearch button {
+    display: grid;
+    flex: none;
+    place-items: center;
+    width: 20px;
+    height: 20px;
+    padding: 0;
+    color: var(--call-muted);
+    background: transparent;
+    border-radius: 5px;
+    cursor: pointer;
+}
+
+.transcriptSearch button:hover {
+    background: #f1f0ed;
+}
+
+.gapSummary {
+    padding-right: 6px;
+    color: #9b6b12;
+    font-size: 11px;
+}
+
+.transcriptBody {
+    max-height: 420px;
+    padding: 8px 12px 12px;
+    overflow: auto;
+    background: #fff;
+    border-top: 1px solid var(--call-line);
+}
+
+.segment {
+    position: relative;
+    margin-top: 8px;
+    padding: 14px 44px 14px 14px;
+    background: #f6f5f2;
+    border: 1px solid transparent;
+    border-radius: 9px;
+    transition:
+        border-color 120ms ease,
+        background 120ms ease;
+}
+
+.segment:hover,
+.segment:focus-within {
+    background: #f9f8f6;
+    border-color: var(--call-line-strong);
+}
+
+.segmentMeta {
+    display: flex;
+    align-items: baseline;
+    gap: 8px;
+}
+
+.segmentMeta strong {
+    font-size: 12px;
+    font-weight: 660;
+}
+
+.segmentMeta span {
+    color: var(--call-faint);
+    font-family: var(--font-mono), monospace;
+    font-size: 10px;
+}
+
+.segment p {
+    margin: 7px 0 0;
+    color: #46443f;
+    font-size: 13px;
+    line-height: 1.58;
+}
+
+.bookmarkButton {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    display: grid;
+    place-items: center;
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    color: var(--call-muted);
+    background: #fff;
+    border: 1px solid var(--call-line);
+    border-radius: 7px;
+    cursor: pointer;
+    opacity: 0;
+    transform: translateY(2px);
+    transition:
+        opacity 120ms ease,
+        transform 120ms ease,
+        color 120ms ease;
+}
+
+.segment:hover .bookmarkButton,
+.segment:focus-within .bookmarkButton,
+.bookmarkSaved {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+.bookmarkButton:hover,
+.bookmarkSaved {
+    color: var(--call-accent);
+}
+
+.bookmarkComment {
+    display: block;
+    margin-top: 11px;
+    padding-top: 9px;
+    color: var(--call-accent);
+    border-top: 1px solid var(--call-line);
+    font-size: 10px;
+}
+
+.citation {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 4px 7px;
+    color: var(--call-muted);
+    background: transparent;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 10px;
+}
+
+.citation:hover {
+    color: var(--call-accent);
+    background: var(--call-accent-soft);
+}
+
+.gap {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    margin: 8px 2px 0;
+    padding: 8px 10px;
+    color: #8a651e;
+    background: #fff9eb;
+    border-radius: 7px;
+    font-size: 10px;
+}
+
+.gap span {
+    color: #9a875e;
+}
+
+.transcriptEmpty {
+    padding: 28px 12px;
+    color: var(--call-muted);
+    text-align: center;
+    font-size: 12px;
+}
+
+.emptyPanel {
+    display: grid;
+    flex: 1;
+    place-content: center;
+    justify-items: center;
+    gap: 7px;
+    color: var(--call-muted);
+    text-align: center;
+}
+
+.emptyPanel h2,
+.emptyPanel p {
+    margin: 0;
+}
+
+.emptyPanel h2 {
+    color: var(--call-ink);
+    font-size: 17px;
+}
+
+.overlay,
+.overlayTop {
+    position: fixed;
+    inset: 0;
+    z-index: 60;
+    display: grid;
+    place-items: center;
+    padding: 20px;
+    background: rgb(36 34 31 / 0.36);
+    backdrop-filter: blur(2px);
+}
+
+.overlayTop {
+    z-index: 80;
+    background: rgb(36 34 31 / 0.48);
+}
+
+.dialog {
+    width: min(460px, 100%);
+    max-height: min(760px, calc(100dvh - 40px));
+    padding: 22px;
+    overflow: auto;
+    background: #fff;
+    border: 1px solid var(--call-line-strong);
+    border-radius: 12px;
+    box-shadow: 0 22px 70px rgb(28 26 22 / 0.18);
+}
+
+.reviewDialog {
+    width: min(880px, 100%);
+}
+
+.dialogHeader {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 20px;
+    margin-bottom: 20px;
+}
+
+.dialogHeader > div {
+    display: grid;
+    gap: 2px;
+}
+
+.dialogHeader span,
+.reviewLabel {
+    color: var(--call-muted);
+    font-size: 10px;
+    font-weight: 680;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.dialogHeader h2 {
+    margin: 0;
+    font-size: 19px;
+    letter-spacing: -0.025em;
+}
+
+.dialog form {
+    display: grid;
+    gap: 10px;
+}
+
+.field {
+    display: grid;
+    gap: 7px;
+    color: var(--call-muted);
+    font-size: 11px;
+}
+
+.field em {
+    color: var(--call-faint);
+    font-style: normal;
+}
+
+.field input,
+.field textarea {
+    width: 100%;
+    padding: 10px 11px;
+    background: #fff;
+    border: 1px solid var(--call-line-strong);
+    border-radius: 7px;
+    outline: 0;
+}
+
+.field textarea {
+    min-height: 90px;
+    resize: vertical;
+}
+
+.field input:focus,
+.field textarea:focus {
+    border-color: var(--call-accent);
+    box-shadow: 0 0 0 3px rgb(101 85 216 / 0.1);
+}
+
+.fieldError {
+    margin: 0;
+    color: var(--call-danger);
+    font-size: 11px;
+}
+
+.dialog blockquote {
+    margin: 0 0 18px;
+    padding: 13px;
+    color: #4b4842;
+    background: #f8f7f4;
+    border-radius: 8px;
+    font-size: 12px;
+    line-height: 1.55;
+}
+
+.dialog blockquote p {
+    margin: 7px 0 0;
+}
+
+.dialogActions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 7px;
+    margin-top: 18px;
+}
+
+.reviewGrid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1px;
+    overflow: hidden;
+    background: var(--call-line);
+    border: 1px solid var(--call-line);
+    border-radius: 9px;
+}
+
+.reviewGrid section {
+    min-width: 0;
+    padding: 17px;
+    background: #fff;
+}
+
+.reviewLabel {
+    display: flex;
+    align-items: center;
+    gap: 5px;
+}
+
+.reviewGrid p,
+.reviewGrid textarea {
+    width: 100%;
+    min-height: 180px;
+    margin: 13px 0 0;
+    color: #44423d;
+    font-family: var(--font-serif), Georgia, serif;
+    font-size: 15px;
+    line-height: 1.58;
+}
+
+.reviewGrid textarea {
+    padding: 0;
+    resize: none;
+    background: transparent;
+    border: 0;
+    outline: 0;
+}
+
+.reviewGrid .citation {
+    margin-top: 12px;
+}
+
+.toast {
+    position: fixed;
+    right: 22px;
+    bottom: 22px;
+    z-index: 100;
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    padding: 9px 12px;
+    color: #fff;
+    background: var(--call-ink);
+    border-radius: 8px;
+    box-shadow: 0 8px 26px rgb(20 19 17 / 0.18);
+    font-size: 11px;
+}
+
+@keyframes pulse {
+    0%,
+    100% {
+        opacity: 0.4;
+    }
+    50% {
+        opacity: 1;
+    }
+}
+
+@media (max-width: 760px) {
+    .rail {
+        position: fixed;
+        inset: 0 auto 0 0;
+        width: min(312px, 88vw);
+        flex-basis: auto;
+        transform: translateX(-102%);
+        transition: transform 180ms ease;
+    }
+
+    .railOpen {
+        transform: translateX(0);
+    }
+
+    .railBrand .iconButton,
+    .panelHeader > .iconButton:first-child {
+        display: inline-flex;
+    }
+
+    .railScrim {
+        position: fixed;
+        inset: 0;
+        z-index: 15;
+        display: block;
+        background: rgb(28 27 24 / 0.28);
+    }
+
+    .panelHeader {
+        grid-template-columns: auto auto 1fr auto auto;
+        min-height: 64px;
+        padding: 12px 16px;
+    }
+
+    .titleBlock {
+        padding-top: 9px;
+    }
+
+    .panelContent {
+        width: min(100% - 34px, 860px);
+        padding-top: 18px;
+    }
+
+    .notice,
+    .failure {
+        grid-template-columns: auto minmax(0, 1fr) auto;
+    }
+
+    .notice .textButton,
+    .failure .textButton {
+        display: none;
+    }
+
+    .reviewGrid {
+        grid-template-columns: 1fr;
+    }
+
+    .bookmarkButton {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@media (max-width: 480px) {
+    .panelHeader {
+        grid-template-columns: auto auto 1fr auto;
+    }
+
+    .panelHeader > .iconButton:last-of-type {
+        display: none;
+    }
+
+    .callMeta {
+        gap: 9px;
+    }
+
+    .notice,
+    .failure {
+        align-items: start;
+        grid-template-columns: auto minmax(0, 1fr);
+    }
+
+    .notice .primaryButton,
+    .failure .controlButton {
+        grid-column: 2;
+        justify-self: start;
+    }
+
+    .note {
+        min-height: 300px;
+    }
+
+    .noteEditor,
+    .privateNote,
+    .enhancedNote {
+        min-height: 230px;
+    }
+
+    .transcriptHeader {
+        grid-template-columns: 1fr;
+    }
+
+    .transcriptSearch {
+        width: 100%;
+    }
+
+    .gapSummary {
+        padding: 0 9px 8px;
+    }
+
+    .overlay,
+    .overlayTop {
+        align-items: end;
+        padding: 0;
+    }
+
+    .dialog,
+    .reviewDialog {
+        width: 100%;
+        max-height: 90dvh;
+        border-radius: 14px 14px 0 0;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .root *,
+    .root *::before,
+    .root *::after {
+        scroll-behavior: auto !important;
+        transition-duration: 0.01ms !important;
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+    }
+}

--- a/apps/web/src/app/prototypes/call-notes/page.tsx
+++ b/apps/web/src/app/prototypes/call-notes/page.tsx
@@ -1,0 +1,19 @@
+import { CallNotesPrototype } from "./CallNotesPrototype";
+
+type SearchParams = {
+    scenario?: string | string[];
+};
+
+export default async function CallNotesPrototypePage({
+    searchParams,
+}: {
+    searchParams: Promise<SearchParams>;
+}) {
+    const params = await searchParams;
+    const routeScenario = Array.isArray(params.scenario) ? params.scenario[0] : params.scenario;
+    const initialScenario =
+        routeScenario === "failure" || routeScenario === "review" || routeScenario === "detected"
+            ? routeScenario
+            : undefined;
+    return <CallNotesPrototype initialScenario={initialScenario} />;
+}

--- a/apps/web/src/lib/tools/rag/retrievers/notes-retriever.ts
+++ b/apps/web/src/lib/tools/rag/retrievers/notes-retriever.ts
@@ -58,6 +58,8 @@ type NotesRetrieverFields = SingleDocConfig | CompanyConfig | MultiDocConfig | U
 
 type NoteRow = {
     note_id: number;
+    note_user_id: string;
+    note_company_id: string | null;
     document_id: string | null;
     company_id: string | null;
     version_id: string | null;
@@ -67,7 +69,35 @@ type NoteRow = {
     anchor: unknown;
     anchor_status: string | null;
     distance: number;
+    call_id: string | null;
+    call_company_id: string | null;
+    call_status: string | null;
+    call_document_note_id: number | null;
+    call_owner_user_id: string | null;
+    call_visibility: string | null;
+    call_knowledge_included: boolean | null;
+    call_revision: number | null;
 };
+
+export function isEligibleCompanyCallNoteRow(
+    row: NoteRow,
+    requestedCompanyId: number | string
+): boolean {
+    if (row.call_id === null) return true;
+    const companyId = String(requestedCompanyId);
+    return (
+        row.call_company_id === companyId &&
+        row.company_id === companyId &&
+        row.note_company_id === companyId &&
+        row.call_status === "completed" &&
+        row.call_document_note_id === row.note_id &&
+        row.call_owner_user_id === row.note_user_id &&
+        row.call_visibility === "company" &&
+        row.call_knowledge_included === true &&
+        row.call_revision !== null &&
+        row.call_revision > 0
+    );
+}
 
 export class NotesRetriever extends BaseRetriever {
     lc_namespace = ["rag", "retrievers", "notes"];
@@ -115,6 +145,8 @@ export class NotesRetriever extends BaseRetriever {
                 await db.execute<NoteRow>(sql`
           SELECT
             ne.note_id,
+            n.user_id AS note_user_id,
+            n.company_id AS note_company_id,
             ne.document_id,
             ne.company_id,
             ne.version_id,
@@ -123,36 +155,74 @@ export class NotesRetriever extends BaseRetriever {
             n.content_markdown,
             n.anchor,
             n.anchor_status,
+            c.id AS call_id,
+            c.company_id::text AS call_company_id,
+            c.status AS call_status,
+            c.document_note_id AS call_document_note_id,
+            c.note_owner_user_id AS call_owner_user_id,
+            c.note_visibility AS call_visibility,
+            c.knowledge_included AS call_knowledge_included,
+            c.current_note_revision AS call_revision,
             (ne.embedding <-> ${fullLiteral}) as distance
           FROM ${T.noteEmbeddings} ne
           JOIN ${T.notes} n ON n.id = ne.note_id
+          LEFT JOIN ${T.callNotesCalls} c ON c.document_note_id = n.id
           WHERE ${where}
             AND ne.embedding IS NOT NULL
             AND ne.embedding_short IS NOT NULL
             AND COALESCE(n.anchor_status, 'resolved') <> 'orphaned'
+            AND (
+              ${this.searchScope !== "company"}
+              OR c.id IS NULL
+              OR (
+                c.company_id::text = ${String(this.companyId ?? "")}
+                AND ne.company_id = c.company_id::text
+                AND n.company_id = c.company_id::text
+                AND c.status = 'completed'
+                AND c.document_note_id = n.id
+                AND c.note_owner_user_id = n.user_id
+                AND c.note_visibility = 'company'
+                AND c.knowledge_included = TRUE
+                AND c.current_note_revision > 0
+              )
+            )
           ORDER BY ne.embedding_short <-> ${shortLiteral}
           LIMIT ${this.topK}
         `)
             );
 
-            return rows.map(r => {
-                const snippet = (r.title ? `${r.title}\n\n` : "") + (r.content ?? "");
-                return new Document({
-                    pageContent: snippet,
-                    metadata: {
-                        source: "note",
-                        noteId: r.note_id,
-                        documentId: r.document_id,
-                        companyId: r.company_id,
-                        versionId: r.version_id,
-                        title: r.title,
-                        anchor: r.anchor,
-                        anchorStatus: r.anchor_status,
-                        distance: r.distance,
-                        searchScope: this.searchScope,
-                    },
+            return rows
+                .filter(
+                    r =>
+                        this.searchScope !== "company" ||
+                        (this.companyId !== undefined &&
+                            isEligibleCompanyCallNoteRow(r, this.companyId))
+                )
+                .map(r => {
+                    const snippet = (r.title ? `${r.title}\n\n` : "") + (r.content ?? "");
+                    const source = r.call_id === null ? "note" : "call_note";
+                    return new Document({
+                        pageContent: snippet,
+                        metadata: {
+                            source,
+                            noteId: r.note_id,
+                            documentId: r.document_id,
+                            companyId: r.company_id,
+                            versionId: r.version_id,
+                            title: r.title,
+                            anchor: r.anchor,
+                            anchorStatus: r.anchor_status,
+                            distance: r.distance,
+                            searchScope: this.searchScope,
+                            ...(r.call_id === null
+                                ? {}
+                                : {
+                                      callId: r.call_id,
+                                      revision: r.call_revision,
+                                  }),
+                        },
+                    });
                 });
-            });
         } catch (err) {
             console.error("[NotesRetriever] error:", err);
             return [];

--- a/apps/web/src/lib/tools/rag/search/ensemble-search.ts
+++ b/apps/web/src/lib/tools/rag/search/ensemble-search.ts
@@ -5,6 +5,7 @@ import { createEmbeddingModel } from "@launchstack/core/embeddings";
 import { resolveEmbeddingIndex } from "@launchstack/core/embeddings";
 import { getRerankProvider, isRerankConfigured } from "@launchstack/core/providers/reranking";
 import { env } from "~/env";
+import { resolveNoteEmbeddingRuntime } from "~/server/notes/embedding-config";
 import {
     createDocumentVectorRetriever,
     createCompanyVectorRetriever,
@@ -103,9 +104,11 @@ export async function createDocumentEnsembleRetriever(
     }
 
     if (isNotesRetrievalEnabled()) {
+        const noteEmbeddings = resolveNoteEmbeddingRuntime()?.embeddings;
+        if (!noteEmbeddings) return new EnsembleRetriever({ retrievers, weights });
         const notesRetriever = createDocumentNotesRetriever(
             documentId,
-            emb,
+            noteEmbeddings,
             Math.min(candidateK, NOTES_MAX_CANDIDATES)
         );
         retrievers.push(notesRetriever);
@@ -146,9 +149,11 @@ export async function createCompanyEnsembleRetriever(
     }
 
     if (isNotesRetrievalEnabled()) {
+        const noteEmbeddings = resolveNoteEmbeddingRuntime()?.embeddings;
+        if (!noteEmbeddings) return new EnsembleRetriever({ retrievers, weights });
         const notesRetriever = createCompanyNotesRetriever(
             companyId,
-            emb,
+            noteEmbeddings,
             Math.min(candidateK, NOTES_MAX_CANDIDATES)
         );
         retrievers.push(notesRetriever);
@@ -190,9 +195,11 @@ export async function createMultiDocEnsembleRetriever(
     }
 
     if (isNotesRetrievalEnabled()) {
+        const noteEmbeddings = resolveNoteEmbeddingRuntime()?.embeddings;
+        if (!noteEmbeddings) return new EnsembleRetriever({ retrievers, weights });
         const notesRetriever = createMultiDocNotesRetriever(
             documentIds,
-            emb,
+            noteEmbeddings,
             Math.min(candidateK, NOTES_MAX_CANDIDATES)
         );
         retrievers.push(notesRetriever);

--- a/apps/web/src/lib/tools/rag/search/ensemble-search.ts
+++ b/apps/web/src/lib/tools/rag/search/ensemble-search.ts
@@ -276,10 +276,48 @@ export async function companyEnsembleSearch(
 ): Promise<SearchResult[]> {
     const { companyId, topK = 10 } = options;
 
-    const chunks = await getCompanyChunks(companyId);
-    if (chunks.length === 0) {
-        console.log(`[EnsembleSearch] No chunks for company ${companyId}, skipping search`);
+    let chunks;
+    try {
+        chunks = await getCompanyChunks(companyId);
+    } catch (error) {
+        console.error("[EnsembleSearch] Failed to load company chunks:", error);
         return [];
+    }
+    if (chunks.length === 0) {
+        if (!isNotesRetrievalEnabled()) {
+            console.log(`[EnsembleSearch] No chunks or enabled notes for company ${companyId}`);
+            return [];
+        }
+
+        try {
+            const noteEmbeddings = resolveNoteEmbeddingRuntime()?.embeddings;
+            if (!noteEmbeddings) {
+                console.log(
+                    `[EnsembleSearch] No chunks or configured note embeddings for company ${companyId}`
+                );
+                return [];
+            }
+            const notesRetriever = createCompanyNotesRetriever(
+                companyId,
+                noteEmbeddings,
+                Math.min(topK * RERANK_CANDIDATE_MULTIPLIER, NOTES_MAX_CANDIDATES)
+            );
+            const notes = await notesRetriever.getRelevantDocuments(query);
+            const mapped: SearchResult[] = notes.map(doc => ({
+                pageContent: doc.pageContent,
+                metadata: {
+                    ...doc.metadata,
+                    retrievalMethod: "vector_ann",
+                    timestamp: new Date().toISOString(),
+                    searchScope: "company" as const,
+                },
+            }));
+            const reranked = await rerankResults(query, mapped);
+            return reranked.slice(0, topK);
+        } catch (error) {
+            console.error("[EnsembleSearch] Notes-only company search error:", error);
+            return [];
+        }
     }
 
     const graphEnabled = isGraphRetrievalEnabled();

--- a/apps/web/src/server/call-notes/enrichment-model.ts
+++ b/apps/web/src/server/call-notes/enrichment-model.ts
@@ -1,0 +1,48 @@
+import { HumanMessage, SystemMessage } from "@langchain/core/messages";
+import { invokeStructured } from "@launchstack/core/llm";
+import {
+    EnrichedNoteProposalSchema,
+    EnrichmentInputSchema,
+    EnrichmentResultSchema,
+    type EnrichedNoteProposal,
+    type EnrichmentInput,
+    type EnrichmentModel,
+    type EnrichmentResult,
+} from "@launchstack/features/call-notes";
+
+import { resolveConfiguredChatModel } from "~/lib/models";
+import {
+    buildCallNotesEnrichmentPrompt,
+    CALL_NOTES_ENRICHMENT_PROMPT_VERSION,
+    CALL_NOTES_ENRICHMENT_SYSTEM_PROMPT,
+} from "./enrichment-prompts";
+import { validateEnrichmentProvenance } from "./enrichment-validation";
+
+export const CALL_NOTES_ENRICHMENT_ROUTE = "reasoning" as const;
+
+/** Configured LaunchStack model adapter for the isolated enrichment core. */
+export class ConfiguredCallNotesEnrichmentModel implements EnrichmentModel {
+    async generate(rawInput: EnrichmentInput): Promise<EnrichmentResult> {
+        const input = EnrichmentInputSchema.parse(rawInput);
+        const resolved = resolveConfiguredChatModel({ route: CALL_NOTES_ENRICHMENT_ROUTE });
+        const proposal = await invokeStructured<EnrichedNoteProposal>(
+            resolved,
+            EnrichedNoteProposalSchema,
+            [
+                new SystemMessage(CALL_NOTES_ENRICHMENT_SYSTEM_PROMPT),
+                new HumanMessage(buildCallNotesEnrichmentPrompt(input)),
+            ],
+            { name: "call_notes_enrichment_v1" }
+        );
+
+        const validatedProposal = validateEnrichmentProvenance(input, proposal);
+
+        return EnrichmentResultSchema.parse({
+            proposal: validatedProposal,
+            modelMetadata: {
+                model: resolved.modelId,
+                promptVersion: CALL_NOTES_ENRICHMENT_PROMPT_VERSION,
+            },
+        });
+    }
+}

--- a/apps/web/src/server/call-notes/enrichment-prompts.ts
+++ b/apps/web/src/server/call-notes/enrichment-prompts.ts
@@ -1,0 +1,76 @@
+import {
+    CALL_NOTES_ENRICHMENT_SCHEMA_VERSION,
+    EnrichmentInputSchema,
+    type EnrichmentInput,
+} from "@launchstack/features/call-notes";
+
+export const CALL_NOTES_ENRICHMENT_PROMPT_VERSION = "call-notes-enrichment-generation/v1" as const;
+
+export const CALL_NOTES_ENRICHMENT_SYSTEM_PROMPT = `You generate a separate structured Call Note enrichment proposal from the supplied evidence. Return the frozen call-notes-enrichment/v1 proposal shape only. Never overwrite or represent the owner-authored current Call Note as model-authored truth.
+
+The owner-authored current Call Note is source context whose intent and wording must be preserved unless the finalized Transcript provides clear contrary evidence. Finalized immutable Transcript segments are the only factual meeting evidence. Bookmarks identify important Transcript segments, and Bookmark user guidance is strong user steering about emphasis; guidance is not independent evidence and cannot support a claim beyond its linked segment.
+
+Never invent decisions, action items, owners, deadlines, speakers, quotations, Bookmark IDs, or Transcript segment IDs. Do not turn uncertain discussion, suggestions, questions, or possibilities into confirmed outcomes. If an owner or deadline is not explicit in an available Transcript segment, use null. Identify conflicts between owner-authored notes and Transcript evidence instead of silently choosing a version.
+
+Transcript gaps mean evidence is unavailable. Never infer, reconstruct, summarize, or bridge content that may have occurred during a gap. Do not use surrounding segments to claim what happened inside a gap.
+
+Every bookmarkPassages citation must exactly copy a supplied Bookmark ID, its linked Transcript segment ID, that segment's speakerName, and that segment's providerStartMs. Omit unsupported claims rather than weakening, guessing, or fabricating provenance.`;
+
+/** Canonical, stable serialization over the frozen enrichment input. */
+export function buildCallNotesEnrichmentPrompt(rawInput: EnrichmentInput): string {
+    const input = EnrichmentInputSchema.parse(rawInput);
+
+    return JSON.stringify(
+        sortObjectKeysRecursively({
+            promptVersion: CALL_NOTES_ENRICHMENT_PROMPT_VERSION,
+            outputSchemaVersion: CALL_NOTES_ENRICHMENT_SCHEMA_VERSION,
+            callId: input.callId,
+            transcriptFingerprint: input.transcriptFingerprint,
+            currentOwnerCallNote: {
+                sourceRole: "owner-authored current Call Note",
+                documentNoteId: input.note.documentNoteId,
+                ownerUserId: input.note.ownerUserId,
+                visibility: input.note.visibility,
+                revision: input.note.revision,
+                title: input.note.title,
+                contentMarkdown: input.note.contentMarkdown,
+                contentRich: input.note.contentRich,
+            },
+            finalizedTranscript: {
+                sourceRole: "finalized immutable Transcript evidence",
+                segments: input.transcript,
+            },
+            transcriptGaps: input.gaps.map(gap => ({
+                ...gap,
+                evidenceAvailability: "unavailable",
+                instruction: "Do not infer or reconstruct content during this gap.",
+            })),
+            bookmarks: input.bookmarks.map(bookmark => ({
+                bookmarkId: bookmark.id,
+                linkedTranscriptSegmentId: bookmark.segmentId,
+                createdAt: bookmark.createdAt,
+                userGuidance: bookmark.comment,
+                guidanceRole: "strong user steering, not independent factual evidence",
+            })),
+            generationMode: "create a separate proposal; do not overwrite the current Call Note",
+        })
+    );
+}
+
+/** Sort object keys recursively while retaining the exact supplied order of arrays. */
+function sortObjectKeysRecursively(value: unknown): unknown {
+    if (Array.isArray(value)) {
+        return value.map(sortObjectKeysRecursively);
+    }
+    if (value && typeof value === "object") {
+        return Object.fromEntries(
+            Object.keys(value as Record<string, unknown>)
+                .sort()
+                .map(key => [
+                    key,
+                    sortObjectKeysRecursively((value as Record<string, unknown>)[key]),
+                ])
+        );
+    }
+    return value;
+}

--- a/apps/web/src/server/call-notes/enrichment-validation.ts
+++ b/apps/web/src/server/call-notes/enrichment-validation.ts
@@ -1,0 +1,140 @@
+import {
+    EnrichedNoteProposalSchema,
+    EnrichmentInputSchema,
+    type EnrichedNoteProposal,
+    type EnrichmentInput,
+} from "@launchstack/features/call-notes";
+
+export type EnrichmentProvenanceIssueCode =
+    | "duplicate_bookmark_id"
+    | "duplicate_transcript_segment_id"
+    | "unknown_bookmark_id"
+    | "unknown_transcript_segment_id"
+    | "bookmark_segment_mismatch"
+    | "speaker_mismatch"
+    | "timestamp_mismatch"
+    | "invalid_transcript_timestamp_range";
+
+export interface EnrichmentProvenanceIssue {
+    code: EnrichmentProvenanceIssueCode;
+    message: string;
+    passageIndex?: number;
+    citationIndex?: number;
+}
+
+export class EnrichmentProvenanceValidationError extends Error {
+    readonly issues: readonly EnrichmentProvenanceIssue[];
+
+    constructor(issues: readonly EnrichmentProvenanceIssue[]) {
+        super(
+            `Call Notes enrichment provenance validation failed: ${issues
+                .map(issue => issue.message)
+                .join("; ")}`
+        );
+        this.name = "EnrichmentProvenanceValidationError";
+        this.issues = issues;
+    }
+}
+
+/**
+ * Validates model-produced Bookmark citations against the canonical input.
+ * Structural validation runs first; unsupported citations are never removed.
+ */
+export function validateEnrichmentProvenance(
+    rawInput: EnrichmentInput,
+    rawProposal: EnrichedNoteProposal
+): EnrichedNoteProposal {
+    const input = EnrichmentInputSchema.parse(rawInput);
+    const proposal = EnrichedNoteProposalSchema.parse(rawProposal);
+    const issues: EnrichmentProvenanceIssue[] = [];
+
+    const segmentsById = indexUnique(
+        input.transcript,
+        "duplicate_transcript_segment_id",
+        "Transcript segment",
+        issues
+    );
+    const bookmarksById = indexUnique(input.bookmarks, "duplicate_bookmark_id", "Bookmark", issues);
+
+    proposal.bookmarkPassages.forEach((passage, passageIndex) => {
+        passage.citations.forEach((citation, citationIndex) => {
+            const location = { passageIndex, citationIndex };
+            const bookmark = bookmarksById.get(citation.bookmarkId);
+            if (!bookmark) {
+                issues.push({
+                    code: "unknown_bookmark_id",
+                    message: `citation references unknown Bookmark ${citation.bookmarkId}`,
+                    ...location,
+                });
+            }
+
+            const segment = segmentsById.get(citation.segmentId);
+            if (!segment) {
+                issues.push({
+                    code: "unknown_transcript_segment_id",
+                    message: `citation references unknown Transcript segment ${citation.segmentId}`,
+                    ...location,
+                });
+                return;
+            }
+
+            if (bookmark && bookmark.segmentId !== citation.segmentId) {
+                issues.push({
+                    code: "bookmark_segment_mismatch",
+                    message: `Bookmark ${bookmark.id} is linked to ${bookmark.segmentId}, not ${citation.segmentId}`,
+                    ...location,
+                });
+            }
+
+            if (citation.speakerName !== segment.speakerName) {
+                issues.push({
+                    code: "speaker_mismatch",
+                    message: `citation speaker does not match Transcript segment ${segment.id}`,
+                    ...location,
+                });
+            }
+
+            if (citation.providerStartMs !== segment.providerStartMs) {
+                issues.push({
+                    code: "timestamp_mismatch",
+                    message: `citation timestamp does not match Transcript segment ${segment.id}`,
+                    ...location,
+                });
+            }
+
+            if (
+                segment.providerStartMs !== null &&
+                segment.providerEndMs !== null &&
+                segment.providerEndMs < segment.providerStartMs
+            ) {
+                issues.push({
+                    code: "invalid_transcript_timestamp_range",
+                    message: `Transcript segment ${segment.id} has an invalid timestamp range`,
+                    ...location,
+                });
+            }
+        });
+    });
+
+    if (issues.length > 0) {
+        throw new EnrichmentProvenanceValidationError(issues);
+    }
+    return proposal;
+}
+
+function indexUnique<T extends { id: string }>(
+    values: readonly T[],
+    code: "duplicate_bookmark_id" | "duplicate_transcript_segment_id",
+    label: string,
+    issues: EnrichmentProvenanceIssue[]
+): Map<string, T> {
+    const result = new Map<string, T>();
+    for (const value of values) {
+        if (result.has(value.id)) {
+            issues.push({ code, message: `${label} ID ${value.id} is duplicated` });
+            continue;
+        }
+        result.set(value.id, value);
+    }
+    return result;
+}

--- a/apps/web/src/server/call-notes/knowledge-note-sink.ts
+++ b/apps/web/src/server/call-notes/knowledge-note-sink.ts
@@ -1,0 +1,256 @@
+import { and, eq } from "drizzle-orm";
+
+import {
+    KnowledgeNoteSchema,
+    type KnowledgeNote,
+    type KnowledgeNoteSink,
+} from "@launchstack/features/call-notes";
+
+import { db } from "~/server/db";
+import { callNotesCalls, documentNoteEmbeddings, documentNotes } from "~/server/db/schema";
+import { requestNoteEmbedding } from "~/server/notes/embed-note";
+
+type KnowledgeNoteSinkErrorCode =
+    | "call_not_found"
+    | "document_note_not_found"
+    | "wrong_document_note"
+    | "wrong_owner"
+    | "wrong_company"
+    | "stale_revision"
+    | "knowledge_disabled"
+    | "private_note"
+    | "call_not_completed"
+    | "content_mismatch"
+    | "unsupported_company_id";
+
+export class KnowledgeNoteSinkError extends Error {
+    readonly code: KnowledgeNoteSinkErrorCode;
+
+    constructor(code: KnowledgeNoteSinkErrorCode, message: string) {
+        super(message);
+        this.name = "KnowledgeNoteSinkError";
+        this.code = code;
+    }
+}
+
+export interface KnowledgeCallState {
+    id: string;
+    companyId: bigint;
+    status: "active" | "finalizing" | "completed" | "failed";
+    documentNoteId: number | null;
+    noteOwnerUserId: string | null;
+    noteVisibility: "company" | "private";
+    knowledgeIncluded: boolean;
+    currentNoteRevision: number;
+}
+
+export interface CanonicalDocumentNoteState {
+    id: number;
+    userId: string;
+    companyId: string | null;
+    title: string | null;
+    content: string | null;
+    contentMarkdown: string | null;
+}
+
+export interface KnowledgeNoteStore {
+    findCall(companyId: bigint, callId: string): Promise<KnowledgeCallState | null>;
+    findDocumentNote(documentNoteId: number): Promise<CanonicalDocumentNoteState | null>;
+    removeProjection(documentNoteId: number): Promise<void>;
+    enqueueEmbedding(documentNoteId: number, companyId: bigint): Promise<void>;
+}
+
+class DrizzleKnowledgeNoteStore implements KnowledgeNoteStore {
+    async findCall(companyId: bigint, callId: string): Promise<KnowledgeCallState | null> {
+        const [call] = await db
+            .select({
+                id: callNotesCalls.id,
+                companyId: callNotesCalls.companyId,
+                status: callNotesCalls.status,
+                documentNoteId: callNotesCalls.documentNoteId,
+                noteOwnerUserId: callNotesCalls.noteOwnerUserId,
+                noteVisibility: callNotesCalls.noteVisibility,
+                knowledgeIncluded: callNotesCalls.knowledgeIncluded,
+                currentNoteRevision: callNotesCalls.currentNoteRevision,
+            })
+            .from(callNotesCalls)
+            .where(and(eq(callNotesCalls.id, callId), eq(callNotesCalls.companyId, companyId)))
+            .limit(1);
+
+        return call ?? null;
+    }
+
+    async findDocumentNote(documentNoteId: number): Promise<CanonicalDocumentNoteState | null> {
+        const [note] = await db
+            .select({
+                id: documentNotes.id,
+                userId: documentNotes.userId,
+                companyId: documentNotes.companyId,
+                title: documentNotes.title,
+                content: documentNotes.content,
+                contentMarkdown: documentNotes.contentMarkdown,
+            })
+            .from(documentNotes)
+            .where(eq(documentNotes.id, documentNoteId))
+            .limit(1);
+
+        return note ?? null;
+    }
+
+    async removeProjection(documentNoteId: number): Promise<void> {
+        await db
+            .delete(documentNoteEmbeddings)
+            .where(eq(documentNoteEmbeddings.noteId, documentNoteId));
+    }
+
+    async enqueueEmbedding(documentNoteId: number, companyId: bigint): Promise<void> {
+        await requestNoteEmbedding(documentNoteId, "updated", companyId);
+    }
+}
+
+function canonicalMarkdown(note: CanonicalDocumentNoteState): string {
+    return note.contentMarkdown ?? note.content ?? "";
+}
+
+function parseSafeCompanyId(value: string): bigint {
+    if (!/^\d+$/.test(value)) {
+        throw new KnowledgeNoteSinkError(
+            "unsupported_company_id",
+            "The company id must contain only decimal digits."
+        );
+    }
+
+    const companyId = BigInt(value);
+    const numericCompanyId = Number(companyId);
+    if (!Number.isSafeInteger(numericCompanyId) || numericCompanyId <= 0) {
+        throw new KnowledgeNoteSinkError(
+            "unsupported_company_id",
+            "The company id cannot be represented safely by the existing durable event protocol."
+        );
+    }
+
+    return companyId;
+}
+
+function requireEligibleCall(call: KnowledgeCallState, note: KnowledgeNote): void {
+    if (call.documentNoteId !== note.documentNoteId) {
+        throw new KnowledgeNoteSinkError(
+            "wrong_document_note",
+            "The supplied document note is not the canonical note for this Call."
+        );
+    }
+    if (call.noteOwnerUserId !== note.ownerUserId) {
+        throw new KnowledgeNoteSinkError(
+            "wrong_owner",
+            "The supplied owner does not own the canonical Call Note."
+        );
+    }
+    if (call.currentNoteRevision !== note.revision) {
+        throw new KnowledgeNoteSinkError(
+            "stale_revision",
+            "The supplied Call Note revision is not current."
+        );
+    }
+    if (!call.knowledgeIncluded) {
+        throw new KnowledgeNoteSinkError(
+            "knowledge_disabled",
+            "Knowledge inclusion is disabled for this Call Note."
+        );
+    }
+    if (call.noteVisibility !== "company") {
+        throw new KnowledgeNoteSinkError(
+            "private_note",
+            "Private Call Notes cannot be included in company knowledge."
+        );
+    }
+    if (call.status !== "completed") {
+        throw new KnowledgeNoteSinkError(
+            "call_not_completed",
+            "Only completed Calls can contribute a Call Note to company knowledge."
+        );
+    }
+}
+
+function requireCanonicalDocumentNote(
+    canonical: CanonicalDocumentNoteState,
+    note: KnowledgeNote
+): void {
+    if (canonical.id !== note.documentNoteId) {
+        throw new KnowledgeNoteSinkError(
+            "wrong_document_note",
+            "The supplied document note identity does not match the canonical note."
+        );
+    }
+    if (canonical.userId !== note.ownerUserId) {
+        throw new KnowledgeNoteSinkError(
+            "wrong_owner",
+            "The canonical document note owner does not match the Call Note owner."
+        );
+    }
+    if (canonical.companyId !== note.companyId) {
+        throw new KnowledgeNoteSinkError(
+            "wrong_company",
+            "The canonical document note company does not match the Call company."
+        );
+    }
+    if (
+        (canonical.title ?? "") !== note.title ||
+        canonicalMarkdown(canonical) !== note.contentMarkdown
+    ) {
+        throw new KnowledgeNoteSinkError(
+            "content_mismatch",
+            "The supplied Call Note content is not the current canonical document note content."
+        );
+    }
+}
+
+export class LaunchStackKnowledgeNoteSink implements KnowledgeNoteSink {
+    constructor(private readonly store: KnowledgeNoteStore = new DrizzleKnowledgeNoteStore()) {}
+
+    async upsert(input: KnowledgeNote): Promise<void> {
+        const note = KnowledgeNoteSchema.parse(input);
+        const companyId = parseSafeCompanyId(note.companyId);
+        const call = await this.store.findCall(companyId, note.callId);
+        if (!call) {
+            throw new KnowledgeNoteSinkError(
+                "call_not_found",
+                "The canonical Call could not be found for this company."
+            );
+        }
+
+        requireEligibleCall(call, note);
+
+        const canonical = await this.store.findDocumentNote(note.documentNoteId);
+        if (!canonical) {
+            throw new KnowledgeNoteSinkError(
+                "document_note_not_found",
+                "The canonical document note could not be found."
+            );
+        }
+        requireCanonicalDocumentNote(canonical, note);
+
+        // Fail closed while durable work is pending: an older projection must
+        // not remain retrievable after the canonical revision changes.
+        await this.store.removeProjection(note.documentNoteId);
+        await this.store.enqueueEmbedding(note.documentNoteId, companyId);
+    }
+
+    async remove(companyIdInput: string, callId: string): Promise<void> {
+        const companyId = parseSafeCompanyId(companyIdInput);
+        const call = await this.store.findCall(companyId, callId);
+        if (!call) {
+            throw new KnowledgeNoteSinkError(
+                "call_not_found",
+                "The canonical Call could not be found for this company."
+            );
+        }
+
+        if (call.documentNoteId !== null) {
+            await this.store.removeProjection(call.documentNoteId);
+        }
+    }
+}
+
+export function createKnowledgeNoteSink(store?: KnowledgeNoteStore): KnowledgeNoteSink {
+    return new LaunchStackKnowledgeNoteSink(store);
+}

--- a/apps/web/src/server/db/tables.ts
+++ b/apps/web/src/server/db/tables.ts
@@ -8,7 +8,12 @@ import {
     documentRetrievalChunks,
     documentStructure,
 } from "@launchstack/core/db/schema";
-import { documentNoteEmbeddings, documentNotes, trendSearchCache } from "~/server/db/schema";
+import {
+    callNotesCalls,
+    documentNoteEmbeddings,
+    documentNotes,
+    trendSearchCache,
+} from "~/server/db/schema";
 
 /**
  * Physical table identifiers for hand-written SQL.
@@ -37,6 +42,7 @@ export const NAME = {
     metadata: getTableName(documentMetadata),
     notes: getTableName(documentNotes),
     noteEmbeddings: getTableName(documentNoteEmbeddings),
+    callNotesCalls: getTableName(callNotesCalls),
     embeddings768: getTableName(documentEmbeddings768),
     embeddings1024: getTableName(documentEmbeddings1024),
     trendSearchCache: getTableName(trendSearchCache),
@@ -50,6 +56,7 @@ export const T = {
     metadata: ident(documentMetadata),
     notes: ident(documentNotes),
     noteEmbeddings: ident(documentNoteEmbeddings),
+    callNotesCalls: ident(callNotesCalls),
     embeddings768: ident(documentEmbeddings768),
     embeddings1024: ident(documentEmbeddings1024),
     trendSearchCache: ident(trendSearchCache),

--- a/apps/web/src/server/notes/embed-note.ts
+++ b/apps/web/src/server/notes/embed-note.ts
@@ -1,35 +1,29 @@
 /**
  * Embed a note's content into `documentNoteEmbeddings` so the hybrid
- * retriever can union notes with regular document chunks. One row per note;
- * re-running replaces the existing row in place so updates don't accumulate
- * stale vectors.
- *
- * Called fire-and-forget from the notes API after create/update. Swallows
- * errors internally — the note itself is already persisted when we reach
- * here, so an embedding failure must not break the user-facing save.
+ * retriever can union notes with regular document chunks. Embedding is
+ * computed outside the final transaction, then the canonical note and any
+ * associated Call are locked and revalidated before atomic replacement.
  */
 
 import { eq } from "drizzle-orm";
-import { OpenAIEmbeddings } from "@langchain/openai";
+
 import { document } from "@launchstack/core/db/schema";
+import type { EmbeddingsProvider } from "@launchstack/core/embeddings";
 
 import { db } from "~/server/db";
-import { type NoteAnchor } from "~/server/db/schema";
-import { documentNotes, documentNoteEmbeddings } from "~/server/db/schema";
 import {
-  EMBEDDING_DIM,
-  EMBEDDING_MODEL,
-  EMBEDDING_SHORT_DIM,
-  resolveEmbeddingConfig,
+  callNotesCalls,
+  documentNoteEmbeddings,
+  documentNotes,
+  type NoteAnchor,
+} from "~/server/db/schema";
+import {
+  resolveNoteEmbeddingRuntime,
+  type NoteEmbeddingRuntime,
 } from "./embedding-config";
 
-/**
- * Build the exact text that gets embedded. Including the anchored quote in
- * addition to the note body is the single biggest quality lever — user
- * queries usually match the document's language, not the annotator's
- * paraphrase. Plays well with BM25 + vector ensemble.
- */
-function buildEmbeddingText(args: {
+/** Build the exact text that gets embedded for both snapshots and writes. */
+export function buildEmbeddingText(args: {
   title: string | null;
   markdown: string | null;
   anchor: NoteAnchor | null;
@@ -42,81 +36,332 @@ function buildEmbeddingText(args: {
   return parts.join("\n\n");
 }
 
-/** Approximate GPT-tokens from char count — fine for bookkeeping. */
 function approxTokens(text: string): number {
   return Math.ceil(text.length / 4);
 }
 
-export async function embedNote(noteId: number): Promise<void> {
-  try {
-    const [note] = await db
-      .select()
-      .from(documentNotes)
-      .where(eq(documentNotes.id, noteId));
-    if (!note) return;
+export interface NoteEmbeddingSource {
+  id: number;
+  userId: string;
+  companyId: string | null;
+  documentId: string | null;
+  versionId: bigint | null;
+  title: string | null;
+  content: string | null;
+  contentMarkdown: string | null;
+  anchor: unknown;
+  createdAt: Date;
+  updatedAt: Date | null;
+}
 
-    const anchor = (note.anchor as NoteAnchor | null) ?? null;
-    const embeddingText = buildEmbeddingText({
+export interface CallNoteEmbeddingState {
+  id: string;
+  companyId: bigint;
+  status: "active" | "finalizing" | "completed" | "failed";
+  documentNoteId: number | null;
+  noteOwnerUserId: string | null;
+  noteVisibility: "company" | "private";
+  knowledgeIncluded: boolean;
+  currentNoteRevision: number;
+}
+
+export interface NoteEmbeddingSnapshot {
+  note: NoteEmbeddingSource;
+  call: CallNoteEmbeddingState | null;
+}
+
+export interface NoteEmbeddingProjection {
+  content: string;
+  tokenCount: number;
+  embedding: number[];
+  embeddingShort: number[];
+  modelVersion: string;
+}
+
+export type NoteEmbeddingWriteResult = "written" | "missing" | "stale" | "ineligible";
+export type NoteEmbeddingCleanupResult = "removed" | "missing" | "stale";
+
+export interface NoteEmbeddingStore {
+  loadSnapshot(noteId: number): Promise<NoteEmbeddingSnapshot | null>;
+  removeProjection(noteId: number): Promise<void>;
+  removeIfCurrent(snapshot: NoteEmbeddingSnapshot): Promise<NoteEmbeddingCleanupResult>;
+  replaceIfCurrent(
+    snapshot: NoteEmbeddingSnapshot,
+    projection: NoteEmbeddingProjection,
+  ): Promise<NoteEmbeddingWriteResult>;
+}
+
+function noteSelection() {
+  return {
+    id: documentNotes.id,
+    userId: documentNotes.userId,
+    companyId: documentNotes.companyId,
+    documentId: documentNotes.documentId,
+    versionId: documentNotes.versionId,
+    title: documentNotes.title,
+    content: documentNotes.content,
+    contentMarkdown: documentNotes.contentMarkdown,
+    anchor: documentNotes.anchor,
+    createdAt: documentNotes.createdAt,
+    updatedAt: documentNotes.updatedAt,
+  };
+}
+
+function callSelection() {
+  return {
+    id: callNotesCalls.id,
+    companyId: callNotesCalls.companyId,
+    status: callNotesCalls.status,
+    documentNoteId: callNotesCalls.documentNoteId,
+    noteOwnerUserId: callNotesCalls.noteOwnerUserId,
+    noteVisibility: callNotesCalls.noteVisibility,
+    knowledgeIncluded: callNotesCalls.knowledgeIncluded,
+    currentNoteRevision: callNotesCalls.currentNoteRevision,
+  };
+}
+
+function sourceIdentity(note: NoteEmbeddingSource): string {
+  return JSON.stringify({
+    userId: note.userId,
+    companyId: note.companyId,
+    documentId: note.documentId,
+    versionId: note.versionId?.toString() ?? null,
+    updatedAt: note.updatedAt?.toISOString() ?? null,
+    embeddingText: buildEmbeddingText({
       title: note.title,
       markdown: note.contentMarkdown ?? note.content ?? "",
-      anchor,
-    });
+      anchor: (note.anchor as NoteAnchor | null) ?? null,
+    }),
+  });
+}
 
-    if (!embeddingText.trim()) {
-      // Nothing to embed — clear any prior vector so stale content can't
-      // resurface in retrieval.
-      await db
+function callIdentity(call: CallNoteEmbeddingState | null): string | null {
+  if (!call) return null;
+  return JSON.stringify({
+    id: call.id,
+    companyId: call.companyId.toString(),
+    status: call.status,
+    documentNoteId: call.documentNoteId,
+    noteOwnerUserId: call.noteOwnerUserId,
+    noteVisibility: call.noteVisibility,
+    knowledgeIncluded: call.knowledgeIncluded,
+    currentNoteRevision: call.currentNoteRevision,
+  });
+}
+
+export function isEligibleCallNote(snapshot: NoteEmbeddingSnapshot): boolean {
+  const { note, call } = snapshot;
+  if (!call) return true;
+  return (
+    call.status === "completed" &&
+    call.knowledgeIncluded &&
+    call.noteVisibility === "company" &&
+    call.documentNoteId === note.id &&
+    call.noteOwnerUserId === note.userId &&
+    call.companyId.toString() === note.companyId &&
+    call.currentNoteRevision > 0
+  );
+}
+
+export function evaluateEmbeddingFreshness(
+  expected: NoteEmbeddingSnapshot,
+  current: NoteEmbeddingSnapshot | null,
+): NoteEmbeddingWriteResult {
+  if (!current) return "missing";
+  if (current.call && !isEligibleCallNote(current)) return "ineligible";
+  if (
+    sourceIdentity(expected.note) !== sourceIdentity(current.note) ||
+    callIdentity(expected.call) !== callIdentity(current.call)
+  ) {
+    return "stale";
+  }
+  return "written";
+}
+
+class DrizzleNoteEmbeddingStore implements NoteEmbeddingStore {
+  async loadSnapshot(noteId: number): Promise<NoteEmbeddingSnapshot | null> {
+    const [note] = await db
+      .select(noteSelection())
+      .from(documentNotes)
+      .where(eq(documentNotes.id, noteId))
+      .limit(1);
+    if (!note) return null;
+
+    const [call] = await db
+      .select(callSelection())
+      .from(callNotesCalls)
+      .where(eq(callNotesCalls.documentNoteId, noteId))
+      .limit(1);
+    return { note, call: call ?? null };
+  }
+
+  async removeProjection(noteId: number): Promise<void> {
+    await db.delete(documentNoteEmbeddings).where(eq(documentNoteEmbeddings.noteId, noteId));
+  }
+
+  async removeIfCurrent(snapshot: NoteEmbeddingSnapshot): Promise<NoteEmbeddingCleanupResult> {
+    return db.transaction(async tx => {
+      const [note] = await tx
+        .select(noteSelection())
+        .from(documentNotes)
+        .where(eq(documentNotes.id, snapshot.note.id))
+        .limit(1)
+        .for("update");
+
+      if (!note) {
+        await tx
+          .delete(documentNoteEmbeddings)
+          .where(eq(documentNoteEmbeddings.noteId, snapshot.note.id));
+        return "missing";
+      }
+
+      const [call] = await tx
+        .select(callSelection())
+        .from(callNotesCalls)
+        .where(eq(callNotesCalls.documentNoteId, snapshot.note.id))
+        .limit(1)
+        .for("update");
+      const current: NoteEmbeddingSnapshot = { note, call: call ?? null };
+
+      // A newer source or eligibility transition owns the projection now.
+      // The stale cleanup must not erase what that newer event wrote.
+      if (evaluateEmbeddingFreshness(snapshot, current) === "stale") return "stale";
+
+      await tx
         .delete(documentNoteEmbeddings)
-        .where(eq(documentNoteEmbeddings.noteId, noteId));
-      return;
-    }
-
-    // Both halves or neither — see resolveEmbeddingConfig.
-    const { apiKey, baseURL } = resolveEmbeddingConfig();
-    if (!apiKey || !baseURL) {
-      console.warn(
-        "[embedNote] no embedding endpoint configured (EMBEDDING_API_BASE_URL " +
-          "+ EMBEDDING_API_KEY, or AI_BASE_URL + AI_API_KEY) — skipping",
-      );
-      return;
-    }
-
-    const client = new OpenAIEmbeddings({
-      openAIApiKey: apiKey,
-      modelName: EMBEDDING_MODEL,
-      dimensions: EMBEDDING_DIM,
-      configuration: { baseURL },
+        .where(eq(documentNoteEmbeddings.noteId, snapshot.note.id));
+      return "removed";
     });
+  }
 
-    const [embedding] = await client.embedDocuments([embeddingText]);
-    if (!embedding || embedding.length !== EMBEDDING_DIM) {
-      console.warn(
-        `[embedNote] unexpected embedding length ${embedding?.length ?? "null"}`,
-      );
-      return;
-    }
-    const embeddingShort = embedding.slice(0, EMBEDDING_SHORT_DIM);
+  async replaceIfCurrent(
+    snapshot: NoteEmbeddingSnapshot,
+    projection: NoteEmbeddingProjection,
+  ): Promise<NoteEmbeddingWriteResult> {
+    return db.transaction(async tx => {
+      // All compliant workers lock the canonical note first and its Call
+      // second. The note row is the serialization mutex for per-note replace.
+      const [note] = await tx
+        .select(noteSelection())
+        .from(documentNotes)
+        .where(eq(documentNotes.id, snapshot.note.id))
+        .limit(1)
+        .for("update");
 
-    await db
-      .delete(documentNoteEmbeddings)
-      .where(eq(documentNoteEmbeddings.noteId, noteId));
+      if (!note) {
+        await tx
+          .delete(documentNoteEmbeddings)
+          .where(eq(documentNoteEmbeddings.noteId, snapshot.note.id));
+        return "missing";
+      }
 
-    await db.insert(documentNoteEmbeddings).values({
-      noteId,
-      userId: note.userId,
-      documentId: note.documentId,
-      companyId: note.companyId,
-      versionId: note.versionId,
-      content: embeddingText,
-      tokenCount: approxTokens(embeddingText),
-      embedding,
-      embeddingShort,
-      modelVersion: EMBEDDING_MODEL,
+      const [call] = await tx
+        .select(callSelection())
+        .from(callNotesCalls)
+        .where(eq(callNotesCalls.documentNoteId, snapshot.note.id))
+        .limit(1)
+        .for("update");
+      const current: NoteEmbeddingSnapshot = { note, call: call ?? null };
+      const freshness = evaluateEmbeddingFreshness(snapshot, current);
+
+      if (freshness !== "written") {
+        // Call Note projections fail closed. Ordinary notes retain their last
+        // good vector while the newer canonical update/event converges.
+        if (freshness !== "stale" || snapshot.call !== null || current.call !== null) {
+          await tx
+            .delete(documentNoteEmbeddings)
+            .where(eq(documentNoteEmbeddings.noteId, snapshot.note.id));
+        }
+        return freshness;
+      }
+
+      await tx
+        .delete(documentNoteEmbeddings)
+        .where(eq(documentNoteEmbeddings.noteId, snapshot.note.id));
+      await tx.insert(documentNoteEmbeddings).values({
+        noteId: note.id,
+        userId: note.userId,
+        documentId: note.documentId,
+        companyId: note.companyId,
+        versionId: note.versionId,
+        content: projection.content,
+        tokenCount: projection.tokenCount,
+        embedding: projection.embedding,
+        embeddingShort: projection.embeddingShort,
+        modelVersion: projection.modelVersion,
+      });
+      return "written";
     });
+  }
+}
+
+async function embedOne(embeddings: EmbeddingsProvider, text: string): Promise<number[] | undefined> {
+  if (embeddings.embedDocuments) {
+    const [embedding] = await embeddings.embedDocuments([text]);
+    return embedding;
+  }
+  return embeddings.embedQuery(text);
+}
+
+export interface EmbedNoteDependencies {
+  store?: NoteEmbeddingStore;
+  runtime?: NoteEmbeddingRuntime | null;
+}
+
+export async function embedNoteWithDependencies(
+  noteId: number,
+  dependencies: EmbedNoteDependencies = {},
+): Promise<NoteEmbeddingWriteResult | "skipped"> {
+  const store = dependencies.store ?? new DrizzleNoteEmbeddingStore();
+  const snapshot = await store.loadSnapshot(noteId);
+  if (!snapshot) {
+    await store.removeProjection(noteId);
+    return "missing";
+  }
+  if (snapshot.call && !isEligibleCallNote(snapshot)) {
+    const cleanup = await store.removeIfCurrent(snapshot);
+    return cleanup === "stale" ? "stale" : "ineligible";
+  }
+
+  const embeddingText = buildEmbeddingText({
+    title: snapshot.note.title,
+    markdown: snapshot.note.contentMarkdown ?? snapshot.note.content ?? "",
+    anchor: (snapshot.note.anchor as NoteAnchor | null) ?? null,
+  });
+  if (!embeddingText.trim()) {
+    const cleanup = await store.removeIfCurrent(snapshot);
+    return cleanup === "stale" ? "stale" : "skipped";
+  }
+
+  const runtime =
+    dependencies.runtime === undefined ? resolveNoteEmbeddingRuntime() : dependencies.runtime;
+  if (!runtime) {
+    console.warn(
+      "[embedNote] no legacy note embedding endpoint configured (EMBEDDING_API_BASE_URL + " +
+      "EMBEDDING_API_KEY, or AI_BASE_URL + AI_API_KEY) — skipping",
+    );
+    return "skipped";
+  }
+
+  const embedding = await embedOne(runtime.embeddings, embeddingText);
+  if (!embedding || embedding.length !== runtime.index.dimension) {
+    console.warn(`[embedNote] unexpected embedding length ${embedding?.length ?? "null"}`);
+    return "skipped";
+  }
+
+  return store.replaceIfCurrent(snapshot, {
+    content: embeddingText,
+    tokenCount: approxTokens(embeddingText),
+    embedding,
+    embeddingShort: embedding.slice(0, runtime.index.shortDimension),
+    modelVersion: runtime.index.model,
+  });
+}
+
+export async function embedNote(noteId: number): Promise<void> {
+  try {
+    await embedNoteWithDependencies(noteId);
   } catch (err) {
-    // Rethrow so the outbox handler records the failure and retries with
-    // backoff (ADR-003). The old fire-and-forget path swallowed this, which
-    // silently left notes unsearchable.
     console.error("[embedNote] failed:", err);
     throw err;
   }
@@ -128,28 +373,13 @@ function parsePositiveInt(
 ): number | null {
   if (value === null || value === undefined) return null;
   const n = Number(value);
-  return Number.isInteger(n) && n > 0 ? n : null;
+  return Number.isSafeInteger(n) && n > 0 ? n : null;
 }
 
-/**
- * Durable replacement for the old fire-and-forget `embedNoteAsync`:
- * enqueues a `note.embedding.requested` outbox event that apps/worker
- * consumes with retries. The event id carries a per-edit fingerprint (the
- * note's `updatedAt` epoch-ms, falling back to `createdAt` for a fresh
- * note), so an edit that lands while a previous request is mid-handler
- * (`processing`) gets its OWN event instead of being absorbed — and lost —
- * by the in-flight row. The handler embeds the CURRENT note content, so
- * redelivery of any fingerprint converges; re-enqueueing an already
- * processed/dead fingerprint revives it via the store's upsert.
- */
+/** Enqueue the existing durable note embedding event. */
 export async function requestNoteEmbedding(
   noteId: number,
   reason: "created" | "updated",
-  /**
-   * Company to attribute the event to when neither the note row nor its
-   * document yields one. The UI note-create paths write null `companyId`,
-   * so routes pass the acting user's active company as this hint.
-   */
   companyIdHint?: string | number | bigint | null,
 ): Promise<void> {
   const [note] = await db
@@ -164,15 +394,8 @@ export async function requestNoteEmbedding(
     .limit(1);
   if (!note) return;
 
-  // Per-edit fingerprint: `updatedAt` is stamped on every update
-  // ($onUpdate); a freshly created note only has `createdAt`. Epoch-ms
-  // keeps the event id deterministic for a given edit, so producer retries
-  // of the SAME edit converge while each new edit gets a new event.
   const fingerprint = String((note.updatedAt ?? note.createdAt).getTime());
 
-  // Resolve the owning company: the note row first, then the anchored
-  // document's row, then the caller-supplied hint. Without the fallbacks,
-  // every UI-created note (null companyId) would silently never be embedded.
   let companyId = parsePositiveInt(note.companyId);
   if (companyId === null) {
     const documentId = parsePositiveInt(note.documentId);
@@ -187,8 +410,6 @@ export async function requestNoteEmbedding(
   }
   companyId ??= parsePositiveInt(companyIdHint);
   if (companyId === null) {
-    // Never drop the event silently — this note will not be searchable until
-    // a later edit manages to resolve a company.
     console.error(
       `[requestNoteEmbedding] could not resolve a company for note ${noteId} ` +
         `(row companyId "${note.companyId}", documentId "${note.documentId}", ` +

--- a/apps/web/src/server/notes/embedding-config.ts
+++ b/apps/web/src/server/notes/embedding-config.ts
@@ -1,3 +1,7 @@
+import { OpenAIEmbeddings } from "@langchain/openai";
+
+import type { EmbeddingsProvider } from "@launchstack/core/embeddings";
+
 /**
  * Shared embedding config for the notes pipeline. Both the write-side
  * (`embed-note.ts`) and read-side (semantic search, retriever) resolve the
@@ -8,6 +12,14 @@
 export const EMBEDDING_MODEL = "text-embedding-3-large";
 export const EMBEDDING_DIM = 1536;
 export const EMBEDDING_SHORT_DIM = 512;
+
+export const NOTE_EMBEDDING_INDEX = Object.freeze({
+  indexKey: "legacy-openai-1536",
+  model: EMBEDDING_MODEL,
+  dimension: EMBEDDING_DIM,
+  shortDimension: EMBEDDING_SHORT_DIM,
+  version: "v1",
+});
 
 export interface EmbeddingProviderConfig {
   apiKey: string | undefined;
@@ -40,5 +52,38 @@ export function resolveEmbeddingConfig(): EmbeddingProviderConfig {
   }
 
   return { apiKey: undefined, baseURL: undefined };
+}
+
+export interface NoteEmbeddingIndex {
+  readonly indexKey: string;
+  readonly model: string;
+  readonly dimension: number;
+  readonly shortDimension: number;
+  readonly version: string;
+}
+
+export interface NoteEmbeddingRuntime {
+  embeddings: EmbeddingsProvider;
+  index: NoteEmbeddingIndex;
+}
+
+/**
+ * One explicit boundary for the fixed-width note vector table. Both note
+ * writes and every note query must resolve through this function until a
+ * schema migration and reindex can move notes to another embedding index.
+ */
+export function resolveNoteEmbeddingRuntime(): NoteEmbeddingRuntime | null {
+  const { apiKey, baseURL } = resolveEmbeddingConfig();
+  if (!apiKey || !baseURL) return null;
+
+  return {
+    embeddings: new OpenAIEmbeddings({
+      openAIApiKey: apiKey,
+      modelName: NOTE_EMBEDDING_INDEX.model,
+      dimensions: NOTE_EMBEDDING_INDEX.dimension,
+      configuration: { baseURL },
+    }),
+    index: NOTE_EMBEDDING_INDEX,
+  };
 }
 

--- a/apps/web/src/server/notes/search.ts
+++ b/apps/web/src/server/notes/search.ts
@@ -7,14 +7,12 @@
 
 import { sql } from "drizzle-orm";
 import { T } from "~/server/db/tables";
-import { OpenAIEmbeddings } from "@langchain/openai";
 
 import { db, toRows } from "~/server/db/index";
 import {
   EMBEDDING_DIM,
-  EMBEDDING_MODEL,
   EMBEDDING_SHORT_DIM,
-  resolveEmbeddingConfig,
+  resolveNoteEmbeddingRuntime,
 } from "./embedding-config";
 
 export type NoteSearchScope = "user" | "document" | "company";
@@ -71,17 +69,10 @@ export async function searchNotes(
 
   // Both halves or neither — an endpoint without a key, or a key without an
   // endpoint, would let the SDK fall back to its own vendor default.
-  const { apiKey, baseURL } = resolveEmbeddingConfig();
-  if (!apiKey || !baseURL) return [];
+  const runtime = resolveNoteEmbeddingRuntime();
+  if (!runtime) return [];
 
-  const client = new OpenAIEmbeddings({
-    openAIApiKey: apiKey,
-    modelName: EMBEDDING_MODEL,
-    dimensions: EMBEDDING_DIM,
-    configuration: { baseURL },
-  });
-
-  const embedding = await client.embedQuery(trimmed);
+  const embedding = await runtime.embeddings.embedQuery(trimmed);
   if (!embedding || embedding.length !== EMBEDDING_DIM) return [];
   const short = embedding.slice(0, EMBEDDING_SHORT_DIM);
 

--- a/apps/web/src/server/rag/port.ts
+++ b/apps/web/src/server/rag/port.ts
@@ -39,24 +39,33 @@ export function createAppRagPort(): RagPort {
 }
 
 function mapResult(r: AppSearchResult): RagSearchResult {
+    const metadata = r.metadata as AppSearchResult["metadata"] & {
+        noteId?: number;
+        callId?: string;
+        revision?: number;
+    };
+    const source = r.source ?? metadata.source;
     return {
         pageContent: r.pageContent,
         pageNumber: r.pageNumber,
         title: r.title,
         documentId: r.documentId,
-        source: r.source,
+        source,
         retrievalMethod: r.retrievalMethod,
         metadata: {
-            chunkId: r.metadata.chunkId,
-            page: r.metadata.page,
-            documentId: r.metadata.documentId,
-            documentTitle: r.metadata.documentTitle,
-            distance: r.metadata.distance,
-            confidence: r.metadata.confidence,
-            source: r.metadata.source,
-            embeddingIndexKey: r.metadata.embeddingIndexKey,
-            rerankScore: r.metadata.rerankScore,
-            timestamp: r.metadata.timestamp,
+            chunkId: metadata.chunkId,
+            page: metadata.page,
+            documentId: metadata.documentId,
+            documentTitle: metadata.documentTitle,
+            distance: metadata.distance,
+            confidence: metadata.confidence,
+            source,
+            embeddingIndexKey: metadata.embeddingIndexKey,
+            rerankScore: metadata.rerankScore,
+            timestamp: metadata.timestamp,
+            ...(metadata.noteId === undefined ? {} : { noteId: metadata.noteId }),
+            ...(metadata.callId === undefined ? {} : { callId: metadata.callId }),
+            ...(metadata.revision === undefined ? {} : { revision: metadata.revision }),
         },
     };
 }

--- a/docs/CALL-NOTES-005-HANDOFF.md
+++ b/docs/CALL-NOTES-005-HANDOFF.md
@@ -1,0 +1,247 @@
+# CALL-NOTES-005 Handoff
+
+## 1. Scope
+
+This branch implements Junkun's assigned Call Notes lane:
+
+- post-call AI enrichment core;
+- structured-output and semantic provenance validation;
+- projection of accepted Call Notes into LaunchStack Knowledge;
+- embedding and retrieval safety for Call Notes; and
+- real-model smoke evidence.
+
+It does not take ownership of the application lifecycle or Accept/Reject orchestration. That seam remains with the team lead.
+
+## 2. Final Architecture
+
+```text
+Finalized Transcript + Bookmarks + Current Call Note
+        |
+        v
+EnrichmentInput
+        |
+        v
+A1 Enrichment Core
+- deterministic/versioned prompt
+- configured/model-neutral generation boundary
+- structured proposal
+- semantic provenance validation
+        |
+        v
+EnrichmentResult
+        |
+        v
+[APPLICATION LIFECYCLE / TEAM-LEAD SEAM]
+- persist run/proposal
+- user review
+- Accept/Reject
+- stale base revision handling
+- create canonical Call Note revision
+        |
+        v
+KnowledgeNote
+        |
+        v
+A2 Knowledge Integration
+- KnowledgeNoteSink
+- eligibility/current-revision validation
+- existing note.embedding.requested path
+- race-safe embedding replacement
+- company retrieval live eligibility filtering
+- notes-only retrieval
+- RAG Call Note metadata
+        |
+        v
+LaunchStack Knowledge / RAG
+```
+
+Three distinctions are architectural invariants:
+
+- Transcript != canonical Call Note.
+- AI proposal != canonical Call Note.
+- Embedding != canonical Call Note.
+
+The accepted, current Call Note is canonical.
+
+## 3. A1 — Enrichment Core
+
+A1 validates `EnrichmentInput`, serializes it deterministically, and sends it through the configured `reasoning` route behind the model-neutral `EnrichmentModel` boundary. The prompt preserves the owner-authored note as source context, treats finalized Transcript segments as factual evidence, marks gaps as unavailable evidence, and treats Bookmark comments as strong guidance rather than independent evidence. It prohibits inventing decisions, action owners, deadlines, speakers, Bookmark IDs, or Transcript segment IDs and prohibits inference across gaps.
+
+The model returns the frozen `EnrichedNoteProposal` structure. Zod validates the proposal, then semantic validation checks every model-produced Bookmark citation against the canonical Bookmark and Transcript segment, including identity, linkage, speaker, timestamp, and timestamp-range validity. A1 returns `EnrichmentResult` with the resolved model ID and versioned prompt metadata; it does not persist a run or mutate a Call Note.
+
+Key files:
+
+- `packages/features/src/call-notes/contracts.ts`
+- `packages/features/src/call-notes/ports.ts`
+- `apps/web/src/server/call-notes/enrichment-prompts.ts`
+- `apps/web/src/server/call-notes/enrichment-model.ts`
+- `apps/web/src/server/call-notes/enrichment-validation.ts`
+- `apps/web/__tests__/callNotes/enrichment-core.test.ts`
+
+## 4. Shared Structured Output Fix
+
+Commit `cc4c415c` fixes provider-neutral structured output for Zod object schemas with optional or defaulted properties. The shared layer converts the schema for compatibility inspection, recursively detects object properties that strict native JSON Schema cannot represent as optional, and safely selects the existing validated JSON fallback before spending an incompatible native request.
+
+Zod remains authoritative for parsing, validation, and defaults. The generic signature permits differing Zod input and output types. Compatible schemas can still use native structured output; fallback responses receive one existing repair attempt, not an open-ended retry loop.
+
+Key file: `packages/adapters/src/llm/structured-output.ts`.
+
+## 5. A2 — Knowledge Integration
+
+`KnowledgeNoteSink.upsert/remove` is the application-facing A2 boundary. `upsert` accepts only a `KnowledgeNote` that matches live canonical state:
+
+- canonical Call and document-note identity;
+- Call, document-note, and payload owner/company identity;
+- current positive revision;
+- `knowledgeIncluded = true`;
+- company visibility; and
+- completed Call state.
+
+It also verifies current canonical title and Markdown before removing the old searchable projection and enqueueing the existing durable `note.embedding.requested` path. `remove` deletes only the searchable projection; it does not delete or edit the canonical Call Note.
+
+Key files:
+
+- `apps/web/src/server/call-notes/knowledge-note-sink.ts`
+- `packages/features/src/call-notes/contracts.ts`
+- `packages/features/src/call-notes/ports.ts`
+- `apps/web/__tests__/callNotes/knowledge-note-sink.test.ts`
+
+## 6. Embedding Race Safety
+
+Embedding computation occurs outside the final transaction. Before replacement, the writer locks the canonical note and associated Call in a consistent order and rechecks live identity, revision, content, visibility, knowledge inclusion, and completed state:
+
+```text
+old embedding job
+        |
+        v
+final live state / revision / content recheck
+        |
+        +--> stale, private, or knowledge-off: discard/remove safely
+        |
+        `--> still current and eligible: atomic projection replacement
+```
+
+The delete-and-insert replacement is atomic. Stale cleanup cannot erase a newer eligible projection, and ordinary non-Call Note behavior remains compatible.
+
+Key files: `apps/web/src/server/notes/embed-note.ts` and `apps/web/__tests__/callNotes/note-embedding-race.test.ts`.
+
+## 7. Retrieval Safety
+
+Ordinary Notes retain their existing retrieval behavior. A company-scoped Call Note must additionally match current live Call state: canonical document-note and owner identity, company identity, completed status, company visibility, enabled knowledge inclusion, and a positive current revision.
+
+This is defense in depth:
+
+- write-side eligibility prevents ineligible projections from being created or refreshed; and
+- read-side eligibility filters stale or newly ineligible projections even if one remains temporarily.
+
+Company retrieval also supports the notes-only case, so eligible Notes and Call Notes remain searchable when the company has no document chunks. RAG results preserve `source`, `noteId`, and, for Call Notes, `callId` and `revision`.
+
+Key files:
+
+- `apps/web/src/lib/tools/rag/retrievers/notes-retriever.ts`
+- `apps/web/src/lib/tools/rag/search/ensemble-search.ts`
+- `apps/web/src/server/rag/port.ts`
+- `apps/web/__tests__/callNotes/notes-retriever-call-notes.test.ts`
+- `apps/web/__tests__/callNotes/company-notes-only-search.test.ts`
+- `apps/web/__tests__/callNotes/rag-call-note-metadata.test.ts`
+
+## 8. Embedding Index Decision
+
+Note writes and Note queries use the same legacy Note embedding space (`text-embedding-3-large`, 1,536 dimensions, with a 512-dimension short vector). Call Notes reuse the Note runtime and do not hardcode provider-specific embedding behavior.
+
+`resolveNoteEmbeddingRuntime` is the single resolver boundary for future configurable Note indexes. Arbitrary-dimension schema migration, reindexing, and cutover are intentionally deferred.
+
+Key file: `apps/web/src/server/notes/embedding-config.ts`.
+
+## 9. Live Kimi Smoke Evidence
+
+- Provider: Kimi / Moonshot
+- Endpoint: `https://api.moonshot.ai/v1`
+- Model: `kimi-k2.6`
+- Structured-output path: validated JSON fallback
+- Prompt version: `call-notes-enrichment-generation/v1`
+- Latency: approximately 153,758 ms
+- Result: PASS
+- Generated evidence: 2 grounded key points, 1 grounded action item, and 1 valid Bookmark citation
+- Semantic provenance: PASS
+- Final `EnrichmentResultSchema`: PASS
+
+This was one successful real-model invocation through an opt-in developer Kimi adapter. Production configured reasoning routing was not changed. The smoke performed no database mutation, lifecycle mutation, `KnowledgeNoteSink` invocation, or embedding write.
+
+Smoke tooling:
+
+- `apps/web/scripts/run-call-notes-enrichment-smoke.ts`
+- `apps/web/scripts/call-notes-kimi-smoke-adapter.ts`
+- `apps/web/scripts/run-call-notes-kimi-smoke.ts`
+
+## 10. Tests / Validation
+
+Validation collected on this branch:
+
+- consolidated Call Notes suites: 8 suites, 73 tests PASS;
+- `enrichment-core.test.ts`: 18 tests PASS (included in the consolidated count);
+- structured-output/transport regression suite: 1 suite, 34 tests PASS;
+- `@launchstack/web` typecheck: PASS;
+- `@launchstack/adapters` typecheck: PASS;
+- targeted ESLint for the three smoke scripts: PASS; and
+- targeted Prettier for the three smoke scripts: PASS.
+
+No live provider request was made during finalization validation.
+
+## 11. Commit Map
+
+Relevant commits in branch order:
+
+1. `72507a61` — specs and prototype
+2. `ea89902e` — frozen Zoom-first architecture contract
+3. `dd0b521f` — implementation ownership alignment
+4. `c4d1a55f` — A1 enrichment core
+5. `65ba4857` — A2.1 `KnowledgeNoteSink`
+6. `ca582113` — A2.2 race-safe Call Note embeddings
+7. `8424ffda` — A2.3 live Call Note eligibility filtering
+8. `2a9a0aa3` — A2.4 notes-only company retrieval
+9. `b90eeb0e` — A2.5 Call Note retrieval metadata
+10. `cc4c415c` — optional/defaulted Zod structured-output compatibility
+11. `469b981c` — opt-in Kimi enrichment smoke tooling
+
+## 12. Remaining Integration Seams
+
+Application/team-lead-owned:
+
+- build and supply production `EnrichmentInput`;
+- persist enrichment runs and proposals, including failures;
+- provide proposal review and Accept/Reject;
+- handle base-revision conflicts and create canonical revisions;
+- invoke A2 after canonical lifecycle changes; and
+- remove knowledge before deleting a Call.
+
+Still deferred:
+
+- canonical Calls deep-link route;
+- guided enrichment rerun/revision;
+- fully configurable, dimension-aware Note embedding migration; and
+- production Kimi provider routing, if ever desired.
+
+These are integration or deferred product seams, not unfinished Junkun-owned application lifecycle work.
+
+## 13. Integration Contract
+
+The clean handoff boundary is:
+
+```text
+Application layer provides: EnrichmentInput
+A1 returns:                EnrichmentResult
+
+After the application creates or updates the accepted canonical Call Note:
+Application layer provides: KnowledgeNote
+A2 provides:                KnowledgeNoteSink.upsert/remove
+```
+
+The application can wire these contracts without copying A1 prompt, validation, embedding, or retrieval logic.
+
+## 14. Known Limitations
+
+- The Kimi smoke took approximately 154 seconds on the synthetic fixture.
+- The live smoke uses an opt-in developer Kimi adapter; production routing remains separately configured.
+- The canonical Calls deep-link route is not finalized.
+- Configurable arbitrary-dimension Note embedding migration and reindexing are deferred.

--- a/docs/call-notes/implementation-contract.md
+++ b/docs/call-notes/implementation-contract.md
@@ -1,0 +1,90 @@
+# Call Notes Implementation Contract
+
+**Contract:** `call-notes/v1`
+**Enrichment output:** `call-notes-enrichment/v1`
+**Execution epic:** [MN-IMP-000](../issues/call-notes-implementation/000-implement-call-notes-zoom-first.md)
+
+This is the shared handoff for independent implementation lanes. Wayfinder tickets remain the source for architecture rationale; exported TypeScript/Zod/Drizzle artifacts are the executable source for wire and persistence shape.
+
+## Domain invariants
+
+- A **Call** is one company-scoped provider occurrence.
+- A Call owns one logical **Capture**. Start/Pause/Resume intent lives on Capture, not on a socket.
+- Each connected or continued stream is a **Capture Attempt** anchored to one authorized **Capture User**.
+- The same Capture User returning while desired mode is `running` creates a new attempt under the existing Call; returning while desired mode is `paused` stays paused.
+- **Transcript Segment** evidence is immutable. Provider timestamps order it when available; `receivedAt` plus `receiveOrder` is the fallback.
+- Known missing intervals are durable **Gaps**. Any retained Transcript with a known gap finalizes as `partial`, never silently `complete`.
+- Every Call has at most one canonical editable **Call Note**, backed by existing `document_notes` and owned by the first user whose Capture start succeeds.
+- Transcript evidence is company-visible. The owner may make the Call Note private; non-owners then receive `note: null` while the Transcript remains visible.
+- **Enriched Note** is a proposal and immutable run record until the owner explicitly accepts or rejects it. Accept creates a new canonical-note revision.
+- Company knowledge contains only the current canonical Call Note when its owner explicitly enables inclusion. Transcript segments never enter company RAG in this release.
+
+## Executable surface
+
+`@launchstack/features/call-notes` exports:
+
+| Artifact                                           | Purpose                                                                           |
+| -------------------------------------------------- | --------------------------------------------------------------------------------- |
+| `CallNotesCommandSchema`                           | Internal application commands issued by authenticated API edges                   |
+| `DetectedCallCandidateSchema`                      | Best-effort pre-Start suggestion; it is not a Call until Start succeeds           |
+| `CaptureEventSchema`                               | The only provider-to-domain event language                                        |
+| `CallSnapshotSchema`                               | Read model consumed by APIs and the Calls UI; supports private-note redaction     |
+| `EnrichmentInputSchema` / `EnrichmentResultSchema` | Model boundary with provenance-ready structured output                            |
+| `KnowledgeNoteSchema`                              | The one downstream knowledge record                                               |
+| `CaptureSource`                                    | Zoom runtime seam; future adapters must satisfy the same normalized contract      |
+| `CallNotesApplication`                             | Domain/application seam consumed by API handlers and conformance tests            |
+| `EnrichmentModel` / `KnowledgeNoteSink`            | AI and retrieval boundaries                                                       |
+| `CALL_NOTES_CAPTURE_EVENTS`                        | Deterministic Zoom occurrence with Pause, Resume, leave, return, and finalization |
+| `assertCaptureSourceContract`                      | Reusable provider conformance check                                               |
+| `runCallNotesVerticalTracer`                       | Shared simulated end-to-end acceptance contract                                   |
+
+The product schema is exported through `@launchstack/features/schema`; its migrations are `apps/web/drizzle/20260820010959_simple_khan.sql`, `apps/web/drizzle/20260820055456_deep_veda.sql`, and `apps/web/drizzle/20260820055726_famous_titanium_man.sql`.
+
+## Replay and identity contract
+
+| Boundary            | Stable identity                        |
+| ------------------- | -------------------------------------- |
+| User command        | `companyId + requestId`                |
+| Provider occurrence | `companyId + provider + occurrenceKey` |
+| Capture attempt     | `captureId + providerAttemptKey`       |
+| Transcript packet   | `attemptId + sourcePacketHash`         |
+| Durable work        | `companyId + kind + idempotencyKey`    |
+
+A provider event may be delivered more than once or after a newer event. Consumers must make repeats harmless and must not replace immutable evidence. `eventId` identifies the normalized observation; `providerEventKey` is preferred when Zoom supplies one; `sourcePacketHash` remains required for transcript replay safety.
+
+## Authorization contract
+
+| Capability                                          | Call Note owner | Same-company user | Company admin |
+| --------------------------------------------------- | --------------: | ----------------: | ------------: |
+| Read Transcript and company-visible note            |             yes |               yes |           yes |
+| Read private note                                   |             yes |                no |            no |
+| Edit note, privacy, enrichment, knowledge inclusion |             yes |                no |            no |
+| Create a company-visible Bookmark                   |             yes |                no |            no |
+| Delete an empty failed Call                         |             yes |                no |           yes |
+| Delete a completed or non-empty Call                | no unless admin |                no |           yes |
+
+OAuth tokens, worker leases, and operator configuration are never exposed by `CallSnapshot`.
+
+## Conformance boundary
+
+The shared tracer drives Start through final knowledge inclusion. Its subject must be the real `CallNotesApplication` backed by the production state machine, repositories, authorization, and PostgreSQL. Zoom transport and model output may be deterministic fakes. A recording `KnowledgeNoteProbe` may observe the production sink boundary.
+
+```ts
+import {
+  runCallNotesVerticalTracer,
+  assertCaptureSourceContract,
+} from "@launchstack/features/call-notes";
+
+await assertCaptureSourceContract(zoomCaptureSource);
+await runCallNotesVerticalTracer(callNotesApplication, recordingKnowledgeSink);
+```
+
+Lane-local tests should reuse the fixture and conformance functions, then add only behavior owned by that lane. The final integration suite exercises PostgreSQL, API handlers, and production UI rather than creating a second mocked Call Notes state machine.
+
+## Contract changes
+
+No lane duplicates or widens these types locally. A mismatch is reported with the failing fixture/event/command and the smallest proposed change. Kien updates the canonical contract, schema/migration when applicable, fixture, and conformance expectation together. Consumers then move to that revision without shims or deprecated aliases.
+
+## Deferred seams
+
+Google Meet/native capture, raw-media/ASR, transcript revisions, cross-user Capture handoff, overlapping Attempts, automatic knowledge inclusion, and centrally hosted OAuth are deliberately absent. Add them only after observed demand or provider evidence invalidates this minimal Zoom-first contract.

--- a/docs/issues/call-notes-implementation/000-implement-call-notes-zoom-first.md
+++ b/docs/issues/call-notes-implementation/000-implement-call-notes-zoom-first.md
@@ -35,6 +35,12 @@ flowchart LR
 
 MN-IMP-003, MN-IMP-004, and MN-IMP-005 may proceed against the deterministic contract fixtures while target-account Zoom verification remains open. MN-IMP-002 may implement everything supported by the settled official contract, but pilot acceptance remains blocked on MN-WF-013 evidence.
 
+## Week Five team alignment
+
+The [Week Five implementation plan](https://docs.google.com/document/d/1ny0H3b_c4RsnJtZ3ed565pE61hya-naT7Rf8pZRh70Y/edit?tab=t.0) agrees with the Zoom-first vertical slice, normalized provider boundary, transcript finalization, synthetic-fixture parallelism, reviewable AI proposal, and deliberate knowledge acceptance. Its provisional-schema premise is obsolete: `call-notes/v1` is frozen, so every lane consumes the shared contract directly and adds no local contract or adapter.
+
+Kien retains Zoom integration because he owns the target Zoom account, as well as canonical contract approval and final release integration. Junkun leads day-to-day implementation and owns enrichment/knowledge. Hank owns the Calls product surface. Peace owns domain/persistence, transcript finalization, shared fixture integration, and the E2E harness. The delivery milestones are fixture E2E, real Zoom E2E, then knowledge integration.
+
 ## Shared baseline
 
 The canonical contract pack is `@launchstack/features/call-notes`:
@@ -49,15 +55,15 @@ Architecture decisions remain in `docs/issues/call-notes-wayfinder/001` through 
 
 ## Ownership and collision rules
 
-| Lane                     | Owner      | Exclusive surface                                                                                                         |
-| ------------------------ | ---------- | ------------------------------------------------------------------------------------------------------------------------- |
-| Contract and integration | Kien       | Canonical contracts, schema/migration, fixtures, package exports, root environment/Compose wiring, final cross-lane fixes |
-| Zoom integration         | Kien       | `apps/call-worker/**`; web OAuth/callback/signed-webhook edge; provider adapter                                           |
-| Domain and persistence   | Teammate-1 | Call/Capture services, repositories, authorization, commands, state transitions, product API handlers                     |
-| Product surface          | Teammate-2 | Production Calls pages/components/client behavior and their UI tests                                                      |
-| Enrichment and knowledge | Teammate-3 | Enrichment generation, provenance/revisions, knowledge sink and retrieval integration                                     |
+| Lane                       | Owner  | Exclusive surface                                                                                                         |
+| -------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------- |
+| Contract and final release | Kien   | Canonical contracts, schema/migration, fixtures, package exports, root environment/Compose wiring, final cross-lane fixes |
+| Zoom integration           | Kien   | `apps/call-worker/**`; web OAuth/callback/signed-webhook edge; provider adapter                                           |
+| Domain and persistence     | Peace  | Call/Capture services, repositories, transcript finalization, fixtures/E2E harness, product API handlers                  |
+| Product surface            | Hank   | Production Calls pages/components/client behavior and their UI tests                                                      |
+| Enrichment and knowledge   | Junkun | Enrichment generation, provenance/revisions, knowledge sink and retrieval integration                                     |
 
-A lane may consume another lane's public interface but must not edit its exclusive surface. Teammates do not edit canonical contracts, schema/migration, root exports, environment parsing, Docker/worker wiring, or another lane's files. Kien resolves shared wiring and integration conflicts.
+A lane may consume another lane's public interface but must not edit its exclusive surface. Teammates do not edit canonical contracts, schema/migration, root exports, environment parsing, Docker/worker wiring, or another lane's files. Junkun coordinates implementation handbacks and reports seam requests; Kien approves contract changes and resolves final wiring and integration conflicts.
 
 ## Contract-change protocol
 

--- a/docs/issues/call-notes-implementation/000-implement-call-notes-zoom-first.md
+++ b/docs/issues/call-notes-implementation/000-implement-call-notes-zoom-first.md
@@ -1,0 +1,91 @@
+---
+id: MN-IMP-000
+title: Implement Call Notes Zoom-First Vertical Slice
+status: open
+assignee: Kien
+labels:
+  - call-notes
+  - implementation
+  - epic
+tracker: local-markdown
+blocked_by: []
+---
+
+# Implement Call Notes Zoom-First Vertical Slice
+
+## Outcome
+
+A production Call Notes feature for one self-hosted LaunchStack deployment: an authorized user can capture a Zoom occurrence, see an attributed live Transcript with honest gaps, write one owner-controlled Call Note, review a post-call AI proposal, and deliberately include the accepted canonical note in company knowledge.
+
+## Delivery graph
+
+```mermaid
+flowchart LR
+    C[MN-IMP-001 Contract baseline] --> R[MN-IMP-002 Zoom runtime]
+    C --> D[MN-IMP-003 Domain and persistence]
+    C --> U[MN-IMP-004 Calls product surface]
+    C --> A[MN-IMP-005 Enrichment and knowledge]
+    R --> I[MN-IMP-006 Vertical integration]
+    D --> I
+    U --> I
+    A --> I
+    Z[MN-WF-013 Target Zoom verification] -. provider facts .-> R
+    Z -. pilot gate .-> I
+```
+
+MN-IMP-003, MN-IMP-004, and MN-IMP-005 may proceed against the deterministic contract fixtures while target-account Zoom verification remains open. MN-IMP-002 may implement everything supported by the settled official contract, but pilot acceptance remains blocked on MN-WF-013 evidence.
+
+## Shared baseline
+
+The canonical contract pack is `@launchstack/features/call-notes`:
+
+- `contracts.ts`: commands, normalized capture events, snapshots, enrichment payloads, and knowledge output.
+- `ports.ts`: capture source, application, model, knowledge sink, clock, and ID boundaries.
+- `schema.ts` plus the product migrations: shared persistence contract.
+- `testing.ts`: deterministic Zoom timeline, capture-source conformance, and simulated vertical tracer.
+- `apps/web/__tests__/callNotes/contracts.test.ts`: focused behavior checks for the frozen contract.
+
+Architecture decisions remain in `docs/issues/call-notes-wayfinder/001` through `014`. The prototype is interaction evidence, not production code.
+
+## Ownership and collision rules
+
+| Lane                     | Owner      | Exclusive surface                                                                                                         |
+| ------------------------ | ---------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Contract and integration | Kien       | Canonical contracts, schema/migration, fixtures, package exports, root environment/Compose wiring, final cross-lane fixes |
+| Zoom integration         | Kien       | `apps/call-worker/**`; web OAuth/callback/signed-webhook edge; provider adapter                                           |
+| Domain and persistence   | Teammate-1 | Call/Capture services, repositories, authorization, commands, state transitions, product API handlers                     |
+| Product surface          | Teammate-2 | Production Calls pages/components/client behavior and their UI tests                                                      |
+| Enrichment and knowledge | Teammate-3 | Enrichment generation, provenance/revisions, knowledge sink and retrieval integration                                     |
+
+A lane may consume another lane's public interface but must not edit its exclusive surface. Teammates do not edit canonical contracts, schema/migration, root exports, environment parsing, Docker/worker wiring, or another lane's files. Kien resolves shared wiring and integration conflicts.
+
+## Contract-change protocol
+
+A discovered mismatch blocks only the affected seam. The owner reports the failing scenario and proposes the smallest contract change; no lane adds a local duplicate type, optional escape hatch, compatibility shim, or workaround. Kien updates the canonical contract, migration/fixture if needed, and conformance expectation. Affected lanes then consume the revised baseline.
+
+## Independent handback
+
+Each lane returns an integration-ready branch/worktree containing:
+
+- the public interfaces and owned artifacts it completed;
+- focused behavior and shared-conformance results;
+- the owned files changed;
+- unresolved contract requests;
+- operational assumptions or known failures.
+
+Lane owners do not merge, edit root wiring, or integrate other lanes.
+
+## Epic acceptance
+
+- The production state path is `Zoom -> normalized capture events -> Call/Capture persistence -> product APIs -> Calls UI -> enrichment proposal -> accepted Call Note -> knowledge sink`.
+- The shared vertical tracer passes through the real domain state machine, PostgreSQL repositories, API handlers, and production UI with only Zoom transport and model output faked.
+- One real Zoom meeting proves that the adapter emits the normalized events exercised by the deterministic fixture.
+- One configured model smoke proves the enrichment schema; deterministic model fixtures remain the correctness oracle.
+- Replayed provider events do not duplicate Transcript segments, work, or Calls.
+- Pause, reconnect, same-user return, partial finalization, private-note isolation, owner-only edits, deletion, and knowledge include/remove behavior are proven.
+- Self-hosted Docker and Vercel-plus-private-worker modes use the same application contract and normal LaunchStack public HTTPS origin.
+- Pilot enablement remains fail-closed until MN-WF-013 supplies the verified concurrency, rate, Pause billing, reconnect, and continuation facts.
+
+## Non-goals
+
+Google Meet or native capture, raw-media retention, custom streaming ASR, live copilot behavior, transcript editing, cross-user capture handoff, centralized OAuth/SaaS operation, automatic company-wide indexing, and a second knowledge system.

--- a/docs/issues/call-notes-implementation/001-freeze-call-notes-contract-baseline.md
+++ b/docs/issues/call-notes-implementation/001-freeze-call-notes-contract-baseline.md
@@ -1,0 +1,51 @@
+---
+id: MN-IMP-001
+title: Freeze the Call Notes Contract Baseline
+parent: MN-IMP-000
+status: closed
+assignee: Kien
+labels:
+  - call-notes
+  - contracts
+  - architecture
+tracker: local-markdown
+blocked_by: []
+---
+
+# Freeze the Call Notes Contract Baseline
+
+## Outcome
+
+One versioned, executable source of truth lets four lanes implement independently without inventing competing Call, Capture, Transcript, note, enrichment, or knowledge contracts.
+
+## Owned surface
+
+- `packages/features/src/call-notes/contracts.ts`
+- `packages/features/src/call-notes/ports.ts`
+- `packages/features/src/call-notes/schema.ts`
+- `packages/features/src/call-notes/testing.ts`
+- `packages/features/src/call-notes/index.ts`
+- `packages/features/src/schema.ts` and package exports
+- Call Notes product migrations
+- Shared contract behavior tests
+
+## Acceptance
+
+- Public commands, normalized provider events, query snapshots, enrichment structures, and knowledge output parse through exported Zod schemas.
+- The persistence schema represents Call, one logical Capture, multiple Capture Attempts, immutable segments, participants, gaps, Bookmarks, canonical-note revisions, enrichment runs, durable work, and operator-owned Zoom authorization.
+- Stable occurrence, attempt, provider-event, packet-hash, request, and work-item keys define replay behavior.
+- Deterministic fixtures cover detected-candidate Dismiss, Start, authoritative Pause/Resume commands, duplicate and late Transcript delivery, capture-user departure, automatic same-user continuation as a new attempt, partial finalization, owner-only Bookmarks, wrong-company not-found behavior, private-note and knowledge isolation, enrichment review/acceptance, transcript search, and knowledge inclusion.
+- Reusable capture-source and application conformance boundaries are exported for every lane.
+- Feature and web typechecks plus focused contract tests pass.
+
+## Relevant decisions
+
+MN-WF-001 through MN-WF-014.
+
+## Non-goals
+
+No Zoom SDK connection, production repository/service, API route, UI, model call, embedding job, Docker wiring, or substitute in-memory Call Notes implementation.
+
+## Resolution
+
+The baseline is frozen at `call-notes/v1` with enrichment output `call-notes-enrichment/v1`. Contract changes now use the epic's strict change protocol and are integrated only by Kien.

--- a/docs/issues/call-notes-implementation/002-implement-zoom-capture-runtime.md
+++ b/docs/issues/call-notes-implementation/002-implement-zoom-capture-runtime.md
@@ -27,6 +27,8 @@ Consumes `StartCaptureInput`, `CaptureControlInput`, durable commands/webhook ev
 
 `apps/call-worker/**`, provider-adapter tests, and the Zoom-specific integration module consumed by the web edge. Per MN-WF-006, `apps/web` hosts OAuth initiation/callbacks and the public signed-webhook endpoint; the worker publishes no endpoint. Root environment/Compose wiring and shared package changes remain Kien's integration work.
 
+Kien retains this lane because the target Zoom account required for OAuth, RTMS, and pilot evidence is available only to him.
+
 ## Acceptance
 
 - OAuth tokens are encrypted at rest and scoped to the LaunchStack user/company connection that owns them.

--- a/docs/issues/call-notes-implementation/002-implement-zoom-capture-runtime.md
+++ b/docs/issues/call-notes-implementation/002-implement-zoom-capture-runtime.md
@@ -1,0 +1,48 @@
+---
+id: MN-IMP-002
+title: Implement the Zoom Capture Runtime
+parent: MN-IMP-000
+status: open
+assignee: Kien
+labels:
+  - call-notes
+  - zoom
+  - runtime
+tracker: local-markdown
+blocked_by:
+  - MN-IMP-001
+---
+
+# Implement the Zoom Capture Runtime
+
+## Outcome
+
+A private long-running Node worker consumes commands and signed webhook events, owns RTMS transcript streams, and turns provider lifecycle signals into the normalized `CaptureEvent` contract while executing authoritative Start, Pause, Resume, reconnect, and same-user continuation behavior.
+
+## Contracts consumed and provided
+
+Consumes `StartCaptureInput`, `CaptureControlInput`, durable commands/webhook events, Zoom connection references, and the settled provider facts. Provides `CaptureSource`, normalized `CaptureEvent` delivery, worker health/readiness, and replay-safe provider identities. Unknown MN-WF-013 account limits remain fail-closed configuration, not guessed constants.
+
+## Owned surface
+
+`apps/call-worker/**`, provider-adapter tests, and the Zoom-specific integration module consumed by the web edge. Per MN-WF-006, `apps/web` hosts OAuth initiation/callbacks and the public signed-webhook endpoint; the worker publishes no endpoint. Root environment/Compose wiring and shared package changes remain Kien's integration work.
+
+## Acceptance
+
+- OAuth tokens are encrypted at rest and scoped to the LaunchStack user/company connection that owns them.
+- Zoom webhook authenticity and tenant/user routing fail closed.
+- The Node RTMS client exposes attributed transcript segments, timestamps/order, lifecycle events, and native Pause/Resume through the frozen capture-source contract.
+- The worker runtime is Node 22 or newer, matching the supported official `@zoom/rtms` package contract.
+- Provider duplicates and reconnect replay retain stable identities; the worker never creates product Calls directly.
+- Same-user return starts a new attempt under the same occurrence; paused intent remains paused and running intent resumes automatically.
+- Lease loss, worker restart, reconnect, provider stop, and terminal failure become explicit normalized evidence rather than silent loss.
+- The shared capture-source conformance suite passes; one real target-account meeting produces the same normalized event classes as the deterministic fixture.
+- The worker runs privately in self-hosted Docker and beside Vercel without a public worker port.
+
+## Relevant decisions
+
+MN-WF-001, MN-WF-006, MN-WF-007, MN-WF-009, MN-WF-010, MN-WF-012, and MN-WF-013.
+
+## Non-goals
+
+Product-domain state transitions, Calls API/UI, AI enrichment, knowledge indexing, Google Meet, native/browser capture, raw-media retention, custom ASR, a public queue, or a provider framework beyond the `CaptureSource` seam.

--- a/docs/issues/call-notes-implementation/003-implement-call-notes-domain-persistence.md
+++ b/docs/issues/call-notes-implementation/003-implement-call-notes-domain-persistence.md
@@ -3,7 +3,7 @@ id: MN-IMP-003
 title: Implement Call Notes Domain and Persistence
 parent: MN-IMP-000
 status: open
-assignee: Teammate-1
+assignee: Peace
 labels:
   - call-notes
   - domain
@@ -26,6 +26,8 @@ Consumes `CallNotesCommand`, `CaptureEvent`, the canonical Drizzle tables, deter
 ## Owned surface
 
 Call/Capture domain services, repositories, authorization rules, state transitions, finalization, durable work claiming, application-service implementation, and Call Notes product API handlers. Canonical contracts/schema/migration, Zoom runtime, production UI, enrichment internals, and root wiring are exclusive to other lanes.
+
+Peace also owns transcript finalization, shared fixture alignment, and the deterministic integration harness. Root environment/Compose wiring and the final cross-lane merge remain Kien's responsibility.
 
 ## Acceptance
 

--- a/docs/issues/call-notes-implementation/003-implement-call-notes-domain-persistence.md
+++ b/docs/issues/call-notes-implementation/003-implement-call-notes-domain-persistence.md
@@ -1,0 +1,48 @@
+---
+id: MN-IMP-003
+title: Implement Call Notes Domain and Persistence
+parent: MN-IMP-000
+status: open
+assignee: Teammate-1
+labels:
+  - call-notes
+  - domain
+  - backend
+tracker: local-markdown
+blocked_by:
+  - MN-IMP-001
+---
+
+# Implement Call Notes Domain and Persistence
+
+## Outcome
+
+The frozen Call Notes commands and normalized capture events drive one durable, company-scoped Call/Capture state machine backed by PostgreSQL, with authorization, idempotency, partial outcomes, and query behavior suitable for the production UI and worker.
+
+## Contracts consumed and provided
+
+Consumes `CallNotesCommand`, `CaptureEvent`, the canonical Drizzle tables, deterministic clock/ID sources, and knowledge/enrichment ports. Provides the real `CallNotesApplication` implementation and stable product API handlers for commands, Call lists/details, Transcript search, and live state updates.
+
+## Owned surface
+
+Call/Capture domain services, repositories, authorization rules, state transitions, finalization, durable work claiming, application-service implementation, and Call Notes product API handlers. Canonical contracts/schema/migration, Zoom runtime, production UI, enrichment internals, and root wiring are exclusive to other lanes.
+
+## Acceptance
+
+- One provider occurrence maps idempotently to one Call and one logical Capture; every connected or continued stream is a separate Capture Attempt.
+- Segment insertion is immutable and replay-safe by provider identity or packet hash, with timestamp-first and receive-order fallback ordering.
+- Pause, Resume, transport interruption, capture-user absence/return, worker unavailability, occurrence end, and failure maintain explicit gaps and honest complete/partial/failed outcomes.
+- Request/work idempotency and PostgreSQL leases survive retries, worker restart, reconnect replay, and concurrent claims without adding another queue.
+- Eligible detected occurrences and per-user Dismiss suppression remain separate from Calls until Start; dismissing one occurrence does not suppress future occurrences.
+- Company membership scopes every access. Company users can read the Transcript; only the owner edits/enriches the canonical Call Note; private notes are redacted from other users; company-admin Call deletion and owner deletion of empty failed Calls follow MN-WF-008.
+- The first successful Capture start owns the one canonical `document_notes` row and revision history; accepted enrichment never overwrites owner changes implicitly.
+- Transcript search filters immutable segments without indexing Transcript evidence into company RAG.
+- Focused state-machine/repository tests and the shared application conformance tracer pass against PostgreSQL and deterministic external fakes.
+
+## Relevant decisions
+
+MN-WF-002 through MN-WF-012 and MN-WF-014.
+
+## Non-goals
+
+Zoom SDK/OAuth behavior, page/component implementation, model prompts, embeddings/retrieval implementation, root exports/Compose, a second note store, transcript editing, or cross-user Capture handoff.

--- a/docs/issues/call-notes-implementation/004-implement-calls-product-surface.md
+++ b/docs/issues/call-notes-implementation/004-implement-calls-product-surface.md
@@ -1,0 +1,47 @@
+---
+id: MN-IMP-004
+title: Implement the Calls Product Surface
+parent: MN-IMP-000
+status: open
+assignee: Teammate-2
+labels:
+  - call-notes
+  - frontend
+  - product
+tracker: local-markdown
+blocked_by:
+  - MN-IMP-001
+---
+
+# Implement the Calls Product Surface
+
+## Outcome
+
+The accepted single-workspace interaction becomes the production Calls experience: a persistent Calls rail, note-first Call workspace, live attributed Transcript, visible capture state/gaps, Bookmarks, privacy, post-call enrichment review, and deliberate knowledge inclusion.
+
+## Contracts consumed and provided
+
+Consumes `CallSnapshot`, Call Notes command/query schemas, stable product APIs, and deterministic fixtures. Provides production Calls routes/components/client behavior and UI-level accessibility/interaction tests without embedding domain or provider policy in the browser.
+
+## Owned surface
+
+Production Calls pages, layouts, components, client state, navigation entry, styling, and their UI tests. Product API handlers, domain persistence, shared contracts/schema, Zoom runtime, enrichment internals, and root integration files remain outside this lane.
+
+## Acceptance
+
+- The prototype's accepted interaction contract is preserved: one compact Live/Recent Calls rail and one restrained, note-first Call detail pane with a contained collapsed Transcript card.
+- Start, detected-call suggestion, manual Zoom URL/meeting ID fallback, Pause, Resume, connecting/live/paused/partial/failed/finalizing states, and retryable outcomes are understandable without hidden provider assumptions.
+- Transcript search filters the current immutable segment list; Bookmarks are visible on hover and keyboard/touch access; speaker/timestamp evidence remains legible.
+- Note edits expose real saving/saved/failed state, never only optimistic local text.
+- Transcript evidence stays company-visible; owner-only edits and private-note redaction are reflected exactly as returned by the API.
+- AI-enhanced is a separate editable proposal with provenance/conflict/citation cues, explicit Accept/Reject, and no silent overwrite of My notes.
+- Knowledge inclusion defaults off and clearly controls the canonical accepted Call Note, not Transcript indexing.
+- Desktop and narrow-browser flows are visually exercised against contract fixtures, with keyboard access and reduced-motion behavior intact.
+
+## Relevant decisions
+
+MN-WF-003 through MN-WF-005, MN-WF-008, MN-WF-011, MN-WF-012, and MN-WF-014. The prototype at `/prototypes/call-notes` is behavior evidence only.
+
+## Non-goals
+
+Reusing prototype code as a production state store, writing product APIs, editing shared schemas, Zoom SDK work, AI orchestration, transcript correction, live copilot features, native/browser recording, or pixel-for-pixel preservation of discarded prototype variants.

--- a/docs/issues/call-notes-implementation/004-implement-calls-product-surface.md
+++ b/docs/issues/call-notes-implementation/004-implement-calls-product-surface.md
@@ -3,7 +3,7 @@ id: MN-IMP-004
 title: Implement the Calls Product Surface
 parent: MN-IMP-000
 status: open
-assignee: Teammate-2
+assignee: Hank
 labels:
   - call-notes
   - frontend

--- a/docs/issues/call-notes-implementation/005-implement-enrichment-knowledge.md
+++ b/docs/issues/call-notes-implementation/005-implement-enrichment-knowledge.md
@@ -3,7 +3,7 @@ id: MN-IMP-005
 title: Implement Enrichment and Knowledge Integration
 parent: MN-IMP-000
 status: open
-assignee: Teammate-3
+assignee: Junkun
 labels:
   - call-notes
   - ai

--- a/docs/issues/call-notes-implementation/005-implement-enrichment-knowledge.md
+++ b/docs/issues/call-notes-implementation/005-implement-enrichment-knowledge.md
@@ -1,0 +1,47 @@
+---
+id: MN-IMP-005
+title: Implement Enrichment and Knowledge Integration
+parent: MN-IMP-000
+status: open
+assignee: Teammate-3
+labels:
+  - call-notes
+  - ai
+  - knowledge
+tracker: local-markdown
+blocked_by:
+  - MN-IMP-001
+---
+
+# Implement Enrichment and Knowledge Integration
+
+## Outcome
+
+A completed Call can produce one reviewable, transcript-grounded Enriched Note proposal, preserve generation provenance and the owner's accepted revision, and synchronize only the deliberately included canonical Call Note through LaunchStack's existing note retrieval path.
+
+## Contracts consumed and provided
+
+Consumes finalized Transcript segments/gaps, Bookmarks, the current owner Call Note, `EnrichmentInput`, and existing LaunchStack model/note-embedding facilities. Provides `EnrichmentModel`, validated `EnrichmentResult`, immutable run provenance, and `KnowledgeNoteSink` behavior for include, reindex, and removal.
+
+## Owned surface
+
+Post-call enrichment orchestration, prompts/model routing, structured-output validation, proposal/provenance handling, canonical-note knowledge synchronization, deep links, and focused AI/knowledge tests. Domain state transitions and repositories, Zoom runtime, production UI, canonical schema/contracts, and root wiring remain outside this lane.
+
+## Acceptance
+
+- Enrichment is an explicit post-call action and creates a proposal separate from My notes; failure or invalid structured output never mutates the canonical note.
+- Transcript order and substantive coverage are preserved while the owner's context controls emphasis. Unsupported owner text is retained and visibly labeled rather than silently discarded.
+- The structured result contains chronological sections, a final summary, decisions/action items where present, and conflict records required by the frozen schema.
+- Each run records transcript fingerprint, base note revision, model/provider/prompt metadata, original output, editable proposal, and final Accept/Reject resolution.
+- Bookmark-derived passages expose segment/speaker/timestamp citations; ordinary generated sections do not create noisy paragraph-level citation decoration.
+- Accept creates a new canonical Call Note revision only when the expected base still applies; Reject preserves both the owner note and immutable run history.
+- Knowledge inclusion defaults off. Include/upsert indexes the current canonical `document_notes` revision with a Call deep link; later accepted or manual revisions reindex; removal/private/delete paths remove or update retrieval visibility without indexing Transcript segments.
+- Deterministic model and knowledge fakes cover correctness; one configured model smoke validates the real structured-output path.
+
+## Relevant decisions
+
+MN-WF-004, MN-WF-005, MN-WF-008, MN-WF-011, and MN-WF-012.
+
+## Non-goals
+
+Call/Capture lifecycle implementation, Zoom capture, Calls UI, a second knowledge database, automatic Transcript RAG, automatic knowledge inclusion, autonomous acceptance, live meeting copilot behavior, or a general-purpose enrichment framework.

--- a/docs/issues/call-notes-implementation/006-integrate-zoom-first-vertical-slice.md
+++ b/docs/issues/call-notes-implementation/006-integrate-zoom-first-vertical-slice.md
@@ -28,7 +28,7 @@ Consumes every lane's handback and the frozen conformance pack. Provides the onl
 
 ## Owned surface
 
-Root/package exports, dependency injection, environment parsing, Docker Compose and deployment wiring, worker registration/health, cross-lane conflict resolution, shared conformance execution, release documentation, and pilot gate configuration. Lane internals change only when a failing shared contract demonstrates a necessary integration fix.
+Root/package exports, dependency injection, environment parsing, Docker Compose and deployment wiring, worker registration/health, cross-lane conflict resolution, release documentation, and pilot gate configuration. Peace hands back the shared fixture/E2E harness and integration write-up; Kien owns the final merge and release evidence. Lane internals change only when a failing shared contract demonstrates a necessary integration fix.
 
 ## Acceptance
 

--- a/docs/issues/call-notes-implementation/006-integrate-zoom-first-vertical-slice.md
+++ b/docs/issues/call-notes-implementation/006-integrate-zoom-first-vertical-slice.md
@@ -1,0 +1,50 @@
+---
+id: MN-IMP-006
+title: Integrate the Zoom-First Vertical Slice
+parent: MN-IMP-000
+status: open
+assignee: Kien
+labels:
+  - call-notes
+  - integration
+  - release
+tracker: local-markdown
+blocked_by:
+  - MN-IMP-002
+  - MN-IMP-003
+  - MN-IMP-004
+  - MN-IMP-005
+---
+
+# Integrate the Zoom-First Vertical Slice
+
+## Outcome
+
+The four independently implemented lanes become one deployable feature with shared package/export wiring, environment configuration, worker lifecycle, API/UI integration, deterministic end-to-end evidence, real Zoom evidence, and fail-closed pilot controls.
+
+## Contracts consumed and provided
+
+Consumes every lane's handback and the frozen conformance pack. Provides the only cross-lane merge, root dependency/environment/Compose wiring, migration integration, production feature enablement, and release evidence.
+
+## Owned surface
+
+Root/package exports, dependency injection, environment parsing, Docker Compose and deployment wiring, worker registration/health, cross-lane conflict resolution, shared conformance execution, release documentation, and pilot gate configuration. Lane internals change only when a failing shared contract demonstrates a necessary integration fix.
+
+## Acceptance
+
+- Self-hosted Docker starts web, PostgreSQL, and one private call worker behind the normal LaunchStack HTTPS origin; Vercel can use the same web contract with the worker hosted privately elsewhere.
+- Database migration applies and verifies against a clean database; rollback/upgrade impact is explicit.
+- The shared simulated vertical tracer passes through the real state machine, PostgreSQL, product API, production Calls UI, deterministic capture adapter, deterministic model, and recording knowledge sink.
+- Duplicate and out-of-order capture events, worker restart, lease expiry, provider reconnect, user Pause/Resume, same-user leave/return, partial finalization, stale enrichment acceptance, private-note access, deletion, and knowledge removal are exercised at the production boundaries.
+- One real Zoom meeting confirms normalized events and authoritative Pause/Resume/reconnect/continuation behavior; one configured model confirms structured output.
+- Operational health identifies web, database, worker, OAuth/webhook validity, active/leased attempts, stuck work, and failed finalization without introducing a new queue or public worker endpoint.
+- Every authenticated user in the deployment may access Call Notes after connecting an eligible Zoom identity. Production uses a deployment-wide new-start kill switch plus verified concurrency and usage boundaries; release one adds no company or user allowlist.
+- No duplicate contract types, compatibility shims, stale prototype routes in production navigation, or teammate-owned temporary wiring remain.
+
+## Relevant decisions
+
+All Call Notes Wayfinder decisions, especially MN-WF-006 through MN-WF-013.
+
+## Non-goals
+
+Expanding scope to Google Meet/native capture, centralized OAuth or SaaS operation, adding Redis/Kafka/RabbitMQ, generalizing adapters/models prematurely, marketplace publication, or silently weakening pilot gates because the Zoom account evidence is incomplete.

--- a/docs/issues/call-notes-wayfinder/002-define-call-notes-domain-model.md
+++ b/docs/issues/call-notes-wayfinder/002-define-call-notes-domain-model.md
@@ -3,7 +3,7 @@ id: MN-WF-002
 title: Define the Call Notes Domain Model
 parent: MN-WF-000
 status: closed
-assignee: Main
+assignee: Kien
 labels:
   - wayfinder:grilling
 blocked_by: []

--- a/docs/issues/call-notes-wayfinder/003-prototype-call-notes-interaction-shape.md
+++ b/docs/issues/call-notes-wayfinder/003-prototype-call-notes-interaction-shape.md
@@ -3,7 +3,7 @@ id: MN-WF-003
 title: Prototype the Call Notes Interaction Shape
 parent: MN-WF-000
 status: closed
-assignee: Main
+assignee: Kien
 labels:
   - wayfinder:prototype
 blocked_by: []
@@ -35,7 +35,7 @@ What minimal interaction shape makes live attributed transcript, a contemporaneo
 - The Call Note is shared read-only with the company by default. Only its initiating owner can edit or accept AI revisions, and a **Shared with company** toggle can make it private during or after the Call; other users then see Transcript only.
 - Transcript segments are immutable and visible to all authorized company users. Only the Call Note owner can add a company-visible Bookmark with an optional freeform comment; AI infers whether that comment requests verbatim reuse or thematic focus.
 - The live editor is a blank rich Call Note using existing formatting and autosave, without templates or live-AI prompts.
-- After transcript finalization, AI automatically prepares an owner-only enrichment proposal. A **My notes / AI enhanced** toggle exposes the ready proposal without replacing the canonical Call Note. **Review suggestion** opens the side-by-side decision view: the current note remains read-only beside an editable proposal; Accept creates the next canonical revision with the Call Note's current visibility and Reject preserves the current note.
+- After transcript finalization, the owner may explicitly request an AI enrichment proposal. A **My notes / AI enhanced** toggle exposes the ready proposal without replacing the canonical Call Note. **Review suggestion** opens the side-by-side decision view: the current note remains read-only beside an editable proposal; Accept creates the next canonical revision with the Call Note's current visibility and Reject preserves the current note.
 - Failed Calls remain in Recent even when empty. Empty failed attempts expose an explicit Delete action so the user can clean them up.
 - Calls uses a list/detail split: a compact Live/Recent rail remains beside the selected Call and collapses on narrow screens.
 - Enrichment review gives the current note and editable proposal two columns; citations open the relevant immutable Transcript segment in a collapsible evidence drawer.

--- a/docs/issues/call-notes-wayfinder/003-prototype-call-notes-interaction-shape.md
+++ b/docs/issues/call-notes-wayfinder/003-prototype-call-notes-interaction-shape.md
@@ -2,7 +2,7 @@
 id: MN-WF-003
 title: Prototype the Call Notes Interaction Shape
 parent: MN-WF-000
-status: open
+status: closed
 assignee: Main
 labels:
   - wayfinder:prototype
@@ -20,8 +20,8 @@ What minimal interaction shape makes live attributed transcript, a contemporaneo
 - Capture starts manually. While any LaunchStack tab is open, LaunchStack offers a global best-effort suggestion when Zoom exposes an eligible call, without promising universal detection or background push.
 - If Zoom does not expose a candidate, the user can paste a Zoom join URL or meeting ID and explicitly start capture.
 - The long-running worker owns capture. Closing the Calls page does not stop it; capture ends only through Zoom/provider lifecycle, while Pause and Resume remain available in the web UI.
-- The live workspace is notes-first: a large owner-editable Call Note beside a narrower company-visible Transcript.
-- The transcript follows new attributed segments until the user scrolls away, then offers **Jump to live**.
+- The live workspace is notes-first: a solid owner-editable Call Note pane with a contained Transcript card below it.
+- The Transcript is collapsed by default, expands into a searchable attributed-segment list, and reveals each segment's Bookmark control on hover or keyboard focus.
 - The first release exposes Start, Pause, and Resume through Zoom's participant RTMS status API, but deliberately omits Stop. Pause preserves the Capture Attempt and records a known `user_paused` gap that makes the Transcript `partial`; nothing resumes automatically.
 - Review and enrichment remain on the same Call page after capture.
 - The Calls library initially shows Live and Recent Calls only.
@@ -35,7 +35,7 @@ What minimal interaction shape makes live attributed transcript, a contemporaneo
 - The Call Note is shared read-only with the company by default. Only its initiating owner can edit or accept AI revisions, and a **Shared with company** toggle can make it private during or after the Call; other users then see Transcript only.
 - Transcript segments are immutable and visible to all authorized company users. Only the Call Note owner can add a company-visible Bookmark with an optional freeform comment; AI infers whether that comment requests verbatim reuse or thematic focus.
 - The live editor is a blank rich Call Note using existing formatting and autosave, without templates or live-AI prompts.
-- After transcript finalization, AI automatically prepares an owner-only enrichment proposal and shows the owner a Ready badge and same-page banner without interrupting or navigating them. If the Call Note is blank, the proposal may generate a complete note from Transcript evidence. Review is side by side: the current note remains read-only beside an editable proposal; Accept creates the next canonical revision with the Call Note's current visibility and Reject preserves the current note.
+- After transcript finalization, AI automatically prepares an owner-only enrichment proposal. A **My notes / AI enhanced** toggle exposes the ready proposal without replacing the canonical Call Note. **Review suggestion** opens the side-by-side decision view: the current note remains read-only beside an editable proposal; Accept creates the next canonical revision with the Call Note's current visibility and Reject preserves the current note.
 - Failed Calls remain in Recent even when empty. Empty failed attempts expose an explicit Delete action so the user can clean them up.
 - Calls uses a list/detail split: a compact Live/Recent rail remains beside the selected Call and collapses on narrow screens.
 - Enrichment review gives the current note and editable proposal two columns; citations open the relevant immutable Transcript segment in a collapsible evidence drawer.
@@ -49,3 +49,19 @@ What minimal interaction shape makes live attributed transcript, a contemporaneo
 - Only the Capture User who started the current Attempt can Pause or Resume it; company viewers have no RTMS controls.
 - When the Call Note is shared, authorized company viewers see owner edits update during the live Call and afterward, but remain read-only.
 - Authorized company users can watch the immutable Transcript stream live, regardless of Call Note visibility.
+
+## Prototype scope
+
+The isolated `/prototypes/call-notes` route uses simulated product state only. It does not add Zoom OAuth, RTMS transport, persistence, production schemas, real enrichment, or imports from the prototype into production code. `scenario=detected`, `scenario=failure`, and `scenario=review` keep architecture-affecting states repeatable.
+
+The accepted wireframe is a single restrained, note-first direction:
+
+- A persistent compact Live/Recent Calls rail.
+- One solid, email-like detail pane rather than nested dashboards.
+- A **My notes / AI enhanced** switch above the note surface.
+- A contained, collapsed Transcript card with search and hover/focus Bookmark controls.
+- Compact capture status and Start/Pause/Resume controls.
+
+## Resolution
+
+Closed after the single note-first wireframe and its detected-call, failure, live capture, transcript search/bookmark, privacy, pause-gap, and enrichment-review interactions were implemented and verified at `/prototypes/call-notes`.

--- a/docs/issues/call-notes-wayfinder/004-decide-transcript-note-rag-model.md
+++ b/docs/issues/call-notes-wayfinder/004-decide-transcript-note-rag-model.md
@@ -3,7 +3,7 @@ id: MN-WF-004
 title: Decide the Transcript, Note, and RAG Knowledge Model
 parent: MN-WF-000
 status: closed
-assignee: Main
+assignee: Kien
 labels:
   - wayfinder:grilling
 blocked_by:

--- a/docs/issues/call-notes-wayfinder/004-decide-transcript-note-rag-model.md
+++ b/docs/issues/call-notes-wayfinder/004-decide-transcript-note-rag-model.md
@@ -2,8 +2,8 @@
 id: MN-WF-004
 title: Decide the Transcript, Note, and RAG Knowledge Model
 parent: MN-WF-000
-status: open
-assignee: null
+status: closed
+assignee: Main
 labels:
   - wayfinder:grilling
 blocked_by:
@@ -16,3 +16,32 @@ blocked_by:
 ## Question
 
 How should LaunchStack preserve a call transcript and its Call Note as equally significant but distinct knowledge: dedicated Call records, transcript segments, an ingested transcript Document, an editable `document_notes` record, embeddings, citations, and links—while reusing the existing document and notes retrieval paths instead of creating a third knowledge system?
+
+## Resolution
+
+The Transcript and Call Note remain distinct, but only the Call Note participates in
+LaunchStack knowledge retrieval for the first release.
+
+- Immutable, speaker-attributed Transcript segments are the Call's evidence source.
+  They support exact in-Call search, Bookmarks, enrichment input, and stable links by
+  segment, speaker, and timestamp. They are not embedded, ingested as a Document, or
+  exposed to company-wide RAG.
+- The one canonical Call Note reuses `document_notes` and
+  `document_note_embeddings`; no Call-specific retrieval index is introduced.
+- The owner may enable a post-call **Use in company knowledge** setting only for a
+  company-visible Call Note. It defaults off. Enabling it indexes the current canonical
+  revision; disabling it removes the retrieval entry without deleting the note or
+  Transcript.
+- Capture completion never indexes a note. The owner can first edit it, request AI
+  enrichment, and accept or reject the proposal. Unaccepted AI output is never indexed.
+- Once knowledge inclusion is enabled, later manual edits or an accepted Enriched Note
+  replace the indexed canonical revision after save.
+- A private Call Note is excluded from company knowledge. Making an included note
+  private removes its retrieval entry.
+- Retrieval results link back to the Call Note. Evidence references stored in the note
+  or its accepted revision resolve directly to immutable Transcript segment IDs; this
+  does not make Transcript content retrievable.
+
+Transcript retrieval remains a future, evidence-driven extension if note-only retrieval
+produces demonstrated recall failures. It is not a release-one adapter seam or dormant
+index.

--- a/docs/issues/call-notes-wayfinder/005-decide-ai-enrichment-provenance-contract.md
+++ b/docs/issues/call-notes-wayfinder/005-decide-ai-enrichment-provenance-contract.md
@@ -2,8 +2,8 @@
 id: MN-WF-005
 title: Decide the AI Enrichment and Provenance Contract
 parent: MN-WF-000
-status: open
-assignee: null
+status: closed
+assignee: Main
 labels:
   - wayfinder:grilling
 blocked_by:
@@ -17,3 +17,52 @@ blocked_by:
 ## Question
 
 How should post-call AI combine the user's steering notes with transcript evidence: precedence, omissions, contradictions, proposed edits versus automatic overwrite, citations to speakers and timestamps, repeat enrichment, model routing, structured outputs, and the boundary between an editable note and generated summary, decisions, and action items?
+
+## Resolution
+
+Enrichment is an explicit post-call action that creates one complete, editable proposal
+beside the current canonical Call Note. It never overwrites the Call Note automatically.
+The owner accepts or rejects the whole proposal; acceptance creates the next canonical
+revision.
+
+### Merge and output contract
+
+- The finalized Transcript determines chronological order and topic coverage.
+- The chronological body covers every substantive topic, decision, disagreement,
+  commitment, and meaningful transition in discussion order. Greetings, repetition,
+  filler, and technical noise may be omitted.
+- Existing owner-note fragments are matched to their relevant Transcript topic or
+  interval. The proposal may reorder those fragments to restore call chronology and may
+  clarify, expand, and elaborate them, but it must preserve their intent.
+- Substantive Transcript topics absent from the owner's note still receive generated
+  notes.
+- The proposal ends with a concise summary and structured action items.
+- Unsupported owner context is retained and visibly labelled as owner-provided rather
+  than Transcript-derived. A conflict between owner context and Transcript evidence is
+  surfaced for review; neither source silently replaces the other.
+
+### Provenance contract
+
+- Every run records the Call, finalized Transcript identity, base Call Note revision,
+  model ID, prompt/schema version, timestamps, status, and original structured output.
+- Only passages generated from Bookmarks expose inline speaker/timestamp citations to
+  immutable Transcript segment IDs. Other generated prose does not show segment-level
+  citations; the run-level Transcript identity is its provenance boundary.
+- The original model output remains distinguishable from owner edits made to the
+  proposal before acceptance.
+- Rejection preserves the canonical Call Note. Acceptance records the owner, accepted
+  content, source enrichment run, and acceptance time as a new canonical revision.
+- A later enrichment starts from the then-current canonical revision and finalized
+  Transcript. At most one proposal is active for review; starting another run does not
+  mutate canonical content.
+- An unaccepted proposal never enters knowledge retrieval. If the Call Note is already
+  included in company knowledge, only acceptance or a later manual save replaces its
+  indexed canonical revision.
+
+### Model boundary
+
+Enrichment uses LaunchStack's configured chat-model routing and structured-output
+validation, never the RTMS transcription source as an analysis model. Provider-specific
+model code is not added. A missing or invalid model route fails the enrichment run
+without changing the Call Note; it does not silently fall back to a different provider
+or accept unvalidated prose.

--- a/docs/issues/call-notes-wayfinder/005-decide-ai-enrichment-provenance-contract.md
+++ b/docs/issues/call-notes-wayfinder/005-decide-ai-enrichment-provenance-contract.md
@@ -3,7 +3,7 @@ id: MN-WF-005
 title: Decide the AI Enrichment and Provenance Contract
 parent: MN-WF-000
 status: closed
-assignee: Main
+assignee: Kien
 labels:
   - wayfinder:grilling
 blocked_by:

--- a/docs/issues/call-notes-wayfinder/006-decide-module-runtime-boundaries.md
+++ b/docs/issues/call-notes-wayfinder/006-decide-module-runtime-boundaries.md
@@ -2,8 +2,8 @@
 id: MN-WF-006
 title: Decide the LaunchStack Module and Runtime Boundaries
 parent: MN-WF-000
-status: open
-assignee: null
+status: closed
+assignee: Main
 labels:
   - wayfinder:grilling
 blocked_by:
@@ -17,3 +17,50 @@ blocked_by:
 ## Question
 
 Which responsibilities belong in `apps/web`, a long-running workspace application such as `apps/call-worker`, `packages/features`, `packages/core`, PostgreSQL, object storage, Inngest, and the existing batch transcription sidecar—and what dependency and process boundaries keep Zoom lifecycle code, product policy, knowledge integration, and portable infrastructure from leaking into one another?
+
+## Resolution
+
+Release one adds one private, long-running TypeScript workspace application:
+`apps/call-worker`. It runs beside the existing web and PostgreSQL containers on the
+same self-hosted deployment; it is not a separately operated product or public API.
+
+### Responsibility boundaries
+
+- `apps/web` owns the Calls UI, Clerk-authenticated user commands, Zoom OAuth
+  initiation/callbacks, and the public signed-webhook endpoint. Its handlers validate,
+  persist, and acknowledge quickly; they never hold an RTMS media connection.
+- `apps/call-worker` owns command leasing, Zoom signaling/media WebSockets, ready and
+  keepalive protocol, Pause/Resume execution, reconnect handling, Transcript packet
+  normalization, and durable lifecycle/segment writes. Browser or web-process exit does
+  not stop a Capture Attempt.
+- `packages/features` owns the Call Notes domain module: state transitions,
+  authorization and ownership policy, command/event contracts, repositories,
+  finalization, Call Note revision rules, and knowledge-inclusion orchestration. Both
+  deployable applications reuse this module rather than reimplementing policy.
+- `packages/core` gains no Call Notes product policy. Call Notes reuses its existing
+  database, model-routing, structured-output, and knowledge primitives.
+- PostgreSQL is the durable coordination boundary. Web transactions append idempotent
+  commands and webhook events; workers claim them with leases, persist provider events,
+  and enforce uniqueness/state constraints. Basic polling is sufficient initially;
+  PostgreSQL `LISTEN/NOTIFY` may reduce wake-up latency without becoming the source of
+  truth.
+- Object storage is not required for Zoom-first capture because release one stores no
+  raw audio or video. Transcript evidence lives in PostgreSQL.
+- Inngest may run finite, retryable post-call work such as user-requested enrichment and
+  note reindexing. It never owns an active RTMS connection or Capture Attempt.
+- The existing transcription sidecar is not used for Zoom RTMS Transcript packets and
+  receives no Call Notes-specific endpoint. Existing note embedding configuration may
+  continue to use its normal infrastructure without Call Notes calling the sidecar
+  directly.
+
+### Operational shape
+
+Only `apps/web` is public. `apps/call-worker` needs database access, Zoom credentials or
+authorized token access, outbound HTTPS/WSS, health checks, logs, and a restart policy.
+One worker replica is the release-one default. Database leases permit later horizontal
+replicas without adding Redis, Kafka, RabbitMQ, or a private worker-control HTTP API.
+
+The extra Node process is accepted to prevent web deploys, request-runtime recycling, or
+browser closure from terminating active Calls. RTMS usage remains the dominant
+incremental cost; the worker adds only a small container and one operational health
+surface.

--- a/docs/issues/call-notes-wayfinder/006-decide-module-runtime-boundaries.md
+++ b/docs/issues/call-notes-wayfinder/006-decide-module-runtime-boundaries.md
@@ -3,7 +3,7 @@ id: MN-WF-006
 title: Decide the LaunchStack Module and Runtime Boundaries
 parent: MN-WF-000
 status: closed
-assignee: Main
+assignee: Kien
 labels:
   - wayfinder:grilling
 blocked_by:

--- a/docs/issues/call-notes-wayfinder/007-decide-self-hosted-docker-topology.md
+++ b/docs/issues/call-notes-wayfinder/007-decide-self-hosted-docker-topology.md
@@ -3,7 +3,7 @@ id: MN-WF-007
 title: Decide the Self-Hosted Docker Topology
 parent: MN-WF-000
 status: closed
-assignee: Main
+assignee: Kien
 labels:
   - wayfinder:grilling
 blocked_by:

--- a/docs/issues/call-notes-wayfinder/007-decide-self-hosted-docker-topology.md
+++ b/docs/issues/call-notes-wayfinder/007-decide-self-hosted-docker-topology.md
@@ -2,8 +2,8 @@
 id: MN-WF-007
 title: Decide the Self-Hosted Docker Topology
 parent: MN-WF-000
-status: open
-assignee: null
+status: closed
+assignee: Main
 labels:
   - wayfinder:grilling
 blocked_by:
@@ -16,3 +16,60 @@ blocked_by:
 ## Question
 
 What is the authoritative operator-owned deployment topology for web UI, RTMS worker, public HTTPS webhook and callback ingress, PostgreSQL, secrets, migrations, health checks, and optional existing services—and how should local development, a public Docker Compose host, and the current Vercel-plus-external-worker mode differ without becoming three architectures?
+
+## Resolution
+
+The authoritative production topology is the operator-owned Docker deployment with one
+additional private `call-worker` service. It reuses the public HTTPS origin already used
+to open the LaunchStack website; Call Notes does not add a mandatory proxy or tunnelling
+vendor.
+
+```text
+Internet / Zoom
+       |
+existing LaunchStack HTTPS ingress
+       |
+     app  ───────── PostgreSQL
+                       |
+                  call-worker ── outbound HTTPS/WSS ── Zoom
+```
+
+### Production Compose contract
+
+- `app` and `call-worker` are built from the same monorepo revision and start only after
+  the one-shot `migrate` service succeeds and PostgreSQL is healthy.
+- Existing HTTPS ingress forwards the website plus the documented Zoom webhook and OAuth
+  callback paths to `app:3000`. `call-worker` publishes no port.
+- `call-worker` restarts unless stopped, reports liveness/readiness, records a periodic
+  database heartbeat, and can reach PostgreSQL and Zoom over outbound HTTPS/WSS.
+- PostgreSQL retains Call Notes state and Transcript evidence in the existing durable
+  volume. No Call Notes object-storage volume is added.
+- Secrets are runtime inputs, never image build arguments or repository files. The web
+  receives the Zoom client/webhook credentials needed at its edge; the worker receives
+  only the Zoom/token-encryption and model credentials required for claimed jobs.
+- OAuth access and refresh tokens are encrypted before database persistence. A separate
+  operator-supplied encryption key is shared only with runtimes that must decrypt them.
+- Health checks distinguish process liveness, database readiness, and stale worker
+  heartbeat. An unhealthy web process must not imply that an active worker-owned Capture
+  has stopped.
+- Existing optional OCR, sidecar, object-storage, and Inngest services remain independent
+  of RTMS availability. Call Notes release one adds no queue or mandatory Inngest
+  production service.
+
+### Same contract in each environment
+
+- **Local development:** web and worker may run as local processes against the Compose
+  database. Because Zoom cannot reach `localhost`, a developer-selected temporary HTTPS
+  tunnel forwards the same Zoom paths to the local web process. That public origin must
+  be configured in the developer's Zoom app for the test.
+- **Public Docker host:** the operator's existing DNS, TLS, and reverse proxy expose the
+  normal LaunchStack origin and Zoom paths. The worker stays on the private Compose
+  network.
+- **Current Vercel plus external worker:** Vercel supplies the web HTTPS origin while the
+  externally hosted worker and web share the same reachable PostgreSQL command/event
+  contract. No RTMS socket runs in Vercel.
+
+The public base URL is configuration, not a separate architecture: production uses the
+normal website URL; local RTMS tests use a tunnel URL. A bundled Caddy service or required
+Cloudflare Tunnel may be documented as operator examples later, but neither is a release
+dependency.

--- a/docs/issues/call-notes-wayfinder/008-decide-identity-consent-retention.md
+++ b/docs/issues/call-notes-wayfinder/008-decide-identity-consent-retention.md
@@ -2,8 +2,8 @@
 id: MN-WF-008
 title: Decide Identity, Consent, Tenancy, and Retention Boundaries
 parent: MN-WF-000
-status: open
-assignee: null
+status: closed
+assignee: Main
 labels:
   - wayfinder:grilling
 blocked_by:
@@ -17,3 +17,83 @@ blocked_by:
 ## Question
 
 How do Clerk identity and company tenancy relate to Zoom app ownership, Zoom users, meeting hosts, participants, and stored OAuth tokens; who may start, view, enrich, share, export, or delete a Call; what consent evidence is retained; and what transcript, note, token, and derived-artifact retention defaults make an OSS deployment safe without inventing a compliance platform?
+
+## Resolution
+
+Call Notes uses existing Clerk company membership as its only application tenancy
+boundary. It records the consent and authorization facts Zoom and LaunchStack can
+actually observe, retains Call data until explicit deletion, and does not claim to be a
+general compliance or retention-policy system.
+
+### Identity and tenancy
+
+- The self-hosting operator owns and configures the Zoom General App for the deployment.
+  That app is infrastructure identity, not a LaunchStack company or user.
+- A Zoom connection belongs to exactly one Clerk user in one LaunchStack company and
+  stores the authorized Zoom account/user identifiers. The same person must authorize
+  separately in another company context.
+- A Capture User is the company member whose connected Zoom identity controls the
+  Attempt. It does not confer Transcript or company ownership.
+- Provider Participants remain call-local identities and display names. They are not
+  matched to Clerk users, contacts, or participants in another Call.
+- Every Call Notes row and command carries `company_id`; uniqueness, lookup, mutation,
+  worker claims, and retrieval filters include it. Wrong-company access resolves as not
+  found.
+
+### Authorization
+
+- An active company member with a valid Zoom connection may start capture for an
+  eligible occurrence. Concurrent starts converge on the existing company Capture.
+- All active members of the Call's company may view its Transcript and company-visible
+  Call Note.
+- Only the Call Note owner may edit it, create Bookmarks, request or accept enrichment,
+  change visibility, and enable or disable company-knowledge inclusion.
+- A private Call Note is visible only to its owner and is excluded from company
+  knowledge; the company Transcript remains visible.
+- There is no external share link or export workflow in release one.
+- A company administrator may explicitly delete a completed or non-empty Call. The Call
+  Note owner may delete only an empty failed Call, as settled by the interaction
+  contract. No background cleanup deletes Calls.
+
+### Authorization secrets
+
+- OAuth access and refresh tokens are encrypted at rest with an operator-supplied key,
+  never returned to the browser, embedded in images, committed, or written to logs.
+- Tokens are scoped to company plus LaunchStack user, refreshed only by an authorized
+  runtime, and removed when the connection is disconnected, revoked, or its user/company
+  is removed. Disconnecting Zoom does not delete already captured company evidence.
+- The worker receives only credentials needed to claim and operate its authorized work;
+  Clerk browser/session credentials are not copied into it.
+
+### Consent evidence
+
+- LaunchStack retains the Capture User's explicit initial Start command, any manual
+  Pause/Resume, automatic same-user continuation events, relevant Zoom account/app
+  setting facts, webhook/event identifiers, host approval outcome when supplied, and
+  timestamps.
+- Automatic continuation after the same user returns is recorded as a new Attempt under
+  the still-open Capture. It is not treated as a new participant-wide consent event.
+- Zoom owns its participant disclosure and host/admin approval UX. LaunchStack may state
+  that Zoom displayed or reported those controls only when observed; it never stores or
+  presents an invented “all participants consented” assertion.
+- The UI clearly identifies capture state and partial intervals. Provider disclosure is
+  not replaced by a hidden LaunchStack-only indicator.
+
+### Retention and deletion
+
+- Calls, Transcript segments, Gaps, Bookmarks, Call Note revisions, enrichment runs,
+  model metadata, and consent evidence are retained until explicit deletion. Release one
+  has no automatic duration, per-artifact retention matrix, or scheduler.
+- Rejected or failed enrichment output remains attached to the Call for provenance but
+  never enters knowledge retrieval.
+- Deleting a Call is a company-scoped, audited cascade that removes Transcript evidence,
+  Bookmarks, Note revisions and embeddings, enrichment artifacts, and provider
+  lifecycle/consent records. It does not delete the operator's Zoom app or unrelated
+  user authorization.
+- Disabling company-knowledge inclusion deletes the retrieval embedding only; it does
+  not delete the Call Note or Call.
+- No raw audio, video, or screen share is retained in the Zoom-first release.
+
+Operators that require timed retention, legal hold, export, or deletion approvals must
+add those as explicit future product requirements. Release one prefers visible,
+operator-controlled deletion over silent loss or a partial compliance framework.

--- a/docs/issues/call-notes-wayfinder/008-decide-identity-consent-retention.md
+++ b/docs/issues/call-notes-wayfinder/008-decide-identity-consent-retention.md
@@ -3,7 +3,7 @@ id: MN-WF-008
 title: Decide Identity, Consent, Tenancy, and Retention Boundaries
 parent: MN-WF-000
 status: closed
-assignee: Main
+assignee: Kien
 labels:
   - wayfinder:grilling
 blocked_by:

--- a/docs/issues/call-notes-wayfinder/009-decide-rtms-session-reliability.md
+++ b/docs/issues/call-notes-wayfinder/009-decide-rtms-session-reliability.md
@@ -2,8 +2,8 @@
 id: MN-WF-009
 title: Decide the RTMS Session Reliability Model
 parent: MN-WF-000
-status: open
-assignee: null
+status: closed
+assignee: Main
 labels:
   - wayfinder:grilling
 blocked_by:
@@ -18,3 +18,90 @@ blocked_by:
 ## Question
 
 What state machine and persistence guarantees govern a single-user RTMS capture from authorization through start, buffering, transcript ingestion, duplicate or out-of-order packets, worker restart, transport reconnect, the Capture User leaving and returning, stop, finalization, and partial failure—and which guarantees are required for the internal pilot versus deferred until measured concurrency demands them? Same-user continuation through a new Capture Attempt is in scope; cross-user handoff is not.
+
+## Resolution
+
+Release one provides durable, gap-honest capture rather than claiming exactly-once or
+gap-free Transcript delivery. PostgreSQL state is authoritative; worker memory and live
+UI events are disposable projections.
+
+### State model
+
+`Capture` records two independent facts to avoid a combinatorial status enum:
+
+- desired mode: `running` or `paused`;
+- lifecycle: `connecting`, `live`, `interrupted`, `finalizing`, `completed`, or
+  `failed`.
+
+Each `Capture Attempt` is one provider stream interval with lifecycle `connecting`,
+`live`, `reconnecting`, `ended`, or `failed`. A Capture outcome is `complete`,
+`partial`, or `failed`; any known interval without Transcript evidence, including a
+user Pause, makes it `partial`.
+
+The normal transitions are:
+
+```text
+start -> connecting -> live
+live -> paused -> live
+live -> reconnecting -> live
+live -> interrupted -> new Attempt -> live
+live/interrupted/paused -> finalizing -> completed
+connecting/reconnecting/finalizing -> failed
+```
+
+The UI derives `Paused`, `Reconnecting`, `Waiting for participant`, and `Partial` from
+these durable facts rather than persisting a second product-only state machine.
+
+### Continuation and gaps
+
+- Native Zoom Pause preserves the current Attempt when Zoom does. Desired mode becomes
+  `paused`; nothing automatically unpauses it. The interval is a visible
+  `user_paused` Gap.
+- A brief media/signaling interruption uses Zoom's supported reconnect path within the
+  same Attempt. The worker records the observed interruption even when reconnect
+  succeeds.
+- When the Capture User leaves, the provider stream and Attempt end. If that same
+  provider user returns to the same still-open Zoom meeting occurrence while desired
+  mode is `running`, LaunchStack automatically starts a new Attempt under the existing
+  Capture. The interval remains a visible `capture_user_absent` Gap.
+- A user-paused Capture does not restart on return until the user explicitly resumes.
+- Automatic continuation never crosses to another user, another Zoom meeting
+  occurrence, or a finalized Call. Cross-user handoff remains out of scope.
+
+### Persistence guarantees
+
+- Start, Pause, Resume, webhook, reconnect, and finalization inputs have durable
+  idempotency keys. Database uniqueness allows only one open Capture per
+  company/provider occurrence and one active Attempt per Capture.
+- Worker leases carry fencing tokens. A worker whose lease expired cannot append state
+  after a successor claims the Attempt.
+- Transcript packets are persisted before they are published to the live UI. Each row
+  records Attempt, provider participant identity, provider timestamps, receive order,
+  normalized text/language, and a hash of the canonical provider packet.
+- Zoom documents no universal Transcript packet idempotency key or total-order
+  guarantee. Identical canonical packets within one Attempt are deduplicated by hash;
+  otherwise evidence is retained. Canonical display order uses provider time followed by
+  receive order as the deterministic tie-breaker.
+- Finalized Transcript segments are immutable. Corrections, guessed words, or AI repairs
+  never replace provider evidence.
+- Every unavailable interval is represented as a typed Gap:
+  `user_paused`, `capture_user_absent`, `transport_interruption`,
+  `worker_unavailable`, or `provider_unknown`. No code fabricates missing Transcript.
+- A worker restart may reclaim an eligible lease and attempt provider-supported
+  reconnect. If Zoom cannot replay or reconnect, the Attempt ends and the Capture
+  remains partial; restart is not represented as seamless.
+- Finalization begins only after a terminal provider event or a bounded, persisted
+  irrecoverable timeout, waits a configurable late-packet grace period, then freezes
+  ordering and outcome. Timeout and reconnect values must come from the verified account
+  behavior in `MN-WF-013`, not guessed production constants.
+- Empty and partial failed Calls remain visible with their failure reason and Retry or
+  owner-only Delete behavior. There is no automatic cleanup.
+
+### Pilot limits
+
+One worker replica and one Capture User per Capture are sufficient for the internal
+pilot. The worker rejects new starts before exceeding the concurrency entitlement
+verified by `MN-WF-013`; it does not optimistically overbook RTMS streams. Horizontal
+workers may later share the same lease protocol. Transcript replay recovery,
+cross-user handoff, overlapping Attempts, and continuity billing are deferred until
+provider evidence and measured demand justify them.

--- a/docs/issues/call-notes-wayfinder/009-decide-rtms-session-reliability.md
+++ b/docs/issues/call-notes-wayfinder/009-decide-rtms-session-reliability.md
@@ -3,7 +3,7 @@ id: MN-WF-009
 title: Decide the RTMS Session Reliability Model
 parent: MN-WF-000
 status: closed
-assignee: Main
+assignee: Kien
 labels:
   - wayfinder:grilling
 blocked_by:

--- a/docs/issues/call-notes-wayfinder/010-define-future-capture-adapter-seam.md
+++ b/docs/issues/call-notes-wayfinder/010-define-future-capture-adapter-seam.md
@@ -3,7 +3,7 @@ id: MN-WF-010
 title: Define the Future Capture Adapter Seam
 parent: MN-WF-000
 status: closed
-assignee: Main
+assignee: Kien
 labels:
   - wayfinder:grilling
 blocked_by:

--- a/docs/issues/call-notes-wayfinder/010-define-future-capture-adapter-seam.md
+++ b/docs/issues/call-notes-wayfinder/010-define-future-capture-adapter-seam.md
@@ -2,8 +2,8 @@
 id: MN-WF-010
 title: Define the Future Capture Adapter Seam
 parent: MN-WF-000
-status: open
-assignee: null
+status: closed
+assignee: Main
 labels:
   - wayfinder:grilling
 blocked_by:
@@ -18,3 +18,67 @@ blocked_by:
 ## Question
 
 What is the minimum platform-neutral boundary that lets a later Google Meet Media API or native capture source feed the settled Call model without weakening Zoom attribution or introducing a speculative provider framework—covering identities, finalized segments, timestamps, capabilities, lifecycle events, and explicitly unsupported raw-media or transcript-revision behavior?
+
+## Resolution
+
+The provider-neutral boundary begins at normalized textual evidence and lifecycle
+events, not raw media. Zoom is the only implemented adapter. No plugin loader, provider
+registry, factory hierarchy, or dormant Google/native implementation is added.
+
+### Minimum contract
+
+The Call Notes domain issues three provider-neutral commands:
+
+- start an Attempt for an authorized provider occurrence and Capture User;
+- pause the active Attempt when the source declares native Pause support;
+- resume a paused Attempt.
+
+There is deliberately no LaunchStack Stop command in release one. Provider termination,
+meeting end, or an irrecoverable lifecycle timeout ends an Attempt.
+
+The adapter emits a small append-only event union:
+
+- Attempt connected, paused, resumed, interrupted, reconnected, ended, or failed;
+- provider participant observed, left, or returned;
+- Transcript segment observed;
+- provider meeting occurrence ended.
+
+A normalized Transcript observation carries:
+
+- provider name, occurrence key, Attempt key, and optional provider event key;
+- a lossless call-local provider participant key and display name when attribution is
+  available, otherwise an explicitly unattributed speaker value;
+- provider start/end or message timestamp when supplied, receive timestamp, and receive
+  order;
+- text, detected language when supplied, and source kind
+  (`provider_transcript` or future `derived_asr`);
+- canonical source-packet hash for evidence deduplication.
+
+The domain, not the adapter, assigns LaunchStack IDs, enforces company scope, creates
+Gaps, orders evidence, decides `partial`, and finalizes the Transcript. The contract has
+no transcript-update or delete event and no invented finality flag. A future provider
+that revises prior transcript text requires a new domain decision rather than mutating
+evidence through this seam.
+
+### Capabilities
+
+An adapter reports only facts that change existing product behavior:
+
+- attributed text delivery;
+- native Pause/Resume;
+- supported transport reconnect;
+- observation of Capture User return.
+
+Release-one Zoom activation fails closed if attributed transcript delivery or required
+lifecycle control is unavailable. A future adapter with weaker attribution does not
+erase or make optional the provider identity stored for Zoom segments.
+
+Raw audio, video, screen share, codec negotiation, ASR, and diarization are outside this
+boundary. If a future Google Meet or native source needs ASR, its source-specific runtime
+must convert media to normalized Transcript observations before entering Call Notes.
+That work is not scaffolded now.
+
+Zoom SDK, OAuth, webhook, and transport types remain inside the Zoom edge/runtime
+adapter. Persistence and product policy contain only the normalized contract. This is
+the one seam required to avoid a future data migration without paying for a speculative
+multi-provider framework.

--- a/docs/issues/call-notes-wayfinder/011-decide-downstream-knowledge-integrations.md
+++ b/docs/issues/call-notes-wayfinder/011-decide-downstream-knowledge-integrations.md
@@ -3,7 +3,7 @@ id: MN-WF-011
 title: Decide Post-Call Outputs and Downstream Integrations
 parent: MN-WF-000
 status: closed
-assignee: Main
+assignee: Kien
 labels:
   - wayfinder:grilling
 blocked_by:

--- a/docs/issues/call-notes-wayfinder/011-decide-downstream-knowledge-integrations.md
+++ b/docs/issues/call-notes-wayfinder/011-decide-downstream-knowledge-integrations.md
@@ -2,8 +2,8 @@
 id: MN-WF-011
 title: Decide Post-Call Outputs and Downstream Integrations
 parent: MN-WF-000
-status: open
-assignee: null
+status: closed
+assignee: Main
 labels:
   - wayfinder:grilling
 blocked_by:
@@ -18,3 +18,34 @@ blocked_by:
 ## Question
 
 Which durable outputs should a completed Call expose to LaunchStack—enriched note, full transcript, summary, decisions, action items, participants, citations, embeddings, RAG retrieval, wiki links, Founder Weekly Review, or document workflows—and which system owns each output so Call Notes plugs into existing capabilities without coupling every downstream consumer to RTMS internals?
+
+## Resolution
+
+Release one exposes one downstream knowledge output: the canonical Call Note, and only
+when its owner explicitly enables **Use in company knowledge**.
+
+- Call Notes owns Calls, Captures, Capture Attempts, Participants, immutable Transcript
+  segments, Bookmarks, Call Note revisions, Enriched Note proposals, and their
+  provenance.
+- The existing `document_notes` embedding and retrieval path owns indexing and
+  company-knowledge discovery of an included canonical Call Note.
+- A retrieval result identifies the source as a Call Note and deep-links to the Call.
+  Consumers do not query RTMS, Capture, or Transcript tables.
+- Founder Weekly Review and document workflows may discover included Call Notes through
+  the same company-scoped knowledge retrieval used for other notes. No Call-specific
+  feed or evidence adapter is added for release one.
+- The full Transcript remains available inside the Call as evidence and exact search,
+  not as a downstream RAG source.
+- The chronological body, summary, and action items are sections of the canonical Call
+  Note, not separately synchronized records or events.
+- Participants remain call-local provider identities; they are not exported as contacts
+  or LaunchStack users.
+- Bookmark citations remain links from accepted note passages to Transcript segments.
+  Bookmarks, citations, and embeddings are implementation evidence, not independent
+  downstream products.
+- Wiki synchronization, task creation, CRM/contact matching, automatic document
+  generation, and dedicated Founder Weekly Review ingestion are deferred until a real
+  consumer requires an ownership and synchronization contract.
+
+This leaves one stable integration seam—company knowledge retrieval plus a Call deep
+link—without making downstream capabilities understand capture-provider internals.

--- a/docs/issues/call-notes-wayfinder/012-decide-verification-rollout-gates.md
+++ b/docs/issues/call-notes-wayfinder/012-decide-verification-rollout-gates.md
@@ -3,7 +3,7 @@ id: MN-WF-012
 title: Decide Architecture Verification and Rollout Gates
 parent: MN-WF-000
 status: open
-assignee: null
+assignee: Main
 labels:
   - wayfinder:grilling
 blocked_by:
@@ -21,3 +21,101 @@ blocked_by:
 ## Question
 
 What observable scenarios, cost limits, security checks, failure drills, migration checks, and operator acceptance criteria must the eventual implementation satisfy before an internal pilot and before a supported OSS release—and which constraints are architectural gates rather than implementation-task details beyond this map's destination?
+
+## Decided rollout shape
+
+Implementation begins as a local-testing slice. Call Notes is available to every
+authenticated user in that local LaunchStack deployment; there is no company or user
+allowlist. Each user must still connect an eligible Zoom identity before starting.
+
+Production rollout keeps the same all-users product shape, but a deployment-wide kill
+switch can prevent new starts. The switch never pretends to terminate an already active
+provider stream. New starts and automatic continuation attempts are also rejected when
+the deployment's verified concurrency or configured usage boundary is exhausted.
+
+`MN-WF-013` must supply the actual account entitlements and Pause/Resume billing
+behavior before numeric limits are configured. This issue remains open until that
+evidence exists.
+
+## Local-testing gate
+
+Before calling the first implementation slice locally complete, one real disclosed Zoom
+meeting through a public HTTPS tunnel must demonstrate:
+
+1. OAuth connection, signed webhook receipt, and one manual Start.
+2. Attributed Transcript segments persisted and streamed to the Calls UI in stable
+   order.
+3. Call Note autosave during capture; Bookmark creation and exact in-Call search.
+4. Native Pause and Resume with a visible typed Gap and `partial` outcome.
+5. Same Capture User leave and return, automatic new Capture Attempt, and one logical
+   Capture with a visible absence Gap.
+6. Web process restart without ending the worker-owned Attempt.
+7. Worker interruption with either verified Zoom reconnect or an honest
+   `worker_unavailable` Gap—never fabricated continuity.
+8. Provider end, bounded finalization, immutable Transcript, and retained failed/partial
+   state.
+9. Owner-requested enrichment with chronological substantive-topic coverage, labelled
+   unsupported owner context, Bookmark-only visible citations, editable proposal,
+   Reject, and Accept as a new canonical revision.
+10. Explicit company-knowledge inclusion and removal for a company-visible note, with
+    private notes and unaccepted proposals absent from retrieval.
+
+## Internal-pilot gates
+
+The local slice may become an internal pilot only when:
+
+- `MN-WF-013` proves the target account's General App, required scopes/events and
+  settings, user assignment, Developer Pack credits, transcription rate, concurrent
+  stream entitlement, Pause/Resume billing, reconnect behavior, and leave/return
+  behavior.
+- configured maximum concurrency is no higher than the observed entitlement;
+- the operator sets a new-start minute/credit budget from the observed rate, usage is
+  visible, and local accounting is reconciled against Zoom for Pause and restarted
+  Attempts;
+- reaching a budget prevents new Attempts rather than silently overbooking or claiming
+  that an active provider stream was stopped;
+- webhook signatures and replay windows, OAuth `state`, least-privilege scopes, encrypted
+  tokens, secret redaction, worker fencing, and wrong-company not-found behavior have
+  been exercised;
+- duplicate webhook/command delivery, duplicate and out-of-order Transcript packets,
+  token revocation, host denial, database interruption, web restart, worker restart, and
+  provider termination all produce the settled durable state;
+- completed-Call admin deletion removes Transcript, notes, embeddings, proposals,
+  consent/lifecycle evidence, and deep-link access in one audited company-scoped
+  operation;
+- operator health output distinguishes web, database, worker heartbeat, Zoom
+  authorization, and active/failed Attempts.
+
+All authenticated users may access the feature after these deployment-wide gates; no
+release-one allowlist is introduced.
+
+## Supported OSS-release gates
+
+A supported OSS release additionally requires:
+
+- a clean Docker Compose install and ordered migration from the previous supported
+  schema;
+- restart and upgrade with an active or partial Capture producing documented,
+  non-corrupt state;
+- backup/restore verification for PostgreSQL Call Notes data;
+- documented public-origin, local-tunnel, Zoom app, secret rotation, disconnect,
+  deletion, health, and troubleshooting procedures;
+- two-company isolation coverage across UI/API reads, commands, worker claims,
+  Transcript search, note retrieval, and deletion;
+- multiple authorized users converging on one company Capture without duplicate RTMS
+  billing or Call Note ownership;
+- bounded logs and metrics that contain IDs/statuses but no OAuth tokens, note bodies, or
+  Transcript text by default;
+- no dependency on raw-media storage, the batch transcription sidecar, a hidden support
+  entitlement, or a development-only Inngest service.
+
+Exact test frameworks, dashboard layout, alert vendor, retry constants, and deployment
+automation are implementation choices. The observable scenarios, tenancy and evidence
+invariants, provider/account proof, budget boundary, recoverability, and operator
+acceptance checks above are architecture gates.
+
+## Closure condition
+
+Close this ticket only after `MN-WF-013` supplies the account-specific concurrency,
+rate, Pause/Resume, reconnect, and continuation facts needed to replace the remaining
+unknown limits with tested configuration.

--- a/docs/issues/call-notes-wayfinder/012-decide-verification-rollout-gates.md
+++ b/docs/issues/call-notes-wayfinder/012-decide-verification-rollout-gates.md
@@ -3,7 +3,7 @@ id: MN-WF-012
 title: Decide Architecture Verification and Rollout Gates
 parent: MN-WF-000
 status: open
-assignee: Main
+assignee: Kien
 labels:
   - wayfinder:grilling
 blocked_by:

--- a/docs/issues/call-notes-wayfinder/013-confirm-target-zoom-rtms-access.md
+++ b/docs/issues/call-notes-wayfinder/013-confirm-target-zoom-rtms-access.md
@@ -14,3 +14,134 @@ blocked_by: []
 ## Question
 
 Can the actual Zoom account intended for the internal pilot create a user-managed General App, purchase or activate Developer Pack credits, expose the required RTMS scopes and events, add the private app to an intended user, show the current transcript-enabled rate and concurrency entitlement, and complete one disclosed single-user test stream without undocumented support enablement? The test must include native Pause and Resume, observe whether the media connection and RTMS billing continue while paused, then have the user leave and return and verify that LaunchStack can append the restarted RTMS session as a new Capture Attempt under the same logical Capture while accurately preserving every gap.
+
+## Observed evidence
+
+Evidence was collected against the actual internal-pilot Zoom account from
+2026-08-17 through 2026-08-19. The runtime test used Zoom's official
+`zoom/rtms-quickstart-js` and `@zoom/rtms` 1.1.0 on Node 24 behind temporary
+public HTTPS tunnels. It did not use or modify the LaunchStack prototype. All
+identifiers below are redacted references; no app secret, OAuth code, token, raw
+meeting identifier, or temporary endpoint is recorded.
+
+### Account and app
+
+- On 2026-08-17 the account owner created `LaunchstackCall` as a Development
+  **General App** with **User-managed app** selected. The Marketplace creation
+  record attributed the app to the account owner.
+- The account activated **Zoom Developer Pack | Free Trial**, showing 20 total
+  credits, 0 used, and a trial period from 2026-08-17 through 2027-08-17. The
+  entitlement card explicitly listed **RTMS with Transcriptions**.
+- Zoom's account-visible rate table on 2026-08-18 showed **RTMS with
+  Transcriptions: $0.02 per Meeting Streaming Minute** and **RTMS without
+  Transcriptions: $0.01 per Meeting Streaming Minute**.
+- The app has the non-optional transcript-only media scope
+  `meeting:read:meeting_transcript`. No audio, video, or screen-share media scope
+  was selected. During the meeting, however, Zoom's Active App Notifier disclosed
+  `Accesses: Audio, Transcript`; this is observed Zoom UI behavior and must not be
+  reinterpreted as proof that the receiver obtained raw audio.
+- The Development Event Subscription validated successfully over public HTTPS.
+  It subscribed to `meeting.rtms_started`, `meeting.rtms_stopped`,
+  `meeting.rtms_interrupted`, `rtms.concurrency_near_limit`, and
+  `rtms.concurrency_limited`. Zoom auto-selected the corresponding event scopes.
+- The owner/pilot user directly enabled **Share realtime meeting content with
+  apps**, privately added and authorized the Local Test app, and selected
+  `LaunchstackCall` as that user's auto-start app. Runtime auto-start proves the
+  setting and assignment were effective.
+- The Local Test OAuth callback returned an authorization code and no error, but
+  did not include a `state` parameter. This records Local Test behavior only;
+  production OAuth must supply and verify its own state.
+
+### Runtime on 2026-08-19
+
+One disclosed meeting used the owner/pilot as the sole RTMS app user and a silent
+control participant. The control participant kept the meeting occurrence open
+but did not speak. Zoom displayed the Active App Notifier for
+`LaunchstackCall`.
+
+| UTC observation | Evidence |
+| --- | --- |
+| `13:53:14.016` | `meeting.rtms_started`; redacted meeting ref `fff23737b888`, stream ref `070b0e912d46`; first Attempt in the temporary evidence harness |
+| `13:53:16.294` | SDK join confirmed with reason `0` |
+| `13:53:16.548` | One attributed participant session added; session ref `d130289889d8` |
+| `13:54:12.119` onward | Speaker-attributed Transcript packets carried participant identity plus provider start/end timestamps. Zoom transcribed the deliberately disclosed marker `MN-WF-013 transcript evidence, alpha bravo` with normal recognition variation. |
+| `13:58:13.896` | Native Zoom Pause produced session operation `3` and status `3` on the existing stream/session |
+| `14:01:05.938` | Native Zoom Resume produced operation `4` and status `4` on the same stream/session |
+| `14:01:28.403` | Attributed Transcript delivery resumed after the visible Pause Gap |
+| `14:03:20.929` | `meeting.rtms_stopped` on the same refs with reason `6`, documented as `STOP_BC_MEETING_ENDED` |
+
+The Pause interval was 172.042 seconds. No Transcript packet, RTMS stop, SDK
+leave, or interruption event arrived during that interval, including after a
+spoken pause marker. The receiver process retained two established TLS
+connections to the same Zoom endpoints and ports before Pause, immediately
+after Pause, and after the interval. Resume required no new SDK join and retained
+the same stream and session references. This proves that native Pause suppresses
+Transcript delivery while the signaling/media connections and provider
+stream/session remain allocated.
+
+The installed SDK reported `isActive: false` and `isPaused: false` for both the
+Pause and Resume callbacks even though their operation/status values were
+respectively `3/3` and `4/4`. LaunchStack must treat the documented operation and
+status transitions as evidence; these SDK booleans were inconsistent in the
+observed 1.1.0 runtime.
+
+The provider stream lasted 606.913 seconds (about 10.115 minutes), of which about
+7.248 minutes were not paused. At the observed $0.02 rate, expected usage is
+about $0.202 if Pause is billable and $0.145 if it is excluded. Immediately after
+the meeting, Zoom still displayed `0 of 20 credits` and exposed no fractional
+service line. The low-volume rounded balance cannot distinguish those cases.
+
+### Unproven acceptance items and exact blockers
+
+This issue remains open.
+
+- **Concurrency entitlement:** no `rtms.concurrency_near_limit` or
+  `rtms.concurrency_limited` event was emitted at one active stream, and the
+  account UI exposed no numeric concurrent-stream entitlement. The value requires
+  an account-specific Zoom support answer or an observed near-limit payload;
+  Developer Pack credits are not a safe proxy.
+- **Paused-time billing:** Zoom had not posted a detailed RTMS service line after
+  the low-volume meeting. Reconcile a later detailed usage report or run a
+  deliberately long, bounded Pause interval that produces measurable fractional
+  usage. This was placed on the backlog on 2026-08-19.
+- **Leave and return:** the operator declined leave/rejoin testing in this
+  meeting. No second provider stream was observed, so a new Capture Attempt,
+  `capture_user_absent` Gap, automatic same-user continuation, and the
+  same-occurrence identity correlation remain unproven.
+- **Paused return:** because leave/rejoin was declined, it is unknown whether
+  Zoom auto-start would restart this configured app after the paused user
+  returns. LaunchStack's requirement to keep desired mode paused therefore
+  remains an implementation gate, not an observed provider fact.
+- **Transport reconnect:** no controlled signaling or media interruption was
+  introduced before the meeting ended. Reconnect-versus-new-Attempt behavior,
+  timing, and any `transport_interruption` Gap remain unobserved.
+
+### Post-test account state
+
+Cleanup completed on 2026-08-19:
+
+- All temporary receiver, callback, and tunnel processes were stopped, and the
+  temporary directory containing the development credentials was deleted and
+  verified absent.
+- The temporary Event Subscription was removed after its HTTPS endpoint expired.
+  Production-development must recreate the five-event subscription above against
+  its persistent public endpoint.
+- The temporary OAuth Redirect URL and OAuth Allow List entry were removed.
+  Production-development must supply its persistent callback before Local Test
+  can authorize again.
+- The owner intentionally retained the General App, Developer Pack, transcript
+  scope, private authorization, user-level realtime-content setting, and pilot
+  auto-start assignment. Until a persistent receiver is configured, ordinary
+  meetings on the pilot identity may auto-start RTMS without a consumer and must
+  be avoided; billing behavior in that failure mode was not tested.
+
+### Official contract used
+
+- [Add RTMS features](https://developers.zoom.us/docs/rtms/meetings/add-features/)
+- [Work with streams](https://developers.zoom.us/docs/rtms/meetings/work-with-streams/)
+- [Host and admin controls](https://developers.zoom.us/docs/rtms/meetings/ux-host-admin-tools-ctrls/)
+- [Participant experience](https://developers.zoom.us/docs/rtms/meetings/ux-participant/)
+- [RTMS event reference](https://developers.zoom.us/docs/api/rtms/events/)
+- [RTMS data types](https://developers.zoom.us/docs/rtms/data-types/)
+- [Official Node SDK](https://github.com/zoom/rtms)
+- [Official Node quickstart](https://github.com/zoom/rtms-quickstart-js)

--- a/docs/issues/call-notes-wayfinder/014-resolve-calls-agent-meetings-boundary.md
+++ b/docs/issues/call-notes-wayfinder/014-resolve-calls-agent-meetings-boundary.md
@@ -3,7 +3,7 @@ id: MN-WF-014
 title: Resolve the Human Calls and Agent Meetings Boundary
 parent: MN-WF-000
 status: closed
-assignee: Main
+assignee: Kien
 labels:
   - wayfinder:grilling
 blocked_by: []

--- a/packages/adapters/src/llm/structured-output.ts
+++ b/packages/adapters/src/llm/structured-output.ts
@@ -55,6 +55,59 @@ const LANGCHAIN_METHOD = {
     "json-object": "jsonMode",
 } as const;
 
+type JsonSchemaNode = Record<string, unknown>;
+
+function isJsonSchemaNode(value: unknown): value is JsonSchemaNode {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Native OpenAI-compatible strict JSON Schema requires every object property to
+ * be present. Zod's optional object properties are valid JSON Schema, but they
+ * cannot be passed through that native LangChain method. Detect that shape
+ * before invoking the model so the existing provider-neutral JSON fallback can
+ * preserve the original Zod contract without spending a failed request.
+ */
+function hasOptionalObjectFields(schema: z.ZodType<unknown>, name: string): boolean {
+    const root = zodToJsonSchema(schema, name) as JsonSchemaNode;
+    const definitions = isJsonSchemaNode(root.definitions) ? root.definitions : {};
+    const visited = new Set<JsonSchemaNode>();
+
+    function visit(value: unknown): boolean {
+        if (!isJsonSchemaNode(value) || visited.has(value)) return false;
+
+        const reference = value.$ref;
+        if (typeof reference === "string" && reference.startsWith("#/definitions/")) {
+            const definition = definitions[reference.slice("#/definitions/".length)];
+            return visit(definition);
+        }
+
+        visited.add(value);
+        const properties = value.properties;
+        if (isJsonSchemaNode(properties)) {
+            const required = new Set(
+                Array.isArray(value.required)
+                    ? value.required.filter((entry): entry is string => typeof entry === "string")
+                    : []
+            );
+            for (const [property, child] of Object.entries(properties)) {
+                if (!required.has(property) || visit(child)) return true;
+            }
+        }
+
+        for (const key of ["items", "additionalProperties"] as const) {
+            if (visit(value[key])) return true;
+        }
+        for (const key of ["anyOf", "oneOf", "allOf"] as const) {
+            const branches = value[key];
+            if (Array.isArray(branches) && branches.some(visit)) return true;
+        }
+        return false;
+    }
+
+    return visit(root);
+}
+
 function jsonInstruction(schema: z.ZodType<unknown>, name: string): string {
     const jsonSchema = JSON.stringify(zodToJsonSchema(schema, name), null, 2);
     return [
@@ -103,7 +156,7 @@ function extractJson(text: string): unknown {
 
 async function invokeJsonFallback<T>(
     resolved: ResolvedChatModel,
-    schema: z.ZodType<T>,
+    schema: z.ZodType<T, z.ZodTypeDef, unknown>,
     messages: readonly BaseMessageLike[],
     options: StructuredOutputOptions
 ): Promise<T> {
@@ -146,12 +199,16 @@ async function invokeJsonFallback<T>(
  */
 export async function invokeStructured<T>(
     resolved: ResolvedChatModel,
-    schema: z.ZodType<T>,
+    schema: z.ZodType<T, z.ZodTypeDef, unknown>,
     messages: readonly BaseMessageLike[],
     options: StructuredOutputOptions
 ): Promise<T> {
     const native = pickNativeStructuredMode(resolved.behavior.nativeStructuredOutput);
     if (!native) {
+        return invokeJsonFallback(resolved, schema, messages, options);
+    }
+
+    if (native === "json-schema" && hasOptionalObjectFields(schema, options.name)) {
         return invokeJsonFallback(resolved, schema, messages, options);
     }
 

--- a/packages/features/package.json
+++ b/packages/features/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "description": "Launchstack vertical features on top of @launchstack/core. (Scaffolding stub \u2014 real sources land in later migration steps.)",
+  "description": "Launchstack vertical features on top of @launchstack/core. (Scaffolding stub — real sources land in later migration steps.)",
   "license": "Apache-2.0",
   "engines": {
     "node": ">=20"
@@ -96,6 +96,10 @@
     "./client-prospector/db": {
       "types": "./src/client-prospector/db.ts",
       "default": "./src/client-prospector/db.ts"
+    },
+    "./call-notes": {
+      "types": "./src/call-notes/index.ts",
+      "default": "./src/call-notes/index.ts"
     },
     "./founder-weekly-review": {
       "types": "./src/founder-weekly-review/index.ts",

--- a/packages/features/src/call-notes/contracts.ts
+++ b/packages/features/src/call-notes/contracts.ts
@@ -1,0 +1,441 @@
+import { z } from "zod";
+
+export const CALL_NOTES_SCHEMA_VERSION = "call-notes/v1" as const;
+export const CALL_NOTES_ENRICHMENT_SCHEMA_VERSION = "call-notes-enrichment/v1" as const;
+
+const IdSchema = z.string().min(1).max(64);
+const ProviderKeySchema = z.string().min(1).max(256);
+const TimestampSchema = z.string().datetime({ offset: true });
+const CompanyIdSchema = z.string().regex(/^\d+$/);
+const MarkdownSchema = z.string().max(120_000);
+const RichTextSchema = z.record(z.unknown());
+
+export const CallNotesProviderSchema = z.literal("zoom");
+export type CallNotesProvider = z.infer<typeof CallNotesProviderSchema>;
+
+export const CallStatusSchema = z.enum(["active", "finalizing", "completed", "failed"]);
+export type CallStatus = z.infer<typeof CallStatusSchema>;
+
+export const CaptureDesiredModeSchema = z.enum(["running", "paused"]);
+export type CaptureDesiredMode = z.infer<typeof CaptureDesiredModeSchema>;
+
+export const CaptureLifecycleSchema = z.enum([
+    "connecting",
+    "live",
+    "interrupted",
+    "finalizing",
+    "completed",
+    "failed",
+]);
+export type CaptureLifecycle = z.infer<typeof CaptureLifecycleSchema>;
+
+export const CaptureOutcomeSchema = z.enum(["complete", "partial", "failed"]);
+export type CaptureOutcome = z.infer<typeof CaptureOutcomeSchema>;
+
+export const CaptureAttemptLifecycleSchema = z.enum([
+    "connecting",
+    "live",
+    "reconnecting",
+    "ended",
+    "failed",
+]);
+export type CaptureAttemptLifecycle = z.infer<typeof CaptureAttemptLifecycleSchema>;
+
+export const GapKindSchema = z.enum([
+    "user_paused",
+    "capture_user_absent",
+    "transport_interruption",
+    "worker_unavailable",
+    "provider_unknown",
+]);
+export type GapKind = z.infer<typeof GapKindSchema>;
+
+export const NoteVisibilitySchema = z.enum(["company", "private"]);
+export type NoteVisibility = z.infer<typeof NoteVisibilitySchema>;
+
+export const EnrichmentStatusSchema = z.enum([
+    "queued",
+    "generating",
+    "ready",
+    "rejected",
+    "accepted",
+    "failed",
+]);
+export type EnrichmentStatus = z.infer<typeof EnrichmentStatusSchema>;
+
+export const ParticipantIdentitySchema = z.object({
+    providerParticipantKey: ProviderKeySchema,
+    providerSessionKey: ProviderKeySchema.optional(),
+    displayName: z.string().min(1).max(512),
+});
+export type ParticipantIdentity = z.infer<typeof ParticipantIdentitySchema>;
+
+export const CaptureSourceCapabilitiesSchema = z.object({
+    attributedTranscript: z.boolean(),
+    nativePauseResume: z.boolean(),
+    transportReconnect: z.boolean(),
+    observesCaptureUserReturn: z.boolean(),
+});
+export type CaptureSourceCapabilities = z.infer<typeof CaptureSourceCapabilitiesSchema>;
+
+const CaptureEventBaseSchema = z.object({
+    schemaVersion: z.literal(CALL_NOTES_SCHEMA_VERSION),
+    eventId: IdSchema,
+    provider: CallNotesProviderSchema,
+    occurrenceKey: ProviderKeySchema,
+    attemptKey: ProviderKeySchema.optional(),
+    occurredAt: TimestampSchema,
+});
+
+export const CaptureEventSchema = z.discriminatedUnion("kind", [
+    CaptureEventBaseSchema.extend({
+        kind: z.literal("attempt_connected"),
+        attemptKey: ProviderKeySchema,
+        streamKey: ProviderKeySchema,
+    }),
+    CaptureEventBaseSchema.extend({
+        kind: z.literal("attempt_paused"),
+        attemptKey: ProviderKeySchema,
+    }),
+    CaptureEventBaseSchema.extend({
+        kind: z.literal("attempt_resumed"),
+        attemptKey: ProviderKeySchema,
+    }),
+    CaptureEventBaseSchema.extend({
+        kind: z.literal("transport_interrupted"),
+        attemptKey: ProviderKeySchema,
+        reason: z.string().max(512).optional(),
+    }),
+    CaptureEventBaseSchema.extend({
+        kind: z.literal("transport_reconnected"),
+        attemptKey: ProviderKeySchema,
+    }),
+    CaptureEventBaseSchema.extend({
+        kind: z.literal("attempt_ended"),
+        attemptKey: ProviderKeySchema,
+        reason: z.enum(["capture_user_left", "meeting_ended", "provider_stopped"]),
+    }),
+    CaptureEventBaseSchema.extend({
+        kind: z.literal("attempt_failed"),
+        attemptKey: ProviderKeySchema,
+        code: z.string().min(1).max(128),
+        message: z.string().max(1024).optional(),
+    }),
+    CaptureEventBaseSchema.extend({
+        kind: z.enum(["participant_joined", "participant_left", "participant_returned"]),
+        attemptKey: ProviderKeySchema,
+        participant: ParticipantIdentitySchema,
+    }),
+    CaptureEventBaseSchema.extend({
+        kind: z.literal("transcript_segment"),
+        attemptKey: ProviderKeySchema,
+        providerEventKey: ProviderKeySchema.optional(),
+        sourcePacketHash: z.string().regex(/^[a-f0-9]{64}$/),
+        sourceKind: z.enum(["provider_transcript", "derived_asr"]),
+        participant: ParticipantIdentitySchema.nullable(),
+        providerStartMs: z.number().int().nonnegative().optional(),
+        providerEndMs: z.number().int().nonnegative().optional(),
+        receivedAt: TimestampSchema,
+        receiveOrder: z.number().int().nonnegative(),
+        text: z.string().min(1).max(20_000),
+        language: z.string().min(1).max(32).optional(),
+    }),
+    CaptureEventBaseSchema.extend({
+        kind: z.literal("occurrence_ended"),
+        reason: z.string().max(512).optional(),
+    }),
+]);
+export type CaptureEvent = z.infer<typeof CaptureEventSchema>;
+
+export const StartCaptureInputSchema = z.object({
+    schemaVersion: z.literal(CALL_NOTES_SCHEMA_VERSION),
+    provider: CallNotesProviderSchema,
+    occurrenceKey: ProviderKeySchema,
+    attemptKey: ProviderKeySchema,
+    authorizationRef: IdSchema,
+    captureUser: ParticipantIdentitySchema,
+});
+export type StartCaptureInput = z.infer<typeof StartCaptureInputSchema>;
+
+export const CaptureControlInputSchema = z.object({
+    schemaVersion: z.literal(CALL_NOTES_SCHEMA_VERSION),
+    provider: CallNotesProviderSchema,
+    occurrenceKey: ProviderKeySchema,
+    attemptKey: ProviderKeySchema,
+});
+export type CaptureControlInput = z.infer<typeof CaptureControlInputSchema>;
+
+export const TranscriptSegmentSchema = z.object({
+    id: IdSchema,
+    attemptId: IdSchema,
+    participantId: IdSchema.nullable(),
+    speakerName: z.string().min(1).max(512).nullable(),
+    providerStartMs: z.number().int().nonnegative().nullable(),
+    providerEndMs: z.number().int().nonnegative().nullable(),
+    receivedAt: TimestampSchema,
+    receiveOrder: z.number().int().nonnegative(),
+    text: z.string().min(1).max(20_000),
+    language: z.string().min(1).max(32).nullable(),
+});
+export type TranscriptSegment = z.infer<typeof TranscriptSegmentSchema>;
+
+export const GapSchema = z.object({
+    id: IdSchema,
+    attemptId: IdSchema.nullable(),
+    kind: GapKindSchema,
+    startedAt: TimestampSchema,
+    endedAt: TimestampSchema.nullable(),
+});
+export type Gap = z.infer<typeof GapSchema>;
+
+export const BookmarkSchema = z.object({
+    id: IdSchema,
+    segmentId: IdSchema,
+    comment: z.string().max(2000).nullable(),
+    createdAt: TimestampSchema,
+});
+export type Bookmark = z.infer<typeof BookmarkSchema>;
+
+export const CallNoteSchema = z.object({
+    documentNoteId: z.number().int().positive().nullable(),
+    ownerUserId: z.string().min(1).max(256).nullable(),
+    visibility: NoteVisibilitySchema,
+    knowledgeIncluded: z.boolean(),
+    revision: z.number().int().nonnegative(),
+    title: z.string().max(512),
+    contentMarkdown: MarkdownSchema,
+    contentRich: RichTextSchema,
+    saveState: z.enum(["saved", "saving", "failed"]),
+});
+export type CallNote = z.infer<typeof CallNoteSchema>;
+
+export const BookmarkCitationSchema = z.object({
+    bookmarkId: IdSchema,
+    segmentId: IdSchema,
+    speakerName: z.string().min(1).max(512).nullable(),
+    providerStartMs: z.number().int().nonnegative().nullable(),
+});
+export type BookmarkCitation = z.infer<typeof BookmarkCitationSchema>;
+
+export const EnrichedNoteProposalSchema = z.object({
+    schemaVersion: z.literal(CALL_NOTES_ENRICHMENT_SCHEMA_VERSION),
+    chronologicalSections: z
+        .array(
+            z.object({
+                heading: z.string().min(1).max(256),
+                markdown: z.string().min(1).max(20_000),
+                ownerContextLabels: z.array(z.string().min(1).max(512)).max(20).default([]),
+            })
+        )
+        .min(1)
+        .max(100),
+    summary: z.string().min(1).max(20_000),
+    actionItems: z
+        .array(
+            z.object({
+                text: z.string().min(1).max(2000),
+                ownerName: z.string().min(1).max(512).nullable(),
+                dueDate: z
+                    .string()
+                    .regex(/^\d{4}-\d{2}-\d{2}$/)
+                    .nullable(),
+            })
+        )
+        .max(100),
+    bookmarkPassages: z
+        .array(
+            z.object({
+                markdown: z.string().min(1).max(10_000),
+                citations: z.array(BookmarkCitationSchema).min(1).max(20),
+            })
+        )
+        .max(100),
+    conflicts: z
+        .array(
+            z.object({
+                ownerText: z.string().min(1).max(4000),
+                explanation: z.string().min(1).max(4000),
+            })
+        )
+        .max(100),
+    contentMarkdown: MarkdownSchema,
+    contentRich: RichTextSchema,
+});
+export type EnrichedNoteProposal = z.infer<typeof EnrichedNoteProposalSchema>;
+
+export const ModelMetadataSchema = z.object({
+    provider: z.string().min(1).max(128).optional(),
+    model: z.string().min(1).max(256),
+    promptVersion: z.string().min(1).max(128),
+    completionId: z.string().min(1).max(256).optional(),
+});
+export type ModelMetadata = z.infer<typeof ModelMetadataSchema>;
+
+export const EnrichmentRunSchema = z.object({
+    id: IdSchema,
+    status: EnrichmentStatusSchema,
+    baseNoteRevision: z.number().int().nonnegative(),
+    transcriptFingerprint: z.string().regex(/^[a-f0-9]{64}$/),
+    proposal: EnrichedNoteProposalSchema.nullable(),
+    modelMetadata: ModelMetadataSchema.nullable(),
+    createdAt: TimestampSchema,
+    resolvedAt: TimestampSchema.nullable(),
+});
+export type EnrichmentRun = z.infer<typeof EnrichmentRunSchema>;
+
+export const CaptureSnapshotSchema = z.object({
+    id: IdSchema,
+    desiredMode: CaptureDesiredModeSchema,
+    lifecycle: CaptureLifecycleSchema,
+    outcome: CaptureOutcomeSchema.nullable(),
+    activeAttemptId: IdSchema.nullable(),
+    attemptCount: z.number().int().nonnegative(),
+});
+export type CaptureSnapshot = z.infer<typeof CaptureSnapshotSchema>;
+
+export const CallSnapshotSchema = z.object({
+    schemaVersion: z.literal(CALL_NOTES_SCHEMA_VERSION),
+    id: IdSchema,
+    companyId: CompanyIdSchema,
+    provider: CallNotesProviderSchema,
+    occurrenceKey: ProviderKeySchema,
+    title: z.string().min(1).max(512),
+    status: CallStatusSchema,
+    capture: CaptureSnapshotSchema,
+    transcript: z.array(TranscriptSegmentSchema),
+    gaps: z.array(GapSchema),
+    bookmarks: z.array(BookmarkSchema),
+    note: CallNoteSchema.nullable(),
+    enrichment: EnrichmentRunSchema.nullable(),
+    createdAt: TimestampSchema,
+    updatedAt: TimestampSchema,
+});
+export type CallSnapshot = z.infer<typeof CallSnapshotSchema>;
+export const DetectedCallCandidateSchema = z.object({
+    schemaVersion: z.literal(CALL_NOTES_SCHEMA_VERSION),
+    provider: CallNotesProviderSchema,
+    occurrenceKey: ProviderKeySchema,
+    title: z.string().min(1).max(512),
+    detectedAt: TimestampSchema,
+    endsAt: TimestampSchema.nullable(),
+});
+export type DetectedCallCandidate = z.infer<typeof DetectedCallCandidateSchema>;
+
+const UserCommandBaseSchema = z.object({
+    schemaVersion: z.literal(CALL_NOTES_SCHEMA_VERSION),
+    requestId: IdSchema,
+    companyId: CompanyIdSchema,
+    actorUserId: z.string().min(1).max(256),
+});
+
+export const CallNotesCommandSchema = z.discriminatedUnion("kind", [
+    UserCommandBaseSchema.extend({
+        kind: z.literal("start_capture"),
+        provider: CallNotesProviderSchema,
+        occurrenceKey: ProviderKeySchema,
+        authorizationRef: IdSchema,
+        title: z.string().min(1).max(512).optional(),
+    }),
+    UserCommandBaseSchema.extend({
+        kind: z.literal("dismiss_detected_occurrence"),
+        provider: CallNotesProviderSchema,
+        occurrenceKey: ProviderKeySchema,
+    }),
+    UserCommandBaseSchema.extend({ kind: z.literal("pause_capture"), callId: IdSchema }),
+    UserCommandBaseSchema.extend({ kind: z.literal("resume_capture"), callId: IdSchema }),
+    UserCommandBaseSchema.extend({
+        kind: z.literal("update_note"),
+        callId: IdSchema,
+        baseRevision: z.number().int().nonnegative(),
+        title: z.string().max(512),
+        contentMarkdown: MarkdownSchema,
+        contentRich: RichTextSchema,
+    }),
+    UserCommandBaseSchema.extend({
+        kind: z.literal("add_bookmark"),
+        callId: IdSchema,
+        segmentId: IdSchema,
+        comment: z.string().max(2000).nullable(),
+    }),
+    UserCommandBaseSchema.extend({
+        kind: z.literal("set_note_visibility"),
+        callId: IdSchema,
+        visibility: NoteVisibilitySchema,
+    }),
+    UserCommandBaseSchema.extend({ kind: z.literal("request_enrichment"), callId: IdSchema }),
+    UserCommandBaseSchema.extend({
+        kind: z.literal("reject_enrichment"),
+        callId: IdSchema,
+        enrichmentRunId: IdSchema,
+    }),
+    UserCommandBaseSchema.extend({
+        kind: z.literal("accept_enrichment"),
+        callId: IdSchema,
+        enrichmentRunId: IdSchema,
+        contentMarkdown: MarkdownSchema,
+        contentRich: RichTextSchema,
+    }),
+    UserCommandBaseSchema.extend({
+        kind: z.literal("set_knowledge_inclusion"),
+        callId: IdSchema,
+        included: z.boolean(),
+    }),
+    UserCommandBaseSchema.extend({ kind: z.literal("delete_call"), callId: IdSchema }),
+]);
+export type CallNotesCommand = z.infer<typeof CallNotesCommandSchema>;
+
+export const CallQuerySchema = z.object({
+    companyId: CompanyIdSchema,
+    actorUserId: z.string().min(1).max(256),
+    callId: IdSchema,
+});
+export type CallQuery = z.infer<typeof CallQuerySchema>;
+
+export const CallListQuerySchema = z.object({
+    companyId: CompanyIdSchema,
+    actorUserId: z.string().min(1).max(256),
+    limit: z.number().int().min(1).max(100).default(50),
+});
+export type CallListQuery = z.infer<typeof CallListQuerySchema>;
+
+export const TranscriptSearchQuerySchema = CallQuerySchema.extend({
+    query: z.string().min(1).max(512),
+});
+export type TranscriptSearchQuery = z.infer<typeof TranscriptSearchQuerySchema>;
+
+export const EnrichmentInputSchema = z.object({
+    schemaVersion: z.literal(CALL_NOTES_ENRICHMENT_SCHEMA_VERSION),
+    callId: IdSchema,
+    transcriptFingerprint: z.string().regex(/^[a-f0-9]{64}$/),
+    transcript: z.array(TranscriptSegmentSchema).min(1),
+    gaps: z.array(GapSchema),
+    bookmarks: z.array(BookmarkSchema),
+    note: CallNoteSchema,
+});
+export type EnrichmentInput = z.infer<typeof EnrichmentInputSchema>;
+
+export const EnrichmentResultSchema = z.object({
+    proposal: EnrichedNoteProposalSchema,
+    modelMetadata: ModelMetadataSchema,
+});
+export type EnrichmentResult = z.infer<typeof EnrichmentResultSchema>;
+
+export const KnowledgeNoteSchema = z.object({
+    companyId: CompanyIdSchema,
+    callId: IdSchema,
+    documentNoteId: z.number().int().positive(),
+    ownerUserId: z.string().min(1).max(256),
+    revision: z.number().int().positive(),
+    title: z.string().max(512),
+    contentMarkdown: MarkdownSchema,
+    deepLink: z.string().min(1).max(2048),
+});
+export type KnowledgeNote = z.infer<typeof KnowledgeNoteSchema>;
+
+export const CompleteEnrichmentInputSchema = z.object({
+    companyId: CompanyIdSchema,
+    callId: IdSchema,
+    enrichmentRunId: IdSchema,
+    result: EnrichmentResultSchema,
+});
+export type CompleteEnrichmentInput = z.infer<typeof CompleteEnrichmentInputSchema>;

--- a/packages/features/src/call-notes/index.ts
+++ b/packages/features/src/call-notes/index.ts
@@ -1,0 +1,3 @@
+export * from "./contracts";
+export * from "./ports";
+export * from "./testing";

--- a/packages/features/src/call-notes/ports.ts
+++ b/packages/features/src/call-notes/ports.ts
@@ -1,0 +1,61 @@
+import type {
+    CallListQuery,
+    CallNotesCommand,
+    CallQuery,
+    CallSnapshot,
+    CaptureControlInput,
+    CaptureEvent,
+    CaptureSourceCapabilities,
+    CompleteEnrichmentInput,
+    DetectedCallCandidate,
+    EnrichmentInput,
+    EnrichmentResult,
+    KnowledgeNote,
+    StartCaptureInput,
+    TranscriptSearchQuery,
+    TranscriptSegment,
+} from "./contracts";
+
+export interface CaptureEventSink {
+    append(event: CaptureEvent): Promise<void>;
+}
+
+export interface CaptureAttemptHandle {
+    pause(input: CaptureControlInput): Promise<void>;
+    resume(input: CaptureControlInput): Promise<void>;
+    /** Releases local resources. It is not a provider Stop command. */
+    dispose(): Promise<void>;
+}
+
+export interface CaptureSource {
+    readonly capabilities: CaptureSourceCapabilities;
+    startAttempt(input: StartCaptureInput, sink: CaptureEventSink): Promise<CaptureAttemptHandle>;
+}
+
+/** Public application boundary consumed by API handlers and contract tests. */
+export interface CallNotesApplication {
+    execute(command: CallNotesCommand): Promise<CallSnapshot | null>;
+    ingestCaptureEvent(companyId: string, event: CaptureEvent): Promise<void>;
+    completeEnrichment(input: CompleteEnrichmentInput): Promise<void>;
+    getCall(query: CallQuery): Promise<CallSnapshot>;
+    listCalls(query: CallListQuery): Promise<readonly CallSnapshot[]>;
+    listDetectedCalls(query: CallListQuery): Promise<readonly DetectedCallCandidate[]>;
+    searchTranscript(query: TranscriptSearchQuery): Promise<readonly TranscriptSegment[]>;
+}
+
+export interface EnrichmentModel {
+    generate(input: EnrichmentInput): Promise<EnrichmentResult>;
+}
+
+export interface KnowledgeNoteSink {
+    upsert(note: KnowledgeNote): Promise<void>;
+    remove(companyId: string, callId: string): Promise<void>;
+}
+
+export interface CallNotesClock {
+    now(): Date;
+}
+
+export interface CallNotesIdSource {
+    next(prefix: string): string;
+}

--- a/packages/features/src/call-notes/schema.ts
+++ b/packages/features/src/call-notes/schema.ts
@@ -1,0 +1,529 @@
+import { sql } from "drizzle-orm";
+import type { InferSelectModel } from "drizzle-orm";
+import {
+    bigint,
+    boolean,
+    index,
+    integer,
+    jsonb,
+    text,
+    timestamp,
+    uniqueIndex,
+    varchar,
+} from "drizzle-orm/pg-core";
+
+import { company } from "@launchstack/core/db/schema";
+import { pgTable } from "@launchstack/core/db/schema/helpers";
+
+import type { EnrichedNoteProposal, ModelMetadata } from "./contracts";
+
+export const callNotesCallStatusEnum = ["active", "finalizing", "completed", "failed"] as const;
+export const callNotesCaptureDesiredModeEnum = ["running", "paused"] as const;
+export const callNotesCaptureLifecycleEnum = [
+    "connecting",
+    "live",
+    "interrupted",
+    "finalizing",
+    "completed",
+    "failed",
+] as const;
+export const callNotesCaptureOutcomeEnum = ["complete", "partial", "failed"] as const;
+export const callNotesAttemptLifecycleEnum = [
+    "connecting",
+    "live",
+    "reconnecting",
+    "ended",
+    "failed",
+] as const;
+export const callNotesGapKindEnum = [
+    "user_paused",
+    "capture_user_absent",
+    "transport_interruption",
+    "worker_unavailable",
+    "provider_unknown",
+] as const;
+export const callNotesNoteVisibilityEnum = ["company", "private"] as const;
+export const callNotesEnrichmentStatusEnum = [
+    "queued",
+    "generating",
+    "ready",
+    "rejected",
+    "accepted",
+    "failed",
+] as const;
+export const callNotesWorkItemKindEnum = [
+    "start",
+    "pause",
+    "resume",
+    "provider_event",
+    "finalize",
+    "enrich",
+    "reindex",
+] as const;
+export const callNotesWorkItemStatusEnum = ["pending", "claimed", "completed", "failed"] as const;
+
+export const callNotesZoomConnections = pgTable(
+    "call_notes_zoom_connections",
+    {
+        id: varchar("id", { length: 64 }).primaryKey(),
+        companyId: bigint("company_id", { mode: "bigint" })
+            .notNull()
+            .references(() => company.id, { onDelete: "cascade" }),
+        userId: varchar("user_id", { length: 256 }).notNull(),
+        zoomAccountId: varchar("zoom_account_id", { length: 256 }).notNull(),
+        zoomUserId: varchar("zoom_user_id", { length: 256 }).notNull(),
+        encryptedAccessToken: text("encrypted_access_token").notNull(),
+        encryptedRefreshToken: text("encrypted_refresh_token"),
+        tokenExpiresAt: timestamp("token_expires_at", { withTimezone: true }),
+        scopes: text("scopes").array().notNull().default([]),
+        status: varchar("status", {
+            length: 24,
+            enum: ["active", "revoked", "disconnected"],
+        })
+            .notNull()
+            .default("active"),
+        createdAt: timestamp("created_at", { withTimezone: true })
+            .default(sql`CURRENT_TIMESTAMP`)
+            .notNull(),
+        updatedAt: timestamp("updated_at", { withTimezone: true }).$onUpdate(() => new Date()),
+    },
+    table => ({
+        companyUserUnique: uniqueIndex("call_notes_zoom_connections_company_user_unique").on(
+            table.companyId,
+            table.userId
+        ),
+        companyZoomUserUnique: uniqueIndex(
+            "call_notes_zoom_connections_company_zoom_user_unique"
+        ).on(table.companyId, table.zoomUserId),
+    })
+);
+
+export const callNotesCalls = pgTable(
+    "call_notes_calls",
+    {
+        id: varchar("id", { length: 64 }).primaryKey(),
+        companyId: bigint("company_id", { mode: "bigint" })
+            .notNull()
+            .references(() => company.id, { onDelete: "cascade" }),
+        provider: varchar("provider", { length: 32, enum: ["zoom"] }).notNull(),
+        providerOccurrenceKey: varchar("provider_occurrence_key", { length: 256 }).notNull(),
+        title: varchar("title", { length: 512 }).notNull(),
+        status: varchar("status", { length: 32, enum: callNotesCallStatusEnum })
+            .notNull()
+            .default("active"),
+        documentNoteId: bigint("document_note_id", { mode: "number" }),
+        noteOwnerUserId: varchar("note_owner_user_id", { length: 256 }),
+        noteVisibility: varchar("note_visibility", {
+            length: 16,
+            enum: callNotesNoteVisibilityEnum,
+        })
+            .notNull()
+            .default("company"),
+        knowledgeIncluded: boolean("knowledge_included").notNull().default(false),
+        currentNoteRevision: integer("current_note_revision").notNull().default(0),
+        failureCode: varchar("failure_code", { length: 128 }),
+        failureMessage: varchar("failure_message", { length: 1024 }),
+        startedAt: timestamp("started_at", { withTimezone: true }),
+        finalizedAt: timestamp("finalized_at", { withTimezone: true }),
+        createdAt: timestamp("created_at", { withTimezone: true })
+            .default(sql`CURRENT_TIMESTAMP`)
+            .notNull(),
+        updatedAt: timestamp("updated_at", { withTimezone: true }).$onUpdate(() => new Date()),
+    },
+    table => ({
+        occurrenceUnique: uniqueIndex("call_notes_calls_company_occurrence_unique").on(
+            table.companyId,
+            table.provider,
+            table.providerOccurrenceKey
+        ),
+        companyCreatedIdx: index("call_notes_calls_company_created_at_idx").on(
+            table.companyId,
+            table.createdAt
+        ),
+        companyStatusIdx: index("call_notes_calls_company_status_idx").on(
+            table.companyId,
+            table.status
+        ),
+        documentNoteUnique: uniqueIndex("call_notes_calls_document_note_unique").on(
+            table.documentNoteId
+        ),
+    })
+);
+
+export const callNotesCaptures = pgTable(
+    "call_notes_captures",
+    {
+        id: varchar("id", { length: 64 }).primaryKey(),
+        callId: varchar("call_id", { length: 64 })
+            .notNull()
+            .references(() => callNotesCalls.id, { onDelete: "cascade" }),
+        companyId: bigint("company_id", { mode: "bigint" })
+            .notNull()
+            .references(() => company.id, { onDelete: "cascade" }),
+        captureUserConnectionId: varchar("capture_user_connection_id", { length: 64 })
+            .notNull()
+            .references(() => callNotesZoomConnections.id, { onDelete: "restrict" }),
+        captureUserProviderKey: varchar("capture_user_provider_key", { length: 256 }).notNull(),
+        desiredMode: varchar("desired_mode", {
+            length: 16,
+            enum: callNotesCaptureDesiredModeEnum,
+        })
+            .notNull()
+            .default("running"),
+        lifecycle: varchar("lifecycle", {
+            length: 32,
+            enum: callNotesCaptureLifecycleEnum,
+        })
+            .notNull()
+            .default("connecting"),
+        outcome: varchar("outcome", { length: 16, enum: callNotesCaptureOutcomeEnum }),
+        activeAttemptId: varchar("active_attempt_id", { length: 64 }),
+        startedAt: timestamp("started_at", { withTimezone: true })
+            .default(sql`CURRENT_TIMESTAMP`)
+            .notNull(),
+        endedAt: timestamp("ended_at", { withTimezone: true }),
+        updatedAt: timestamp("updated_at", { withTimezone: true }).$onUpdate(() => new Date()),
+    },
+    table => ({
+        callUnique: uniqueIndex("call_notes_captures_call_unique").on(table.callId),
+        companyLifecycleIdx: index("call_notes_captures_company_lifecycle_idx").on(
+            table.companyId,
+            table.lifecycle
+        ),
+    })
+);
+
+export const callNotesCaptureAttempts = pgTable(
+    "call_notes_capture_attempts",
+    {
+        id: varchar("id", { length: 64 }).primaryKey(),
+        captureId: varchar("capture_id", { length: 64 })
+            .notNull()
+            .references(() => callNotesCaptures.id, { onDelete: "cascade" }),
+        callId: varchar("call_id", { length: 64 })
+            .notNull()
+            .references(() => callNotesCalls.id, { onDelete: "cascade" }),
+        companyId: bigint("company_id", { mode: "bigint" })
+            .notNull()
+            .references(() => company.id, { onDelete: "cascade" }),
+        providerAttemptKey: varchar("provider_attempt_key", { length: 256 }).notNull(),
+        providerStreamKey: varchar("provider_stream_key", { length: 256 }),
+        lifecycle: varchar("lifecycle", {
+            length: 24,
+            enum: callNotesAttemptLifecycleEnum,
+        })
+            .notNull()
+            .default("connecting"),
+        leaseToken: varchar("lease_token", { length: 128 }),
+        leaseOwner: varchar("lease_owner", { length: 256 }),
+        leaseExpiresAt: timestamp("lease_expires_at", { withTimezone: true }),
+        startedAt: timestamp("started_at", { withTimezone: true })
+            .default(sql`CURRENT_TIMESTAMP`)
+            .notNull(),
+        endedAt: timestamp("ended_at", { withTimezone: true }),
+        failureCode: varchar("failure_code", { length: 128 }),
+        failureMessage: varchar("failure_message", { length: 1024 }),
+    },
+    table => ({
+        providerAttemptUnique: uniqueIndex(
+            "call_notes_capture_attempts_capture_provider_key_unique"
+        ).on(table.captureId, table.providerAttemptKey),
+        oneActiveAttemptUnique: uniqueIndex("call_notes_capture_attempts_one_active_unique")
+            .on(table.captureId)
+            .where(sql`${table.lifecycle} in ('connecting', 'live', 'reconnecting')`),
+        captureStartedIdx: index("call_notes_capture_attempts_capture_started_idx").on(
+            table.captureId,
+            table.startedAt
+        ),
+        leaseIdx: index("call_notes_capture_attempts_lease_idx").on(
+            table.lifecycle,
+            table.leaseExpiresAt
+        ),
+    })
+);
+
+export const callNotesParticipants = pgTable(
+    "call_notes_participants",
+    {
+        id: varchar("id", { length: 64 }).primaryKey(),
+        callId: varchar("call_id", { length: 64 })
+            .notNull()
+            .references(() => callNotesCalls.id, { onDelete: "cascade" }),
+        attemptId: varchar("attempt_id", { length: 64 })
+            .notNull()
+            .references(() => callNotesCaptureAttempts.id, { onDelete: "cascade" }),
+        companyId: bigint("company_id", { mode: "bigint" })
+            .notNull()
+            .references(() => company.id, { onDelete: "cascade" }),
+        providerParticipantKey: varchar("provider_participant_key", { length: 256 }).notNull(),
+        providerSessionKey: varchar("provider_session_key", { length: 256 }),
+        displayName: varchar("display_name", { length: 512 }).notNull(),
+        observedAt: timestamp("observed_at", { withTimezone: true })
+            .default(sql`CURRENT_TIMESTAMP`)
+            .notNull(),
+        leftAt: timestamp("left_at", { withTimezone: true }),
+    },
+    table => ({
+        attemptParticipantIdx: index("call_notes_participants_attempt_key_idx").on(
+            table.attemptId,
+            table.providerParticipantKey
+        ),
+        callObservedIdx: index("call_notes_participants_call_observed_idx").on(
+            table.callId,
+            table.observedAt
+        ),
+    })
+);
+
+export const callNotesTranscriptSegments = pgTable(
+    "call_notes_transcript_segments",
+    {
+        id: varchar("id", { length: 64 }).primaryKey(),
+        callId: varchar("call_id", { length: 64 })
+            .notNull()
+            .references(() => callNotesCalls.id, { onDelete: "cascade" }),
+        attemptId: varchar("attempt_id", { length: 64 })
+            .notNull()
+            .references(() => callNotesCaptureAttempts.id, { onDelete: "cascade" }),
+        participantId: varchar("participant_id", { length: 64 }).references(
+            () => callNotesParticipants.id,
+            { onDelete: "set null" }
+        ),
+        companyId: bigint("company_id", { mode: "bigint" })
+            .notNull()
+            .references(() => company.id, { onDelete: "cascade" }),
+        providerEventKey: varchar("provider_event_key", { length: 256 }),
+        sourcePacketHash: varchar("source_packet_hash", { length: 64 }).notNull(),
+        sourceKind: varchar("source_kind", {
+            length: 32,
+            enum: ["provider_transcript", "derived_asr"],
+        }).notNull(),
+        speakerName: varchar("speaker_name", { length: 512 }),
+        providerStartMs: bigint("provider_start_ms", { mode: "number" }),
+        providerEndMs: bigint("provider_end_ms", { mode: "number" }),
+        receivedAt: timestamp("received_at", { withTimezone: true }).notNull(),
+        receiveOrder: integer("receive_order").notNull(),
+        text: text("text").notNull(),
+        language: varchar("language", { length: 32 }),
+        createdAt: timestamp("created_at", { withTimezone: true })
+            .default(sql`CURRENT_TIMESTAMP`)
+            .notNull(),
+    },
+    table => ({
+        packetUnique: uniqueIndex("call_notes_segments_attempt_packet_unique").on(
+            table.attemptId,
+            table.sourcePacketHash
+        ),
+        callOrderIdx: index("call_notes_segments_call_order_idx").on(
+            table.callId,
+            table.providerStartMs,
+            table.receiveOrder
+        ),
+        companyReceivedIdx: index("call_notes_segments_company_received_idx").on(
+            table.companyId,
+            table.receivedAt
+        ),
+    })
+);
+
+export const callNotesGaps = pgTable(
+    "call_notes_gaps",
+    {
+        id: varchar("id", { length: 64 }).primaryKey(),
+        callId: varchar("call_id", { length: 64 })
+            .notNull()
+            .references(() => callNotesCalls.id, { onDelete: "cascade" }),
+        captureId: varchar("capture_id", { length: 64 })
+            .notNull()
+            .references(() => callNotesCaptures.id, { onDelete: "cascade" }),
+        attemptId: varchar("attempt_id", { length: 64 }).references(
+            () => callNotesCaptureAttempts.id,
+            { onDelete: "set null" }
+        ),
+        companyId: bigint("company_id", { mode: "bigint" })
+            .notNull()
+            .references(() => company.id, { onDelete: "cascade" }),
+        kind: varchar("kind", { length: 32, enum: callNotesGapKindEnum }).notNull(),
+        startedAt: timestamp("started_at", { withTimezone: true }).notNull(),
+        endedAt: timestamp("ended_at", { withTimezone: true }),
+        details: jsonb("details").$type<Record<string, unknown> | null>(),
+    },
+    table => ({
+        callStartedIdx: index("call_notes_gaps_call_started_idx").on(table.callId, table.startedAt),
+    })
+);
+
+export const callNotesBookmarks = pgTable(
+    "call_notes_bookmarks",
+    {
+        id: varchar("id", { length: 64 }).primaryKey(),
+        callId: varchar("call_id", { length: 64 })
+            .notNull()
+            .references(() => callNotesCalls.id, { onDelete: "cascade" }),
+        segmentId: varchar("segment_id", { length: 64 })
+            .notNull()
+            .references(() => callNotesTranscriptSegments.id, { onDelete: "cascade" }),
+        companyId: bigint("company_id", { mode: "bigint" })
+            .notNull()
+            .references(() => company.id, { onDelete: "cascade" }),
+        createdByUserId: varchar("created_by_user_id", { length: 256 }).notNull(),
+        comment: text("comment"),
+        createdAt: timestamp("created_at", { withTimezone: true })
+            .default(sql`CURRENT_TIMESTAMP`)
+            .notNull(),
+    },
+    table => ({
+        callCreatedIdx: index("call_notes_bookmarks_call_created_idx").on(
+            table.callId,
+            table.createdAt
+        ),
+    })
+);
+
+export const callNotesEnrichmentRuns = pgTable(
+    "call_notes_enrichment_runs",
+    {
+        id: varchar("id", { length: 64 }).primaryKey(),
+        callId: varchar("call_id", { length: 64 })
+            .notNull()
+            .references(() => callNotesCalls.id, { onDelete: "cascade" }),
+        companyId: bigint("company_id", { mode: "bigint" })
+            .notNull()
+            .references(() => company.id, { onDelete: "cascade" }),
+        requestedByUserId: varchar("requested_by_user_id", { length: 256 }).notNull(),
+        baseNoteRevision: integer("base_note_revision").notNull(),
+        transcriptFingerprint: varchar("transcript_fingerprint", { length: 64 }).notNull(),
+        status: varchar("status", {
+            length: 24,
+            enum: callNotesEnrichmentStatusEnum,
+        })
+            .notNull()
+            .default("queued"),
+        originalOutput: jsonb("original_output").$type<EnrichedNoteProposal | null>(),
+        editableProposal: jsonb("editable_proposal").$type<EnrichedNoteProposal | null>(),
+        modelMetadata: jsonb("model_metadata").$type<ModelMetadata | null>(),
+        errorCode: varchar("error_code", { length: 128 }),
+        errorMessage: varchar("error_message", { length: 1024 }),
+        resolvedByUserId: varchar("resolved_by_user_id", { length: 256 }),
+        createdAt: timestamp("created_at", { withTimezone: true })
+            .default(sql`CURRENT_TIMESTAMP`)
+            .notNull(),
+        generatedAt: timestamp("generated_at", { withTimezone: true }),
+        resolvedAt: timestamp("resolved_at", { withTimezone: true }),
+    },
+    table => ({
+        callCreatedIdx: index("call_notes_enrichment_runs_call_created_idx").on(
+            table.callId,
+            table.createdAt
+        ),
+        companyStatusIdx: index("call_notes_enrichment_runs_company_status_idx").on(
+            table.companyId,
+            table.status
+        ),
+        oneActiveProposalUnique: uniqueIndex("call_notes_enrichment_runs_one_active_unique")
+            .on(table.callId)
+            .where(sql`${table.status} in ('queued', 'generating', 'ready')`),
+    })
+);
+
+export const callNotesNoteRevisions = pgTable(
+    "call_notes_note_revisions",
+    {
+        id: varchar("id", { length: 64 }).primaryKey(),
+        callId: varchar("call_id", { length: 64 })
+            .notNull()
+            .references(() => callNotesCalls.id, { onDelete: "cascade" }),
+        companyId: bigint("company_id", { mode: "bigint" })
+            .notNull()
+            .references(() => company.id, { onDelete: "cascade" }),
+        documentNoteId: bigint("document_note_id", { mode: "number" }).notNull(),
+        revision: integer("revision").notNull(),
+        origin: varchar("origin", { length: 24, enum: ["manual", "enrichment"] }).notNull(),
+        enrichmentRunId: varchar("enrichment_run_id", { length: 64 }).references(
+            () => callNotesEnrichmentRuns.id,
+            { onDelete: "set null" }
+        ),
+        title: text("title"),
+        contentMarkdown: text("content_markdown").notNull(),
+        contentRich: jsonb("content_rich").$type<Record<string, unknown>>().notNull(),
+        createdByUserId: varchar("created_by_user_id", { length: 256 }).notNull(),
+        createdAt: timestamp("created_at", { withTimezone: true })
+            .default(sql`CURRENT_TIMESTAMP`)
+            .notNull(),
+    },
+    table => ({
+        callRevisionUnique: uniqueIndex("call_notes_note_revisions_call_revision_unique").on(
+            table.callId,
+            table.revision
+        ),
+        documentNoteIdx: index("call_notes_note_revisions_document_note_idx").on(
+            table.documentNoteId
+        ),
+    })
+);
+
+export const callNotesWorkItems = pgTable(
+    "call_notes_work_items",
+    {
+        id: varchar("id", { length: 64 }).primaryKey(),
+        companyId: bigint("company_id", { mode: "bigint" })
+            .notNull()
+            .references(() => company.id, { onDelete: "cascade" }),
+        callId: varchar("call_id", { length: 64 }).references(() => callNotesCalls.id, {
+            onDelete: "cascade",
+        }),
+        captureId: varchar("capture_id", { length: 64 }).references(() => callNotesCaptures.id, {
+            onDelete: "cascade",
+        }),
+        kind: varchar("kind", { length: 32, enum: callNotesWorkItemKindEnum }).notNull(),
+        idempotencyKey: varchar("idempotency_key", { length: 256 }).notNull(),
+        payload: jsonb("payload").$type<Record<string, unknown>>().notNull(),
+        status: varchar("status", {
+            length: 24,
+            enum: callNotesWorkItemStatusEnum,
+        })
+            .notNull()
+            .default("pending"),
+        leaseToken: varchar("lease_token", { length: 128 }),
+        leaseOwner: varchar("lease_owner", { length: 256 }),
+        leaseExpiresAt: timestamp("lease_expires_at", { withTimezone: true }),
+        attempts: integer("attempts").notNull().default(0),
+        errorCode: varchar("error_code", { length: 128 }),
+        errorMessage: varchar("error_message", { length: 1024 }),
+        availableAt: timestamp("available_at", { withTimezone: true })
+            .default(sql`CURRENT_TIMESTAMP`)
+            .notNull(),
+        createdAt: timestamp("created_at", { withTimezone: true })
+            .default(sql`CURRENT_TIMESTAMP`)
+            .notNull(),
+        completedAt: timestamp("completed_at", { withTimezone: true }),
+    },
+    table => ({
+        idempotencyUnique: uniqueIndex("call_notes_work_items_company_kind_key_unique").on(
+            table.companyId,
+            table.kind,
+            table.idempotencyKey
+        ),
+        claimIdx: index("call_notes_work_items_claim_idx").on(
+            table.status,
+            table.availableAt,
+            table.leaseExpiresAt
+        ),
+        callCreatedIdx: index("call_notes_work_items_call_created_idx").on(
+            table.callId,
+            table.createdAt
+        ),
+    })
+);
+
+export type CallNotesCallRow = InferSelectModel<typeof callNotesCalls>;
+export type CallNotesCaptureRow = InferSelectModel<typeof callNotesCaptures>;
+export type CallNotesCaptureAttemptRow = InferSelectModel<typeof callNotesCaptureAttempts>;
+export type CallNotesParticipantRow = InferSelectModel<typeof callNotesParticipants>;
+export type CallNotesTranscriptSegmentRow = InferSelectModel<typeof callNotesTranscriptSegments>;
+export type CallNotesGapRow = InferSelectModel<typeof callNotesGaps>;
+export type CallNotesBookmarkRow = InferSelectModel<typeof callNotesBookmarks>;
+export type CallNotesEnrichmentRunRow = InferSelectModel<typeof callNotesEnrichmentRuns>;
+export type CallNotesNoteRevisionRow = InferSelectModel<typeof callNotesNoteRevisions>;
+export type CallNotesWorkItemRow = InferSelectModel<typeof callNotesWorkItems>;
+export type CallNotesZoomConnectionRow = InferSelectModel<typeof callNotesZoomConnections>;

--- a/packages/features/src/call-notes/testing.ts
+++ b/packages/features/src/call-notes/testing.ts
@@ -1,0 +1,567 @@
+import {
+    CALL_NOTES_ENRICHMENT_SCHEMA_VERSION,
+    CALL_NOTES_SCHEMA_VERSION,
+    CallNotesCommandSchema,
+    CallSnapshotSchema,
+    CaptureControlInputSchema,
+    CaptureEventSchema,
+    CompleteEnrichmentInputSchema,
+    DetectedCallCandidateSchema,
+    EnrichedNoteProposalSchema,
+    StartCaptureInputSchema,
+    type CallNotesCommand,
+    type CallSnapshot,
+    type CaptureEvent,
+    type KnowledgeNote,
+} from "./contracts";
+import type {
+    CallNotesApplication,
+    CaptureAttemptHandle,
+    CaptureEventSink,
+    CaptureSource,
+} from "./ports";
+
+function invariant(value: unknown, message: string): asserts value {
+    if (!value) throw new Error(`Call Notes contract violation: ${message}`);
+}
+async function invariantRejects(promise: Promise<unknown>, message: string): Promise<void> {
+    try {
+        await promise;
+    } catch {
+        return;
+    }
+    throw new Error(`Call Notes contract violation: ${message}`);
+}
+
+const fixtureParticipant = {
+    providerParticipantKey: "zoom-user-owner",
+    providerSessionKey: "zoom-session-owner",
+    displayName: "Alex Founder",
+};
+
+const fixtureGuest = {
+    providerParticipantKey: "zoom-user-guest",
+    providerSessionKey: "zoom-session-guest",
+    displayName: "Maya Customer",
+};
+
+export const CALL_NOTES_FIXTURE_IDS = {
+    companyId: "1",
+    ownerUserId: "user_owner",
+    otherUserId: "user_teammate",
+    occurrenceKey: "zoom-occurrence-2026-08-15",
+    firstAttemptKey: "zoom-attempt-1",
+    secondAttemptKey: "zoom-attempt-2",
+    authorizationRef: "zoom-connection-owner",
+} as const;
+export const CALL_NOTES_DETECTED_CANDIDATE = DetectedCallCandidateSchema.parse({
+    schemaVersion: CALL_NOTES_SCHEMA_VERSION,
+    provider: "zoom",
+    occurrenceKey: CALL_NOTES_FIXTURE_IDS.occurrenceKey,
+    title: "Customer onboarding review",
+    detectedAt: "2026-08-15T13:59:00.000Z",
+    endsAt: null,
+});
+
+export const CALL_NOTES_CAPTURE_EVENTS = CaptureEventSchema.array().parse([
+    {
+        schemaVersion: CALL_NOTES_SCHEMA_VERSION,
+        eventId: "event-connected-1",
+        kind: "attempt_connected",
+        provider: "zoom",
+        occurrenceKey: CALL_NOTES_FIXTURE_IDS.occurrenceKey,
+        attemptKey: CALL_NOTES_FIXTURE_IDS.firstAttemptKey,
+        streamKey: "zoom-stream-1",
+        occurredAt: "2026-08-15T14:00:00.000Z",
+    },
+    {
+        schemaVersion: CALL_NOTES_SCHEMA_VERSION,
+        eventId: "event-owner-joined",
+        kind: "participant_joined",
+        provider: "zoom",
+        occurrenceKey: CALL_NOTES_FIXTURE_IDS.occurrenceKey,
+        attemptKey: CALL_NOTES_FIXTURE_IDS.firstAttemptKey,
+        participant: fixtureParticipant,
+        occurredAt: "2026-08-15T14:00:01.000Z",
+    },
+    {
+        schemaVersion: CALL_NOTES_SCHEMA_VERSION,
+        eventId: "event-guest-joined",
+        kind: "participant_joined",
+        provider: "zoom",
+        occurrenceKey: CALL_NOTES_FIXTURE_IDS.occurrenceKey,
+        attemptKey: CALL_NOTES_FIXTURE_IDS.firstAttemptKey,
+        participant: fixtureGuest,
+        occurredAt: "2026-08-15T14:00:02.000Z",
+    },
+    {
+        schemaVersion: CALL_NOTES_SCHEMA_VERSION,
+        eventId: "event-segment-1",
+        kind: "transcript_segment",
+        provider: "zoom",
+        occurrenceKey: CALL_NOTES_FIXTURE_IDS.occurrenceKey,
+        attemptKey: CALL_NOTES_FIXTURE_IDS.firstAttemptKey,
+        providerEventKey: "zoom-transcript-1",
+        sourcePacketHash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        sourceKind: "provider_transcript",
+        participant: fixtureGuest,
+        providerStartMs: 1_000,
+        providerEndMs: 4_000,
+        receivedAt: "2026-08-15T14:00:04.100Z",
+        receiveOrder: 1,
+        text: "We need to reduce onboarding time before the September launch.",
+        language: "en",
+        occurredAt: "2026-08-15T14:00:04.100Z",
+    },
+    {
+        schemaVersion: CALL_NOTES_SCHEMA_VERSION,
+        eventId: "event-paused-1",
+        kind: "attempt_paused",
+        provider: "zoom",
+        occurrenceKey: CALL_NOTES_FIXTURE_IDS.occurrenceKey,
+        attemptKey: CALL_NOTES_FIXTURE_IDS.firstAttemptKey,
+        occurredAt: "2026-08-15T14:05:00.000Z",
+    },
+    {
+        schemaVersion: CALL_NOTES_SCHEMA_VERSION,
+        eventId: "event-resumed-1",
+        kind: "attempt_resumed",
+        provider: "zoom",
+        occurrenceKey: CALL_NOTES_FIXTURE_IDS.occurrenceKey,
+        attemptKey: CALL_NOTES_FIXTURE_IDS.firstAttemptKey,
+        occurredAt: "2026-08-15T14:07:00.000Z",
+    },
+    {
+        schemaVersion: CALL_NOTES_SCHEMA_VERSION,
+        eventId: "event-segment-2",
+        kind: "transcript_segment",
+        provider: "zoom",
+        occurrenceKey: CALL_NOTES_FIXTURE_IDS.occurrenceKey,
+        attemptKey: CALL_NOTES_FIXTURE_IDS.firstAttemptKey,
+        providerEventKey: "zoom-transcript-2",
+        sourcePacketHash: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        sourceKind: "provider_transcript",
+        participant: fixtureParticipant,
+        providerStartMs: 421_000,
+        providerEndMs: 425_000,
+        receivedAt: "2026-08-15T14:07:05.050Z",
+        receiveOrder: 2,
+        text: "I will send the revised onboarding checklist by Friday.",
+        language: "en",
+        occurredAt: "2026-08-15T14:07:05.050Z",
+    },
+    {
+        schemaVersion: CALL_NOTES_SCHEMA_VERSION,
+        eventId: "event-attempt-1-ended",
+        kind: "attempt_ended",
+        provider: "zoom",
+        occurrenceKey: CALL_NOTES_FIXTURE_IDS.occurrenceKey,
+        attemptKey: CALL_NOTES_FIXTURE_IDS.firstAttemptKey,
+        reason: "capture_user_left",
+        occurredAt: "2026-08-15T14:10:00.000Z",
+    },
+    {
+        schemaVersion: CALL_NOTES_SCHEMA_VERSION,
+        eventId: "event-connected-2",
+        kind: "attempt_connected",
+        provider: "zoom",
+        occurrenceKey: CALL_NOTES_FIXTURE_IDS.occurrenceKey,
+        attemptKey: CALL_NOTES_FIXTURE_IDS.secondAttemptKey,
+        streamKey: "zoom-stream-2",
+        occurredAt: "2026-08-15T14:11:00.000Z",
+    },
+    {
+        schemaVersion: CALL_NOTES_SCHEMA_VERSION,
+        eventId: "event-owner-returned",
+        kind: "participant_returned",
+        provider: "zoom",
+        occurrenceKey: CALL_NOTES_FIXTURE_IDS.occurrenceKey,
+        attemptKey: CALL_NOTES_FIXTURE_IDS.secondAttemptKey,
+        participant: fixtureParticipant,
+        occurredAt: "2026-08-15T14:11:00.100Z",
+    },
+    {
+        schemaVersion: CALL_NOTES_SCHEMA_VERSION,
+        eventId: "event-segment-3",
+        kind: "transcript_segment",
+        provider: "zoom",
+        occurrenceKey: CALL_NOTES_FIXTURE_IDS.occurrenceKey,
+        attemptKey: CALL_NOTES_FIXTURE_IDS.secondAttemptKey,
+        providerEventKey: "zoom-transcript-3",
+        sourcePacketHash: "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+        sourceKind: "provider_transcript",
+        participant: fixtureGuest,
+        providerStartMs: 665_000,
+        providerEndMs: 669_000,
+        receivedAt: "2026-08-15T14:11:09.040Z",
+        receiveOrder: 3,
+        text: "That checklist and a short walkthrough should unblock our team.",
+        language: "en",
+        occurredAt: "2026-08-15T14:11:09.040Z",
+    },
+    {
+        schemaVersion: CALL_NOTES_SCHEMA_VERSION,
+        eventId: "event-occurrence-ended",
+        kind: "occurrence_ended",
+        provider: "zoom",
+        occurrenceKey: CALL_NOTES_FIXTURE_IDS.occurrenceKey,
+        occurredAt: "2026-08-15T14:30:00.000Z",
+        reason: "meeting ended",
+    },
+]);
+
+export const CALL_NOTES_ENRICHMENT_PROPOSAL = EnrichedNoteProposalSchema.parse({
+    schemaVersion: CALL_NOTES_ENRICHMENT_SCHEMA_VERSION,
+    chronologicalSections: [
+        {
+            heading: "Onboarding launch risk",
+            markdown: "Maya needs onboarding time reduced before the September launch.",
+            ownerContextLabels: ["Pricing concerns and launch sequencing"],
+        },
+        {
+            heading: "Next step",
+            markdown: "Alex will send a revised onboarding checklist by Friday.",
+            ownerContextLabels: [],
+        },
+    ],
+    summary: "The onboarding checklist and a short walkthrough should unblock the launch.",
+    actionItems: [
+        {
+            text: "Send the revised onboarding checklist.",
+            ownerName: "Alex Founder",
+            dueDate: "2026-08-21",
+        },
+    ],
+    bookmarkPassages: [],
+    conflicts: [],
+    contentMarkdown:
+        "## Onboarding launch risk\nMaya needs onboarding time reduced before the September launch.\n\n## Next step\nAlex will send a revised onboarding checklist by Friday.\n\n## Summary\nThe onboarding checklist and a short walkthrough should unblock the launch.",
+    contentRich: { type: "doc", content: [] },
+});
+
+export const CALL_NOTES_START_COMMAND: Extract<CallNotesCommand, { kind: "start_capture" }> =
+    CallNotesCommandSchema.parse({
+        schemaVersion: CALL_NOTES_SCHEMA_VERSION,
+        requestId: "request-start-1",
+        kind: "start_capture",
+        companyId: CALL_NOTES_FIXTURE_IDS.companyId,
+        actorUserId: CALL_NOTES_FIXTURE_IDS.ownerUserId,
+        provider: "zoom",
+        occurrenceKey: CALL_NOTES_FIXTURE_IDS.occurrenceKey,
+        authorizationRef: CALL_NOTES_FIXTURE_IDS.authorizationRef,
+        title: "Customer onboarding review",
+    }) as Extract<CallNotesCommand, { kind: "start_capture" }>;
+export const CALL_NOTES_DISMISS_COMMAND: Extract<
+    CallNotesCommand,
+    { kind: "dismiss_detected_occurrence" }
+> = CallNotesCommandSchema.parse({
+    schemaVersion: CALL_NOTES_SCHEMA_VERSION,
+    requestId: "request-dismiss-1",
+    kind: "dismiss_detected_occurrence",
+    companyId: CALL_NOTES_FIXTURE_IDS.companyId,
+    actorUserId: CALL_NOTES_FIXTURE_IDS.ownerUserId,
+    provider: "zoom",
+    occurrenceKey: CALL_NOTES_FIXTURE_IDS.occurrenceKey,
+}) as Extract<CallNotesCommand, { kind: "dismiss_detected_occurrence" }>;
+
+export interface KnowledgeNoteProbe {
+    get(companyId: string, callId: string): Promise<KnowledgeNote | null>;
+}
+
+export async function assertCaptureSourceContract(source: CaptureSource): Promise<void> {
+    const events: CaptureEvent[] = [];
+    const sink: CaptureEventSink = {
+        async append(event) {
+            events.push(CaptureEventSchema.parse(event));
+        },
+    };
+    const startInput = StartCaptureInputSchema.parse({
+        schemaVersion: CALL_NOTES_SCHEMA_VERSION,
+        provider: "zoom",
+        occurrenceKey: CALL_NOTES_FIXTURE_IDS.occurrenceKey,
+        attemptKey: CALL_NOTES_FIXTURE_IDS.firstAttemptKey,
+        authorizationRef: CALL_NOTES_FIXTURE_IDS.authorizationRef,
+        captureUser: fixtureParticipant,
+    });
+    const controlInput = CaptureControlInputSchema.parse(startInput);
+    const handle = await source.startAttempt(startInput, sink);
+    await handle.pause(controlInput);
+    await handle.resume(controlInput);
+    await handle.dispose();
+
+    invariant(source.capabilities.attributedTranscript, "source must attribute transcript");
+    invariant(
+        events.some(event => event.kind === "attempt_connected"),
+        "missing connected event"
+    );
+    invariant(
+        events.some(event => event.kind === "attempt_paused"),
+        "missing paused event"
+    );
+    invariant(
+        events.some(event => event.kind === "attempt_resumed"),
+        "missing resumed event"
+    );
+    invariant(
+        events.every(
+            event =>
+                event.occurrenceKey === startInput.occurrenceKey &&
+                event.attemptKey === startInput.attemptKey
+        ),
+        "source changed occurrence or attempt identity"
+    );
+}
+
+export function createScriptedCaptureSource(): CaptureSource {
+    return {
+        capabilities: {
+            attributedTranscript: true,
+            nativePauseResume: true,
+            transportReconnect: true,
+            observesCaptureUserReturn: true,
+        },
+        async startAttempt(input, sink): Promise<CaptureAttemptHandle> {
+            await sink.append(CALL_NOTES_CAPTURE_EVENTS[0]!);
+            return {
+                async pause(control) {
+                    CaptureControlInputSchema.parse(control);
+                    await sink.append(CALL_NOTES_CAPTURE_EVENTS[4]!);
+                },
+                async resume(control) {
+                    CaptureControlInputSchema.parse(control);
+                    await sink.append(CALL_NOTES_CAPTURE_EVENTS[5]!);
+                },
+                async dispose() {
+                    return undefined;
+                },
+            };
+        },
+    };
+}
+
+function userCommand(
+    actorUserId: string,
+    callId: string,
+    command: { kind: CallNotesCommand["kind"] } & Record<string, unknown>
+): CallNotesCommand {
+    return CallNotesCommandSchema.parse({
+        schemaVersion: CALL_NOTES_SCHEMA_VERSION,
+        requestId: `request-${actorUserId}-${command.kind}`,
+        companyId: CALL_NOTES_FIXTURE_IDS.companyId,
+        actorUserId,
+        callId,
+        ...command,
+    });
+}
+
+function ownerCommand(
+    callId: string,
+    command: { kind: CallNotesCommand["kind"] } & Record<string, unknown>
+): CallNotesCommand {
+    return userCommand(CALL_NOTES_FIXTURE_IDS.ownerUserId, callId, command);
+}
+
+/**
+ * Shared end-to-end contract. The subject must use its real state machine,
+ * persistence, authorization, API-facing application boundary, and knowledge sink.
+ * Only Zoom transport and model output may be deterministic fakes.
+ */
+export async function runCallNotesVerticalTracer(
+    application: CallNotesApplication,
+    knowledgeProbe?: KnowledgeNoteProbe
+): Promise<CallSnapshot> {
+    const started = await application.execute(CALL_NOTES_START_COMMAND);
+    invariant(started, "start_capture returned no Call");
+    CallSnapshotSchema.parse(started);
+
+    for (const event of CALL_NOTES_CAPTURE_EVENTS.slice(0, 4)) {
+        await application.ingestCaptureEvent(CALL_NOTES_FIXTURE_IDS.companyId, event);
+    }
+
+    const paused = await application.execute(ownerCommand(started.id, { kind: "pause_capture" }));
+    invariant(paused?.capture.desiredMode === "paused", "Pause did not persist desired mode");
+    await application.ingestCaptureEvent(
+        CALL_NOTES_FIXTURE_IDS.companyId,
+        CALL_NOTES_CAPTURE_EVENTS[4]!
+    );
+
+    const resumed = await application.execute(ownerCommand(started.id, { kind: "resume_capture" }));
+    invariant(resumed?.capture.desiredMode === "running", "Resume did not persist desired mode");
+    await application.ingestCaptureEvent(
+        CALL_NOTES_FIXTURE_IDS.companyId,
+        CALL_NOTES_CAPTURE_EVENTS[5]!
+    );
+
+    for (const index of [7, 8, 9, 10, 6, 6, 11]) {
+        await application.ingestCaptureEvent(
+            CALL_NOTES_FIXTURE_IDS.companyId,
+            CALL_NOTES_CAPTURE_EVENTS[index]!
+        );
+    }
+
+    let current = await application.getCall({
+        companyId: CALL_NOTES_FIXTURE_IDS.companyId,
+        actorUserId: CALL_NOTES_FIXTURE_IDS.ownerUserId,
+        callId: started.id,
+    });
+    invariant(current.status === "completed", "occurrence did not finalize the Call");
+    invariant(current.capture.outcome === "partial", "known gaps must produce a partial outcome");
+    invariant(current.capture.attemptCount === 2, "same-user return must create a second attempt");
+    invariant(current.transcript.length === 3, "transcript replay lost or duplicated segments");
+    invariant(
+        current.transcript.map(segment => segment.text).join("|") ===
+            [
+                "We need to reduce onboarding time before the September launch.",
+                "I will send the revised onboarding checklist by Friday.",
+                "That checklist and a short walkthrough should unblock our team.",
+            ].join("|"),
+        "late Transcript packets were not restored to deterministic provider-time order"
+    );
+    invariant(current.gaps.length >= 2, "pause and capture-user absence must remain visible gaps");
+    invariant(current.note, "owner cannot see the Call Note");
+    await invariantRejects(
+        application.execute(
+            userCommand(CALL_NOTES_FIXTURE_IDS.otherUserId, started.id, {
+                kind: "add_bookmark",
+                segmentId: current.transcript[0]!.id,
+                comment: null,
+            })
+        ),
+        "non-owner created a Bookmark"
+    );
+    await invariantRejects(
+        application.getCall({
+            companyId: "2",
+            actorUserId: CALL_NOTES_FIXTURE_IDS.ownerUserId,
+            callId: started.id,
+        }),
+        "wrong-company Call lookup did not resolve as not found"
+    );
+
+    await application.execute(
+        ownerCommand(started.id, {
+            kind: "update_note",
+            baseRevision: current.note.revision,
+            title: current.note.title,
+            contentMarkdown: "Pricing concerns and launch sequencing.",
+            contentRich: { type: "doc", content: [] },
+        })
+    );
+    await application.execute(
+        ownerCommand(started.id, {
+            kind: "add_bookmark",
+            segmentId: current.transcript[0]!.id,
+            comment: "Use this evidence in the follow-up.",
+        })
+    );
+    await application.execute(
+        ownerCommand(started.id, {
+            kind: "set_note_visibility",
+            visibility: "private",
+        })
+    );
+
+    const teammateView = await application.getCall({
+        companyId: CALL_NOTES_FIXTURE_IDS.companyId,
+        actorUserId: CALL_NOTES_FIXTURE_IDS.otherUserId,
+        callId: started.id,
+    });
+    invariant(teammateView.transcript.length === 3, "company transcript must remain visible");
+    invariant(teammateView.note === null, "private Call Note leaked to another company user");
+    await invariantRejects(
+        application.execute(
+            ownerCommand(started.id, {
+                kind: "set_knowledge_inclusion",
+                included: true,
+            })
+        ),
+        "private Call Note entered company knowledge"
+    );
+
+    await application.execute(
+        ownerCommand(started.id, {
+            kind: "set_note_visibility",
+            visibility: "company",
+        })
+    );
+    current = (await application.execute(
+        ownerCommand(started.id, {
+            kind: "request_enrichment",
+        })
+    ))!;
+    invariant(current.enrichment, "request_enrichment did not create a run");
+
+    await application.completeEnrichment(
+        CompleteEnrichmentInputSchema.parse({
+            companyId: CALL_NOTES_FIXTURE_IDS.companyId,
+            callId: started.id,
+            enrichmentRunId: current.enrichment.id,
+            result: {
+                proposal: CALL_NOTES_ENRICHMENT_PROPOSAL,
+                modelMetadata: {
+                    provider: "fixture",
+                    model: "deterministic-enrichment",
+                    promptVersion: "call-notes/v1",
+                    completionId: "fixture-completion-1",
+                },
+            },
+        })
+    );
+    current = await application.getCall({
+        companyId: CALL_NOTES_FIXTURE_IDS.companyId,
+        actorUserId: CALL_NOTES_FIXTURE_IDS.ownerUserId,
+        callId: started.id,
+    });
+    invariant(current.enrichment?.status === "ready", "enrichment proposal was not reviewable");
+
+    await application.execute(
+        ownerCommand(started.id, {
+            kind: "accept_enrichment",
+            enrichmentRunId: current.enrichment.id,
+            contentMarkdown: CALL_NOTES_ENRICHMENT_PROPOSAL.contentMarkdown,
+            contentRich: CALL_NOTES_ENRICHMENT_PROPOSAL.contentRich,
+        })
+    );
+    await application.execute(
+        ownerCommand(started.id, {
+            kind: "set_knowledge_inclusion",
+            included: true,
+        })
+    );
+
+    const searchResults = await application.searchTranscript({
+        companyId: CALL_NOTES_FIXTURE_IDS.companyId,
+        actorUserId: CALL_NOTES_FIXTURE_IDS.ownerUserId,
+        callId: started.id,
+        query: "checklist",
+    });
+    invariant(searchResults.length === 2, "transcript search did not filter matching segments");
+
+    const finalSnapshot = CallSnapshotSchema.parse(
+        await application.getCall({
+            companyId: CALL_NOTES_FIXTURE_IDS.companyId,
+            actorUserId: CALL_NOTES_FIXTURE_IDS.ownerUserId,
+            callId: started.id,
+        })
+    );
+    invariant(
+        finalSnapshot.note?.knowledgeIncluded,
+        "accepted Call Note was not included in knowledge"
+    );
+    invariant(
+        finalSnapshot.enrichment?.status === "accepted",
+        "accepted proposal was not immutable history"
+    );
+    invariant(finalSnapshot.bookmarks.length === 1, "bookmark was not persisted");
+
+    if (knowledgeProbe) {
+        const indexed = await knowledgeProbe.get(CALL_NOTES_FIXTURE_IDS.companyId, started.id);
+        invariant(indexed, "knowledge sink did not receive the canonical Call Note");
+        invariant(
+            indexed.revision === finalSnapshot.note.revision,
+            "knowledge sink indexed a stale Call Note revision"
+        );
+    }
+
+    return finalSnapshot;
+}

--- a/packages/features/src/index.ts
+++ b/packages/features/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./founder-weekly-review";
+export * from "./call-notes";

--- a/packages/features/src/schema.ts
+++ b/packages/features/src/schema.ts
@@ -16,3 +16,4 @@ export * from "./company-metadata/schema";
 export * from "./marketing-pipeline/schema";
 export * from "./founder-weekly-review/schema";
 export * from "./email-pipeline/schema";
+export * from "./call-notes/schema";


### PR DESCRIPTION
Summary

Implements the Call Notes enrichment and knowledge-integration lane.

AI enrichment
Adds deterministic/versioned enrichment prompting.
Adds structured proposal generation and semantic transcript/Bookmark provenance validation.
Adds generic optional/defaulted Zod structured-output compatibility.
Validated through a real Kimi K2.6 smoke using the existing OpenAI-compatible model path.
Knowledge integration
Adds KnowledgeNoteSink over the existing LaunchStack Notes/embedding path.
Adds current-revision and knowledge-eligibility validation.
Adds race-safe embedding replacement for delayed/stale jobs.
Filters private/knowledge-disabled Call Notes from company retrieval.
Supports Notes-only company retrieval and preserves Call Note RAG metadata.
Validation
8 Call Notes suites / 73 tests passing.
34 structured-output regression tests passing.
Web and adapters typechecks passing.
Integration boundary

This PR intentionally does not implement the Call Notes application lifecycle. The application layer remains responsible for:

constructing production EnrichmentInput;
enrichment-run persistence and failure handling;
proposal review / Accept / Reject;
base-revision conflict handling;
canonical Call Note revision creation;
invoking KnowledgeNoteSink after canonical lifecycle changes.

See docs/CALL-NOTES-005-HANDOFF.md for the full architecture and handoff.