### PR TITLE
Make the mindmap fill the viewport, and give it a theme that works

### DIFF
--- a/apps/web/src/app/dev/mindmap/MindmapPreview.tsx
+++ b/apps/web/src/app/dev/mindmap/MindmapPreview.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+
+import { DriftShell } from "~/app/employer/_chrome/DriftShell";
+import { ToolsStudioShell } from "~/app/employer/_chrome/ToolsStudioShell";
+import { buildTemplate } from "~/app/employer/mindmap/_mindmap/model/templates";
+import { MindmapEditor } from "~/app/employer/mindmap/_mindmap/ui/MindmapEditor";
+import { MindmapGallery } from "~/app/employer/mindmap/_mindmap/ui/MindmapGallery";
+
+/**
+ * Local harness for the mindmap editor. It reproduces the real chrome chain —
+ * employer layout → DriftShell → ToolsStudioShell → editor — so layout work
+ * here is layout work there, but skips Clerk so the canvas can be driven
+ * without a session. Gated to non-production by the server page.
+ *
+ * `?template=flowchart` picks a starter document; the default is the mindmap.
+ * The full list is in `_mindmap/model/template-meta.ts`. `?view=gallery` shows
+ * the index page instead of the editor — it shares the same shell, so it shares
+ * the same layout bugs.
+ */
+
+/**
+ * `/api/mindmaps/*` is session-guarded, so autosave and the presence heartbeat
+ * would 401 on a loop here. Answering them locally keeps the console readable
+ * and lets both code paths run. Installed at module scope: an effect would let
+ * the first heartbeat through before it took hold.
+ */
+let stubbed = false;
+function stubMindmapApi() {
+    if (stubbed || typeof window === "undefined") return;
+    stubbed = true;
+
+    const real = window.fetch.bind(window);
+    let revision = 1;
+
+    window.fetch = async (input, init) => {
+        const url =
+            typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+        if (!url.includes("/api/mindmaps")) return real(input, init);
+
+        const json = (body: unknown) =>
+            new Response(JSON.stringify(body), {
+                status: 200,
+                headers: { "Content-Type": "application/json" },
+            });
+
+        if (url.includes("/presence")) return json({ peers: [], revision });
+        if (url.includes("/versions")) return json({ versions: [] });
+        if (/\/api\/mindmaps(\?|$)/.test(url)) return json({ mindmaps: [], folders: [] });
+        if (init?.method && init.method !== "GET") {
+            revision += 1;
+            return json({ mindmap: { revision }, revision });
+        }
+        return json({ mindmap: { revision } });
+    };
+}
+
+stubMindmapApi();
+
+export function MindmapPreview() {
+    // Client-only. Node and edge ids are generated per build, so a server pass
+    // and a client pass produce different documents and every shape hydrates
+    // mismatched — noise that would bury any real warning.
+    const [query, setQuery] = useState<URLSearchParams | null>(null);
+
+    useEffect(() => {
+        setQuery(new URLSearchParams(window.location.search));
+    }, []);
+
+    const gallery = query?.get("view") === "gallery";
+    const template = query && !gallery ? (query.get("template") ?? "mindmap") : null;
+
+    const doc = useMemo(
+        () => (template ? buildTemplate(template, "Preview mindmap") : null),
+        [template]
+    );
+
+    return (
+        <div style={{ minHeight: "100vh", width: "100%" }}>
+            <DriftShell>
+                <ToolsStudioShell>
+                    {gallery && <MindmapGallery />}
+                    {doc && (
+                        <MindmapEditor
+                            key={template}
+                            mindmapId={1}
+                            initialDoc={doc}
+                            initialTitle={doc.title}
+                            initialRevision={1}
+                            folder="Preview"
+                            publishedDocumentId={null}
+                            author="Preview user"
+                        />
+                    )}
+                </ToolsStudioShell>
+            </DriftShell>
+        </div>
+    );
+}

--- a/apps/web/src/app/dev/mindmap/page.tsx
+++ b/apps/web/src/app/dev/mindmap/page.tsx
@@ -1,0 +1,8 @@
+import { notFound } from "next/navigation";
+
+import { MindmapPreview } from "./MindmapPreview";
+
+export default function MindmapPreviewPage() {
+    if (process.env.NODE_ENV === "production") notFound();
+    return <MindmapPreview />;
+}

--- a/apps/web/src/app/employer/_chrome/DriftShell.module.css
+++ b/apps/web/src/app/employer/_chrome/DriftShell.module.css
@@ -29,6 +29,29 @@
 /* When immersive children fill the viewport (e.g. the documents WorkspaceShell),
    they can apply `data-drift-immersive="true"` to opt out of body padding. */
 .body > [data-drift-immersive="true"] {
-    flex: 1;
+    /* `flex: 1` is `flex-basis: 0%`, and a percentage basis is indefinite
+       whenever the column above is content-sized — which silently throws away
+       the child's own `height`. `auto` keeps it, so the immersive shell's
+       declared viewport height survives and its descendants' `height: 100%`
+       has something real to resolve against. */
+    flex: 1 1 auto;
+    min-height: 0;
+}
+
+/* An immersive child owns the viewport and scrolls internally, so the chain
+   above it has to be a *definite* height rather than a floor. With
+   `min-height` alone every box from <body> down is content-sized: a child
+   asking for `height: 100%` gets its own content back, and anything
+   intrinsically sized — the mindmap's `<svg width="100%" height="100%"
+   viewBox=…>` — has no ceiling to stop against and inflates the page to
+   hundreds of thousands of pixels. */
+.app:has(> .main > .body > [data-drift-immersive="true"]) {
+    height: 100dvh;
+    min-height: 0;
+    overflow: hidden;
+}
+
+.app:has(> .main > .body > [data-drift-immersive="true"]) .main {
+    height: 100%;
     min-height: 0;
 }

--- a/apps/web/src/app/employer/_chrome/ToolsStudioShell.tsx
+++ b/apps/web/src/app/employer/_chrome/ToolsStudioShell.tsx
@@ -4,6 +4,10 @@ import type { ReactNode } from "react";
 
 /**
  * Full-height wrapper for standalone tool routes. Navigation lives inside Studio controls.
+ *
+ * `dvh` rather than `vh`: on mobile browsers `100vh` is the viewport with the
+ * URL bar retracted, so a tool that fills it puts its own bottom chrome — the
+ * mindmap's zoom bar, for one — underneath the browser's.
  */
 export function ToolsStudioShell({ children }: { children: ReactNode }) {
     return (
@@ -11,7 +15,7 @@ export function ToolsStudioShell({ children }: { children: ReactNode }) {
             data-drift-immersive="true"
             style={{
                 display: "flex",
-                height: "100vh",
+                height: "100dvh",
                 width: "100%",
                 overflow: "hidden",
                 position: "relative",

--- a/apps/web/src/app/employer/documents/_workspace/WorkspaceShell.tsx
+++ b/apps/web/src/app/employer/documents/_workspace/WorkspaceShell.tsx
@@ -486,7 +486,10 @@ export function WorkspaceShell() {
             data-drift-immersive="true"
             style={{
                 display: "flex",
-                height: "100vh",
+                // `dvh`, not `vh`: on mobile `100vh` is the viewport with the
+                // URL bar retracted, so the workspace's own bottom chrome ends
+                // up underneath the browser's.
+                height: "100dvh",
                 width: "100%",
                 overflow: "hidden",
                 position: "relative",

--- a/apps/web/src/app/employer/mindmap/README.md
+++ b/apps/web/src/app/employer/mindmap/README.md
@@ -50,7 +50,26 @@ resize keeps the opposite corner pinned) rather than screenshots.
 | `serialize.ts` | The trust boundary. `parseDoc` never throws. Markdown/Mermaid/CSV import and export.                                 |
 | `templates.ts` | Starter documents, built from the same factories.                                                                    |
 
-### Two hierarchies
+### Nodes vs. annotations
+
+The palette's first two groups carry the distinction that matters to someone
+looking at a blank canvas — not which diagram type a shape came from, but
+whether it is **a thing you type in and connect** (`Nodes`) or **a mark you
+leave on the canvas** (`Annotate`). A sticky note is a node; a caption is not.
+Everything after them is a shape library, browsed by name.
+
+Three details keep that promise honest:
+
+- Tiles are captioned and previewed with the colours `createNode` will actually
+  give them, so `Topic` cannot be mistaken for the `Rounded rectangle` it shares
+  an outline with.
+- Placing any shape whose registry entry does not say `holdsText: false` drops
+  straight into its label. A box you have to discover is double-clickable does
+  not read as a container you put words in.
+- `Topic` is on the tool rail beside `Connector`, because those two are the
+  whole of "draw me a diagram".
+
+## Two hierarchies
 
 A page has both, and confusing them causes bugs:
 
@@ -69,6 +88,61 @@ Shape fills and strokes are literal OKLCH values stored in the document, not
 `var(--…)` references. A design token would repaint when the _viewer_ switches
 theme, silently changing someone else's diagram. Editor chrome — panels,
 toolbars, handles — uses the tokens as normal.
+
+### Light and dark boards
+
+A board's paper is part of the document, so "dark mode" here is a **document
+theme**, not a viewer preference: ten of them in `model/palette.ts`, five light
+and five dark, paired so each is the same identity under different lighting
+(Launchstack ↔ Midnight, Ocean ↔ Abyss, …). Picking Midnight makes the board
+dark for everyone who opens the file. A new document is seeded in whichever
+theme matches the app theme of the person creating it — a choice made once and
+stored, rather than a per-viewer repaint, which is how a dark-mode user stops
+being handed a white page without breaking sharing.
+
+Every swatch therefore has two tones (`SWATCHES` / `DARK_SWATCHES`, read
+through `swatchFor(id, mode)`), and every node-creating path passes the
+document's mode so a box dropped on a dark board is not born white. `docMode()`
+in `commands.ts` is the single place that answers "which paper is this?".
+
+### Chrome on the paper follows the paper
+
+The corollary is easy to miss and was wrong for a long time: because the paper
+does not follow the viewer's theme, **nothing drawn on the paper may follow it
+either**. In dark theme `--ink-2` rises to 0.80 lightness and vanishes against
+a white board; `--panel` goes near-black and turns selection handles and
+arrowhead cutouts into blobs.
+
+So the canvas `<svg>` carries `.paper` (`ui/Canvas.module.css`) plus a
+`data-paper` attribute derived from `isDarkSurface(page.background.color)` —
+the colour itself, not the theme id, so a custom background works too. That
+rebinds the semantic names to one of two `--paper-*` sets defined in
+`packages/design-tokens/tokens.css`, both in `:root` and neither overridden by
+the app's dark block. Canvas chrome goes on writing `var(--accent)` like the
+rest of the app and comes out right on any board.
+
+Export resolves `var(--…)` through `getComputedStyle` on the live `<svg>`, so
+it picks the same set up for free.
+
+Two things sit _outside_ that scope on purpose — the rulers and the
+text-editing field are siblings of the `<svg>`, not children — so anything of
+theirs that lands on the paper says so itself. The editing field does: it
+paints with the node's own fill and ink, which is also what stops it being
+dark-on-black.
+
+### Contrast is a tested property, not a matter of taste
+
+`__tests__/theme.test.ts` asserts it over the whole palette rather than
+spot-checking: every swatch's ink clears 4.5:1 on its own fill, every theme's
+cycled stroke clears 3:1 on its own paper, and every label in a repainted
+document is readable in all ten themes. Two colours were moved to satisfy it
+(green's and amber's light strokes), and `readableInkOn()` picks a root topic's
+label colour by measurement instead of by mode — near-white loses on a bright
+violet root and wins on a mid violet one, and no fixed choice gets both.
+
+The same contract governs the app's own ink ladder in `tokens.css`: `--ink-3`
+is the smallest tier used for prose and must clear 4.5:1 on every surface in
+its block; `--ink-4` is de-emphasised UI and must clear 3:1.
 
 ## Saving
 
@@ -97,6 +171,20 @@ it `data-export="omit"`, and `var(--…)` colours are resolved to literals so th
 file opens anywhere. Images are stored as data URIs for the same reason: an SVG
 loaded through `<img>` cannot fetch external resources, so a linked image would
 vanish from every exported PNG.
+
+## Working on the UI
+
+`/dev/mindmap` mounts the editor inside the real chrome chain — employer layout
+→ `DriftShell` → `ToolsStudioShell` → editor — with a template document and
+`/api/mindmaps/*` answered locally, so the canvas can be driven without a Clerk
+session or a row in the database. `?template=flowchart` picks a starter (ids in
+`model/template-meta.ts`); `?view=gallery` shows the index page, which shares
+the same shell and therefore the same layout bugs. The route 404s in
+production.
+
+Because it reproduces the chain rather than approximating it, layout that works
+there works in the app: the shell is what has to hand the editor a *definite*
+height, and getting that wrong is not visible from the editor alone.
 
 ## Tests
 

--- a/apps/web/src/app/employer/mindmap/[id]/page.tsx
+++ b/apps/web/src/app/employer/mindmap/[id]/page.tsx
@@ -9,6 +9,7 @@ import { Button } from "~/components/ui/button";
 
 import { useSetBreadcrumbs } from "../../_chrome/BreadcrumbContext";
 import { getMindmap, type MindmapDetail } from "../_mindmap/lib/api";
+import type { ThemeMode } from "../_mindmap/model/palette";
 import { parseDoc } from "../_mindmap/model/serialize";
 import { buildTemplate, TEMPLATE_BY_ID } from "../_mindmap/model/templates";
 import type { MindmapDoc } from "../_mindmap/model/types";
@@ -33,8 +34,13 @@ function seedDocument(mindmap: MindmapDetail): { doc: MindmapDoc; seeded: boolea
     const empty = doc.pages.every(page => page.nodes.length === 0);
     const template = mindmap.templateId ? TEMPLATE_BY_ID[mindmap.templateId] : undefined;
     if (!empty || !template || template.id === "blank") return { doc, seeded: false };
+    // Seed the board lit the way this person is working. It is stored, not
+    // re-derived per viewer, so the document stays stable once shared — and it
+    // is far better than handing someone in dark mode a white page.
+    const mode: ThemeMode =
+        document.documentElement.getAttribute("data-theme") === "dark" ? "dark" : "light";
     return {
-        doc: { ...buildTemplate(template.id, mindmap.title), title: mindmap.title },
+        doc: { ...buildTemplate(template.id, mindmap.title, mode), title: mindmap.title },
         seeded: true,
     };
 }

--- a/apps/web/src/app/employer/mindmap/_mindmap/__tests__/canvas.render.test.tsx
+++ b/apps/web/src/app/employer/mindmap/_mindmap/__tests__/canvas.render.test.tsx
@@ -371,6 +371,113 @@ describe("dragging", () => {
     });
 });
 
+describe("double-click", () => {
+    /**
+     * The browser fires `dblclick` on the nearest common inclusive ancestor of
+     * the two clicks' targets. Selecting a shape on the first click re-renders
+     * the canvas and swaps the element under the cursor, so the two targets
+     * differ and the reported target is the `<svg>` — which is why this used to
+     * conclude "empty canvas" and drop a new topic on the shape being renamed.
+     */
+    function doubleClickReportedOnSvg(
+        container: HTMLElement,
+        grabbed: Element,
+        at: [number, number]
+    ) {
+        const svg = svgOf(container);
+        pressOn(grabbed, at);
+        act(() => {
+            svg.dispatchEvent(pointer("pointerup", at[0], at[1], { buttons: 0 }));
+        });
+        act(() => {
+            svg.dispatchEvent(
+                new MouseEvent("dblclick", {
+                    bubbles: true,
+                    cancelable: true,
+                    clientX: at[0],
+                    clientY: at[1],
+                })
+            );
+        });
+    }
+
+    it("edits the shape under the pointer, and adds nothing", () => {
+        const { view, doc, callbacks, store } = mount();
+        const node = doc.pages[0]!.nodes[0]!;
+        const before = store.getState().doc.pages[0]!.nodes.length;
+
+        doubleClickReportedOnSvg(view.container, nodeElement(view.container, node.id), [200, 140]);
+
+        expect(callbacks.onEditText).toHaveBeenCalledWith({ kind: "node", id: node.id });
+        expect(store.getState().doc.pages[0]!.nodes).toHaveLength(before);
+    });
+
+    it("edits a connector's label rather than dropping a topic on it", () => {
+        const { view, doc, callbacks, store } = mount();
+        const edge = doc.pages[0]!.edges[0]!;
+        const edgeEl = view.container.querySelector(`[data-edge-id="${edge.id}"]`)!;
+        const before = store.getState().doc.pages[0]!.nodes.length;
+
+        doubleClickReportedOnSvg(view.container, edgeEl, [330, 150]);
+
+        expect(callbacks.onEditText).toHaveBeenCalledWith({
+            kind: "edge-label",
+            id: edge.id,
+            index: 0,
+        });
+        expect(store.getState().doc.pages[0]!.nodes).toHaveLength(before);
+    });
+
+    it("still drops a topic when the canvas really is empty there", () => {
+        const { view, callbacks, store } = mount();
+        const svg = svgOf(view.container);
+        const before = store.getState().doc.pages[0]!.nodes.length;
+
+        doubleClickReportedOnSvg(view.container, svg, [820, 620]);
+
+        const after = store.getState().doc.pages[0]!.nodes;
+        expect(after).toHaveLength(before + 1);
+        expect(callbacks.onEditText).toHaveBeenCalledWith({ kind: "node", id: after.at(-1)!.id });
+    });
+});
+
+describe("placing a shape", () => {
+    /** Arm a shape tool, then click the canvas once — no drag. */
+    function placeAt(shape: string, at: [number, number]) {
+        const mounted = mount();
+        mounted.store.setTool("shape", shape as never);
+        const svg = svgOf(mounted.view.container);
+        pressOn(svg, at);
+        act(() => {
+            svg.dispatchEvent(pointer("pointerup", at[0], at[1], { buttons: 0 }));
+        });
+        return mounted;
+    }
+
+    it("opens the label editor for a shape that holds text", () => {
+        // `setTool("select")` clears `editing`, so the order of those two calls
+        // is load-bearing: get it wrong and the caret never appears, which is
+        // what made a freshly placed box feel like a dead rectangle.
+        const { callbacks, store } = placeAt("mind-branch", [500, 400]);
+        const added = store.getState().doc.pages[0]!.nodes.at(-1)!;
+        expect(added.shape).toBe("mind-branch");
+        // The shell wires `onEditText` to `store.setEditing`; asserting the
+        // call is what pins the ordering without restating that wiring here.
+        expect(callbacks.onEditText).toHaveBeenCalledWith({ kind: "node", id: added.id });
+    });
+
+    it("leaves the tool disarmed afterwards", () => {
+        const { store } = placeAt("mind-branch", [500, 400]);
+        expect(store.getState().tool).toBe("select");
+    });
+
+    it("does not open a label editor for a shape with nothing to say", () => {
+        const { callbacks, store } = placeAt("image", [500, 400]);
+        expect(store.getState().doc.pages[0]!.nodes.at(-1)!.shape).toBe("image");
+        expect(callbacks.onEditText).not.toHaveBeenCalled();
+    });
+});
+
 describe("inspector", () => {
     it("shows page settings when nothing is selected", () => {
         mount();

--- a/apps/web/src/app/employer/mindmap/_mindmap/__tests__/theme.test.ts
+++ b/apps/web/src/app/employer/mindmap/_mindmap/__tests__/theme.test.ts
@@ -1,0 +1,226 @@
+import { createDoc, createEdge, createNode, createPage } from "../model/factory";
+import {
+    contrastRatio,
+    DARK_SWATCHES,
+    isDarkSurface,
+    readableInkOn,
+    relativeLuminance,
+    stickyColors,
+    swatchFor,
+    SWATCHES,
+    THEMES,
+    themeMode,
+} from "../model/palette";
+import { applyThemeToDoc } from "../model/theme";
+import type { MindmapDoc } from "../model/types";
+
+/**
+ * The theme system's contract.
+ *
+ * These are the assertions that stop a board from becoming unreadable again.
+ * The contrast ones are properties over the whole palette rather than spot
+ * checks, so adding a swatch or a theme cannot quietly ship something nobody
+ * can read — which is exactly how the dark boards went wrong the first time.
+ */
+
+/** WCAG AA: 4.5:1 for body text, 3:1 for large or bold display text. */
+const AA_BODY = 4.5;
+const AA_LARGE = 3;
+
+describe("relativeLuminance", () => {
+    it("agrees with the WCAG anchors", () => {
+        expect(relativeLuminance("oklch(1 0 0)")).toBeCloseTo(1, 2);
+        expect(relativeLuminance("oklch(0 0 0)")).toBeCloseTo(0, 2);
+        expect(relativeLuminance("#ffffff")).toBeCloseTo(1, 3);
+        expect(relativeLuminance("#000000")).toBeCloseTo(0, 3);
+    });
+
+    it("puts white against black at the full 21:1", () => {
+        expect(contrastRatio("#ffffff", "#000000")).toBeCloseTo(21, 1);
+    });
+
+    it("returns null rather than guessing at a notation it cannot read", () => {
+        expect(relativeLuminance("rebeccapurple")).toBeNull();
+        expect(relativeLuminance("")).toBeNull();
+    });
+});
+
+describe("isDarkSurface", () => {
+    it("reads the lightness out of an oklch paper", () => {
+        expect(isDarkSurface("oklch(0.19 0.018 285)")).toBe(true);
+        expect(isDarkSurface("oklch(0.992 0.003 80)")).toBe(false);
+    });
+
+    it("handles hex, which is the other notation a document can hold", () => {
+        expect(isDarkSurface("#111111")).toBe(true);
+        expect(isDarkSurface("#ffffff")).toBe(false);
+    });
+
+    it("treats an unreadable value as light, the safe guess for a canvas", () => {
+        expect(isDarkSurface("papayawhip")).toBe(false);
+    });
+});
+
+describe("swatch contrast", () => {
+    it.each([
+        ["light", SWATCHES],
+        ["dark", DARK_SWATCHES],
+    ] as const)("%s swatches keep their ink readable on their own fill", (_mode, set) => {
+        for (const sw of set) {
+            expect({ id: sw.id, ratio: +contrastRatio(sw.ink, sw.fill).toFixed(2) }).toEqual({
+                id: sw.id,
+                ratio: expect.any(Number),
+            });
+            expect(contrastRatio(sw.ink, sw.fill)).toBeGreaterThanOrEqual(AA_BODY);
+        }
+    });
+
+    it("picks whichever ink actually wins on a saturated fill", () => {
+        // The root topic's fill is the swatch's stroke. On a dark board that is
+        // a bright tone where near-white loses and near-black wins; on a light
+        // board it is a mid tone where the opposite holds.
+        for (const mode of ["light", "dark"] as const) {
+            for (const sw of mode === "dark" ? DARK_SWATCHES : SWATCHES) {
+                expect(contrastRatio(readableInkOn(sw.stroke), sw.stroke)).toBeGreaterThanOrEqual(
+                    AA_LARGE
+                );
+            }
+        }
+    });
+});
+
+describe("document themes", () => {
+    it("offers a light and a dark board", () => {
+        expect(THEMES.some(t => t.mode === "light")).toBe(true);
+        expect(THEMES.some(t => t.mode === "dark")).toBe(true);
+    });
+
+    it("names a paper whose lightness matches the mode it claims", () => {
+        for (const theme of THEMES) {
+            expect({ id: theme.id, dark: isDarkSurface(theme.background) }).toEqual({
+                id: theme.id,
+                dark: theme.mode === "dark",
+            });
+        }
+    });
+
+    it("keeps the theme's own ink readable on its paper", () => {
+        for (const theme of THEMES) {
+            expect(contrastRatio(theme.ink, theme.background)).toBeGreaterThanOrEqual(AA_BODY);
+        }
+    });
+
+    it("keeps every cycled node colour readable on the theme's paper", () => {
+        for (const theme of THEMES) {
+            for (const id of theme.cycle) {
+                const sw = swatchFor(id, theme.mode);
+                // A node has to be distinguishable from the paper it sits on,
+                // or the board is a field of invisible boxes.
+                expect(contrastRatio(sw.stroke, theme.background)).toBeGreaterThanOrEqual(AA_LARGE);
+            }
+        }
+    });
+
+    it("keeps sticky ink readable on every sticky colour", () => {
+        for (const mode of ["light", "dark"] as const) {
+            for (const color of stickyColors(mode)) {
+                const ink = readableInkOn(color);
+                expect(contrastRatio(ink, color)).toBeGreaterThanOrEqual(AA_BODY);
+            }
+        }
+    });
+
+    it("resolves an unknown palette id to light rather than throwing", () => {
+        expect(themeMode("no-such-theme")).toBe("light");
+        expect(themeMode(null)).toBe("light");
+    });
+});
+
+// ---------------------------------------------------------------------------
+// applyThemeToDoc
+// ---------------------------------------------------------------------------
+
+function sampleDoc(): MindmapDoc {
+    const root = createNode({ shape: "mind-root", x: 0, y: 0, text: "Root" });
+    const branch = createNode({ shape: "mind-branch", x: 300, y: 0, text: "Branch" });
+    const detail = createNode({ shape: "mind-branch", x: 600, y: 0, text: "Detail" });
+    const caption = createNode({ shape: "text", x: 0, y: 300, text: "A caption" });
+    const sticky = createNode({ shape: "sticky", x: 300, y: 300, text: "A note" });
+
+    return createDoc("Test", [
+        {
+            ...createPage(),
+            nodes: [root, branch, detail, caption, sticky],
+            edges: [
+                createEdge({
+                    from: { nodeId: root.id, port: "auto" },
+                    to: { nodeId: branch.id, port: "auto" },
+                }),
+                createEdge({
+                    from: { nodeId: branch.id, port: "auto" },
+                    to: { nodeId: detail.id, port: "auto" },
+                }),
+            ],
+        },
+    ]);
+}
+
+describe("applyThemeToDoc", () => {
+    it.each(THEMES.map(t => [t.id, t.name] as const))(
+        "leaves every label readable after switching to %s",
+        themeId => {
+            const doc = applyThemeToDoc(sampleDoc(), themeId);
+            const page = doc.pages[0]!;
+            for (const nd of page.nodes) {
+                // An unfilled shape is read against the paper it sits on.
+                const behind = nd.style.fill === "none" ? page.background.color : nd.style.fill;
+                expect({
+                    shape: nd.shape,
+                    readable: contrastRatio(nd.textStyle.color, behind) >= AA_LARGE,
+                }).toEqual({ shape: nd.shape, readable: true });
+            }
+        }
+    );
+
+    it("recolours the ink of unfilled shapes, not just the ones with a surface", () => {
+        // The bug this pins: a caption keeps `fill: none`, so it used to be
+        // skipped entirely and kept near-black ink on a near-black board.
+        const doc = applyThemeToDoc(sampleDoc(), "midnight");
+        const caption = doc.pages[0]!.nodes.find(n => n.shape === "text")!;
+        expect(caption.style.fill).toBe("none");
+        expect(
+            contrastRatio(caption.textStyle.color, doc.pages[0]!.background.color)
+        ).toBeGreaterThan(AA_BODY);
+    });
+
+    it("colours a mindmap by depth so a branch and its details agree", () => {
+        const doc = applyThemeToDoc(sampleDoc(), "default");
+        const page = doc.pages[0]!;
+        const byText = (t: string) => page.nodes.find(n => n.text === t)!;
+        // Root, branch and detail are three different depths and so three
+        // different colours; cycling by array order instead produced confetti.
+        const fills = [byText("Root"), byText("Branch"), byText("Detail")].map(n => n.style.fill);
+        expect(new Set(fills).size).toBe(3);
+    });
+
+    it("repaints every page, not only the active one", () => {
+        const base = sampleDoc();
+        const second = {
+            ...createPage("Page 2"),
+            nodes: [createNode({ shape: "mind-branch", x: 0, y: 0 })],
+        };
+        const doc = applyThemeToDoc({ ...base, pages: [...base.pages, second] }, "ember");
+        for (const page of doc.pages) {
+            expect(page.background.color).toBe(THEMES.find(t => t.id === "ember")!.background);
+        }
+    });
+
+    it("records the theme it applied", () => {
+        expect(applyThemeToDoc(sampleDoc(), "abyss").settings.paletteId).toBe("abyss");
+    });
+
+    it("leaves the document alone for an unknown theme", () => {
+        const doc = sampleDoc();
+        expect(applyThemeToDoc(doc, "chartreuse")).toBe(doc);
+    });
+});

--- a/apps/web/src/app/employer/mindmap/_mindmap/__tests__/viewport.test.ts
+++ b/apps/web/src/app/employer/mindmap/_mindmap/__tests__/viewport.test.ts
@@ -1,0 +1,89 @@
+import { setZoom, zoomByStep } from "../model/commands";
+import { createDoc, createNode, createPage } from "../model/factory";
+import { MAX_ZOOM, MIN_ZOOM } from "../model/geometry";
+import { EditorStore } from "../model/store";
+
+/**
+ * Zoom anchoring.
+ *
+ * `setViewport({ zoom })` scales about the *world origin*, so a board zoomed
+ * that way slides off the screen and at 400% the diagram is somewhere past the
+ * corner. Every zoom that is not aimed at the pointer has to be aimed at the
+ * middle of the canvas instead, and these tests are what keep it that way.
+ */
+
+const SIZE = { w: 1000, h: 700 };
+
+function store(): EditorStore {
+    const s = new EditorStore(
+        createDoc("Test", [
+            {
+                ...createPage(),
+                nodes: [createNode({ shape: "rectangle", x: 400, y: 300, w: 200, h: 100 })],
+                edges: [],
+            },
+        ])
+    );
+    s.setViewport({ x: 0, y: 0, zoom: 1 });
+    return s;
+}
+
+/** The world point currently under the middle of the canvas. */
+function centre(s: EditorStore): { x: number; y: number } {
+    const v = s.getState().viewport;
+    return { x: v.x + SIZE.w / 2 / v.zoom, y: v.y + SIZE.h / 2 / v.zoom };
+}
+
+describe("zoomByStep", () => {
+    it("holds the centre of the canvas while zooming in", () => {
+        const s = store();
+        const before = centre(s);
+        zoomByStep(s, 1, SIZE);
+        expect(s.getState().viewport.zoom).toBeGreaterThan(1);
+        const after = centre(s);
+        expect(after.x).toBeCloseTo(before.x, 6);
+        expect(after.y).toBeCloseTo(before.y, 6);
+    });
+
+    it("holds the centre while zooming out", () => {
+        const s = store();
+        const before = centre(s);
+        zoomByStep(s, -1, SIZE);
+        expect(s.getState().viewport.zoom).toBeLessThan(1);
+        const after = centre(s);
+        expect(after.x).toBeCloseTo(before.x, 6);
+        expect(after.y).toBeCloseTo(before.y, 6);
+    });
+
+    it("comes back to where it started after a round trip", () => {
+        const s = store();
+        const before = { ...s.getState().viewport };
+        for (let i = 0; i < 4; i++) zoomByStep(s, 1, SIZE);
+        for (let i = 0; i < 4; i++) zoomByStep(s, -1, SIZE);
+        const after = s.getState().viewport;
+        expect(after.zoom).toBeCloseTo(before.zoom, 6);
+        expect(after.x).toBeCloseTo(before.x, 6);
+        expect(after.y).toBeCloseTo(before.y, 6);
+    });
+
+    it("stops at the ends of the range instead of running away", () => {
+        const s = store();
+        for (let i = 0; i < 40; i++) zoomByStep(s, 1, SIZE);
+        expect(s.getState().viewport.zoom).toBeCloseTo(MAX_ZOOM, 6);
+        for (let i = 0; i < 80; i++) zoomByStep(s, -1, SIZE);
+        expect(s.getState().viewport.zoom).toBeCloseTo(MIN_ZOOM, 6);
+    });
+});
+
+describe("setZoom", () => {
+    it("holds the centre when jumping to an exact percentage", () => {
+        const s = store();
+        s.setViewport({ x: 120, y: -80, zoom: 0.4 });
+        const before = centre(s);
+        setZoom(s, 2, SIZE);
+        expect(s.getState().viewport.zoom).toBeCloseTo(2, 6);
+        const after = centre(s);
+        expect(after.x).toBeCloseTo(before.x, 6);
+        expect(after.y).toBeCloseTo(before.y, 6);
+    });
+});

--- a/apps/web/src/app/employer/mindmap/_mindmap/model/commands.ts
+++ b/apps/web/src/app/employer/mindmap/_mindmap/model/commands.ts
@@ -44,15 +44,18 @@ import {
 import {
     clamp,
     fitViewport,
+    nextZoomStep,
     nodeBounds,
     nodesBounds,
     rectCenter,
     unionRects,
+    zoomAt,
     type ViewportLike,
 } from "./geometry";
 import { computeLayout, suggestChildPosition, type LayoutKind, type LayoutOptions } from "./layout";
-import { branchSwatch, SWATCH_BY_ID, THEME_BY_ID } from "./palette";
+import { branchSwatch, SWATCH_BY_ID, THEME_BY_ID, themeMode, type ThemeMode } from "./palette";
 import { shapeDef, shapeTextBox } from "./shapes";
+import { applyThemeToDoc } from "./theme";
 import type { EditorStore } from "./store";
 import { layoutText } from "./text";
 import type {
@@ -76,13 +79,23 @@ import type {
 // Insertion
 // ---------------------------------------------------------------------------
 
+/**
+ * The paper the document is currently painted on. Every creation path asks
+ * this before minting a node — otherwise dropping a box on a dark board hands
+ * you a white one, which was the single most jarring thing about the dark
+ * themes before they existed.
+ */
+export function docMode(store: EditorStore): ThemeMode {
+    return themeMode(store.getState().doc.settings.paletteId);
+}
+
 export function insertShape(
     store: EditorStore,
     shape: ShapeId,
     at: Point,
     opts: { text?: string; w?: number; h?: number; parentId?: string | null } = {}
 ): string {
-    const node = createNodeAt(shape, at, opts);
+    const node = createNodeAt(shape, at, { ...opts, mode: docMode(store) });
     store.updatePage(page => addNodes(page, [node]), { label: `Add ${shapeDef(shape).name}` });
     store.selectNodes([node.id]);
     return node.id;
@@ -685,46 +698,7 @@ export function toggleLock(store: EditorStore): void {
 export function applyTheme(store: EditorStore, themeId: string): void {
     const theme = THEME_BY_ID[themeId];
     if (!theme) return;
-    store.update(
-        doc => {
-            const page = activePage(doc);
-            let cycleIndex = 0;
-            const nodes = page.nodes.map(nd => {
-                if (nd.shape === "group" || nd.shape === "text" || nd.shape === "image") return nd;
-                const key = theme.cycle[cycleIndex % theme.cycle.length]!;
-                cycleIndex += 1;
-                const sw = SWATCH_BY_ID[key]!;
-                const isRoot = nd.shape === "mind-root";
-                return {
-                    ...nd,
-                    style: {
-                        ...nd.style,
-                        fill: isRoot ? sw.stroke : sw.fill,
-                        stroke: isRoot ? "none" : sw.stroke,
-                    },
-                    textStyle: {
-                        ...nd.textStyle,
-                        color: isRoot ? "oklch(0.99 0.002 285)" : sw.ink,
-                    },
-                };
-            });
-            const edges = page.edges.map(e => ({
-                ...e,
-                style: { ...e.style, stroke: theme.edgeStroke },
-            }));
-            const next: DiagramPage = {
-                ...page,
-                nodes,
-                edges,
-                background: { ...page.background, color: theme.background },
-            };
-            return {
-                ...updatePage(doc, page.id, () => next),
-                settings: { ...doc.settings, paletteId: themeId },
-            };
-        },
-        { label: `Theme: ${theme.name}` }
-    );
+    store.update(doc => applyThemeToDoc(doc, themeId), { label: `Theme: ${theme.name}` });
 }
 
 // ---------------------------------------------------------------------------
@@ -871,12 +845,14 @@ export function addChildTopic(store: EditorStore, parentId: string): string | nu
     const parent = nodeById(page, parentId);
     if (!parent) return null;
     const depth = depthOf(page, parentId) + 1;
-    const sw = branchSwatch(depth);
+    const mode = themeMode(store.getState().doc.settings.paletteId);
+    const sw = branchSwatch(depth, mode);
     const size = { w: depth === 1 ? 170 : 150, h: depth === 1 ? 56 : 48 };
     const at = suggestChildPosition(page, parentId, size, "right");
 
     const child = createNode({
         shape: depth >= 3 ? "mind-leaf" : "mind-branch",
+        mode,
         x: at.x,
         y: at.y,
         w: size.w,
@@ -1109,6 +1085,27 @@ export function fitToScreen(store: EditorStore, size: { w: number; h: number }):
         return;
     }
     store.setViewport(fitViewport(bounds, size));
+}
+
+/**
+ * Step the zoom, keeping the middle of the canvas where it is.
+ *
+ * `setViewport({ zoom })` on its own scales about the world origin, so the
+ * board lurches away from you and at 400% your diagram is somewhere off past
+ * the corner. Every zoom that is not aimed at the cursor should be aimed at
+ * the centre of what you are looking at.
+ */
+export function zoomByStep(store: EditorStore, dir: 1 | -1, size: { w: number; h: number }): void {
+    const { viewport } = store.getState();
+    store.setViewport(
+        zoomAt(viewport, nextZoomStep(viewport.zoom, dir), { x: size.w / 2, y: size.h / 2 })
+    );
+}
+
+/** Jump to an exact zoom (the percentage menu), also about the centre. */
+export function setZoom(store: EditorStore, zoom: number, size: { w: number; h: number }): void {
+    const { viewport } = store.getState();
+    store.setViewport(zoomAt(viewport, zoom, { x: size.w / 2, y: size.h / 2 }));
 }
 
 export function zoomToSelection(store: EditorStore, size: { w: number; h: number }): void {

--- a/apps/web/src/app/employer/mindmap/_mindmap/model/factory.ts
+++ b/apps/web/src/app/employer/mindmap/_mindmap/model/factory.ts
@@ -5,7 +5,16 @@
  * document's active palette, snap settings, and text defaults.
  */
 
-import { branchSwatch, HAIRLINE, INK, PAPER, STICKY_COLORS, SWATCH_BY_ID } from "./palette";
+import {
+    branchSwatch,
+    neutralsFor,
+    PAPER,
+    stickyColors,
+    readableInkOn,
+    stickyInk,
+    swatchFor,
+    type ThemeMode,
+} from "./palette";
 import { shapeDef } from "./shapes";
 import {
     DOC_SCHEMA_VERSION,
@@ -48,10 +57,14 @@ export function __resetIdCounter(): void {
 // Styles
 // ---------------------------------------------------------------------------
 
-export function defaultNodeStyle(overrides: Partial<NodeStyle> = {}): NodeStyle {
+export function defaultNodeStyle(
+    overrides: Partial<NodeStyle> = {},
+    mode: ThemeMode = "light"
+): NodeStyle {
+    const n = neutralsFor(mode);
     return {
-        fill: PAPER,
-        stroke: HAIRLINE,
+        fill: n.paper,
+        stroke: n.hairline,
         strokeWidth: 1.5,
         strokeStyle: "solid",
         opacity: 1,
@@ -61,9 +74,12 @@ export function defaultNodeStyle(overrides: Partial<NodeStyle> = {}): NodeStyle 
     };
 }
 
-export function defaultTextStyle(overrides: Partial<TextStyle> = {}): TextStyle {
+export function defaultTextStyle(
+    overrides: Partial<TextStyle> = {},
+    mode: ThemeMode = "light"
+): TextStyle {
     return {
-        color: INK,
+        color: neutralsFor(mode).ink,
         size: 14,
         family: "sans",
         bold: false,
@@ -108,18 +124,23 @@ export function defaultSettings(overrides: Partial<DocSettings> = {}): DocSettin
  * Shape-specific styling applied on top of the document defaults — a sticky
  * looks nothing like a UML class even before the user touches the inspector.
  */
-function presetFor(shape: ShapeId): { style: Partial<NodeStyle>; text: Partial<TextStyle> } {
+function presetFor(
+    shape: ShapeId,
+    mode: ThemeMode = "light"
+): { style: Partial<NodeStyle>; text: Partial<TextStyle> } {
+    const n = neutralsFor(mode);
+    const sticky = stickyColors(mode);
     switch (shape) {
         case "sticky":
             return {
                 style: {
-                    fill: STICKY_COLORS[0]!,
+                    fill: sticky[0]!,
                     stroke: "none",
                     strokeWidth: 0,
                     radius: 3,
                     shadow: true,
                 },
-                text: { align: "left", valign: "top", size: 15 },
+                text: { align: "left", valign: "top", size: 15, color: stickyInk(mode) },
             };
         case "text":
             return {
@@ -127,7 +148,7 @@ function presetFor(shape: ShapeId): { style: Partial<NodeStyle>; text: Partial<T
                 text: { align: "left", valign: "top", size: 16 },
             };
         case "mind-root": {
-            const sw = branchSwatch(0);
+            const sw = branchSwatch(0, mode);
             return {
                 style: {
                     fill: sw.stroke,
@@ -136,11 +157,11 @@ function presetFor(shape: ShapeId): { style: Partial<NodeStyle>; text: Partial<T
                     shadow: true,
                     radius: 22,
                 },
-                text: { color: "oklch(0.99 0.002 285)", size: 18, bold: true },
+                text: { color: readableInkOn(sw.stroke), size: 18, bold: true },
             };
         }
         case "mind-branch": {
-            const sw = branchSwatch(1);
+            const sw = branchSwatch(1, mode);
             return {
                 style: { fill: sw.fill, stroke: sw.stroke, strokeWidth: 1.5, radius: 10 },
                 text: { color: sw.ink, size: 14, bold: false },
@@ -148,18 +169,20 @@ function presetFor(shape: ShapeId): { style: Partial<NodeStyle>; text: Partial<T
         }
         case "mind-leaf":
             return {
-                style: { fill: "none", stroke: HAIRLINE, strokeWidth: 1.5 },
-                text: { align: "left", valign: "bottom", size: 13 },
+                style: { fill: "none", stroke: n.hairline, strokeWidth: 1.5 },
+                text: { align: "left", valign: "bottom", size: 13, color: n.ink },
             };
         case "frame":
             return {
                 style: {
-                    fill: "oklch(0.985 0.004 280)",
-                    stroke: "oklch(0.80 0.01 280)",
+                    // A frame is a slightly raised patch of paper, so it tracks
+                    // the paper rather than sitting at a fixed lightness.
+                    fill: mode === "dark" ? "oklch(0.235 0.018 285)" : "oklch(0.985 0.004 280)",
+                    stroke: mode === "dark" ? "oklch(0.36 0.02 285)" : "oklch(0.80 0.01 280)",
                     strokeWidth: 1,
                     radius: 8,
                 },
-                text: { align: "left", valign: "middle", size: 12, color: "oklch(0.50 0.01 280)" },
+                text: { align: "left", valign: "middle", size: 12, color: n.inkSoft },
             };
         case "group":
             return {
@@ -170,35 +193,43 @@ function presetFor(shape: ShapeId): { style: Partial<NodeStyle>; text: Partial<T
         case "swimlane-v":
             return {
                 style: {
-                    fill: "oklch(0.99 0.003 280)",
-                    stroke: "oklch(0.78 0.012 280)",
+                    fill: mode === "dark" ? "oklch(0.22 0.015 285)" : "oklch(0.99 0.003 280)",
+                    stroke: mode === "dark" ? "oklch(0.38 0.02 285)" : "oklch(0.78 0.012 280)",
                     strokeWidth: 1.2,
                     radius: 4,
                 },
-                text: { align: "left", valign: "middle", size: 13, bold: true },
+                text: { align: "left", valign: "middle", size: 13, bold: true, color: n.ink },
             };
         case "uml-class":
         case "erd-entity":
             return {
-                style: { fill: PAPER, stroke: "oklch(0.45 0.02 280)", strokeWidth: 1.4, radius: 4 },
-                text: { align: "center", valign: "top", size: 14, bold: true },
+                style: {
+                    fill: n.paper,
+                    stroke: mode === "dark" ? "oklch(0.60 0.02 280)" : "oklch(0.45 0.02 280)",
+                    strokeWidth: 1.4,
+                    radius: 4,
+                },
+                text: { align: "center", valign: "top", size: 14, bold: true, color: n.ink },
             };
         case "uml-note":
             return {
-                style: { fill: "oklch(0.97 0.05 95)", stroke: "oklch(0.65 0.09 90)" },
-                text: { align: "left", valign: "top", size: 13 },
+                style: {
+                    fill: mode === "dark" ? "oklch(0.31 0.06 92)" : "oklch(0.97 0.05 95)",
+                    stroke: mode === "dark" ? "oklch(0.66 0.10 90)" : "oklch(0.65 0.09 90)",
+                },
+                text: { align: "left", valign: "top", size: 13, color: n.ink },
             };
         case "uml-actor":
         case "uml-interface":
             return {
-                style: { fill: PAPER, stroke: INK, strokeWidth: 1.6 },
-                text: { valign: "top", size: 13 },
+                style: { fill: n.paper, stroke: n.ink, strokeWidth: 1.6 },
+                text: { valign: "top", size: 13, color: n.ink },
             };
         case "line":
         case "ink":
         case "bracket-pair":
             return {
-                style: { fill: "none", stroke: INK, strokeWidth: 2 },
+                style: { fill: "none", stroke: n.ink, strokeWidth: 2 },
                 text: {},
             };
         case "image":
@@ -210,11 +241,11 @@ function presetFor(shape: ShapeId): { style: Partial<NodeStyle>; text: Partial<T
         case "or-junction":
         case "summing-junction":
             return {
-                style: { fill: PAPER, stroke: INK, strokeWidth: 1.5 },
-                text: { size: 12 },
+                style: { fill: n.paper, stroke: n.ink, strokeWidth: 1.5 },
+                text: { size: 12, color: n.ink },
             };
         default: {
-            const sw = SWATCH_BY_ID.violet!;
+            const sw = swatchFor("violet", mode);
             return {
                 style: { fill: sw.fill, stroke: sw.stroke, strokeWidth: 1.5 },
                 text: { color: sw.ink },
@@ -240,11 +271,14 @@ export interface CreateNodeOptions {
     parentId?: string | null;
     data?: DiagramNode["data"];
     rotation?: number;
+    /** Which paper this node is being drawn on. Defaults to light. */
+    mode?: ThemeMode;
 }
 
 export function createNode(opts: CreateNodeOptions): DiagramNode {
     const d = shapeDef(opts.shape);
-    const preset = presetFor(opts.shape);
+    const mode = opts.mode ?? "light";
+    const preset = presetFor(opts.shape, mode);
     return {
         id: makeId("n"),
         shape: opts.shape,
@@ -254,8 +288,8 @@ export function createNode(opts: CreateNodeOptions): DiagramNode {
         h: opts.h ?? d.defaultSize.h,
         rotation: opts.rotation ?? 0,
         text: opts.text ?? "",
-        style: defaultNodeStyle({ ...preset.style, ...opts.style }),
-        textStyle: defaultTextStyle({ ...preset.text, ...opts.textStyle }),
+        style: defaultNodeStyle({ ...preset.style, ...opts.style }, mode),
+        textStyle: defaultTextStyle({ ...preset.text, ...opts.textStyle }, mode),
         parentId: opts.parentId ?? null,
         locked: false,
         hidden: false,
@@ -276,11 +310,17 @@ export function createNodeAt(
 }
 
 /** A mindmap topic auto-styled for its depth. */
-export function createMindNode(depth: number, at: Point, text = ""): DiagramNode {
+export function createMindNode(
+    depth: number,
+    at: Point,
+    text = "",
+    mode: ThemeMode = "light"
+): DiagramNode {
     const shape: ShapeId = depth === 0 ? "mind-root" : depth === 1 ? "mind-branch" : "mind-branch";
-    const sw = branchSwatch(depth);
+    const sw = branchSwatch(depth, mode);
     const node = createNodeAt(shape, at, {
         text,
+        mode,
         w: depth === 0 ? 200 : depth === 1 ? 170 : 150,
         h: depth === 0 ? 76 : depth === 1 ? 56 : 48,
         style:
@@ -289,7 +329,7 @@ export function createMindNode(depth: number, at: Point, text = ""): DiagramNode
                 : { fill: sw.fill, stroke: sw.stroke },
         textStyle:
             depth === 0
-                ? { color: "oklch(0.99 0.002 285)", size: 18, bold: true }
+                ? { color: readableInkOn(sw.stroke), size: 18, bold: true }
                 : { color: sw.ink, size: depth === 1 ? 15 : 13.5, bold: depth === 1 },
         data: { depth },
     });

--- a/apps/web/src/app/employer/mindmap/_mindmap/model/palette.ts
+++ b/apps/web/src/app/employer/mindmap/_mindmap/model/palette.ts
@@ -74,7 +74,10 @@ export const SWATCHES: readonly Swatch[] = [
         id: "green",
         name: "Green",
         fill: "oklch(0.94 0.05 150)",
-        stroke: "oklch(0.58 0.16 150)",
+        // 0.52, not 0.58: green is the most luminous hue at a given lightness,
+        // and at 0.58 a white label on a green root topic measured 4.34:1 —
+        // under AA. Every other swatch's stroke already cleared it.
+        stroke: "oklch(0.52 0.15 150)",
         ink: "oklch(0.34 0.11 150)",
     },
     {
@@ -88,7 +91,10 @@ export const SWATCHES: readonly Swatch[] = [
         id: "amber",
         name: "Amber",
         fill: "oklch(0.95 0.06 85)",
-        stroke: "oklch(0.70 0.16 75)",
+        // 0.62, not 0.70: amber against near-white paper measured 2.65:1, so
+        // an amber node's outline barely separated from the board. 3:1 is the
+        // WCAG floor for a UI boundary and 0.62 clears it at 3.6:1.
+        stroke: "oklch(0.62 0.16 75)",
         ink: "oklch(0.40 0.12 70)",
     },
     {
@@ -125,12 +131,154 @@ export const SWATCH_BY_ID: Record<string, Swatch> = Object.fromEntries(
     SWATCHES.map(s => [s.id, s])
 );
 
+/**
+ * Dark counterparts, one per swatch above and in the same order.
+ *
+ * Not a filter over the light set — inverting lightness alone gives muddy,
+ * desaturated boxes. Each tone is placed by hand against a ~0.19 backdrop:
+ * the fill sits far enough above the paper to read as a surface, the stroke
+ * carries the hue, and the ink clears 7:1 against its own fill so a label is
+ * never the thing you have to squint at.
+ */
+export const DARK_SWATCHES: readonly Swatch[] = [
+    {
+        id: "slate",
+        name: "Slate",
+        fill: "oklch(0.30 0.012 280)",
+        stroke: "oklch(0.62 0.02 280)",
+        ink: "oklch(0.93 0.006 280)",
+    },
+    {
+        id: "graphite",
+        name: "Graphite",
+        fill: "oklch(0.36 0.014 280)",
+        stroke: "oklch(0.70 0.02 280)",
+        ink: "oklch(0.95 0.004 280)",
+    },
+    {
+        id: "violet",
+        name: "Violet",
+        fill: "oklch(0.32 0.10 285)",
+        stroke: "oklch(0.72 0.19 285)",
+        ink: "oklch(0.93 0.04 285)",
+    },
+    {
+        id: "indigo",
+        name: "Indigo",
+        fill: "oklch(0.32 0.09 275)",
+        stroke: "oklch(0.70 0.17 275)",
+        ink: "oklch(0.93 0.035 275)",
+    },
+    {
+        id: "blue",
+        name: "Blue",
+        fill: "oklch(0.32 0.08 245)",
+        stroke: "oklch(0.72 0.14 245)",
+        ink: "oklch(0.93 0.03 245)",
+    },
+    {
+        id: "cyan",
+        name: "Cyan",
+        fill: "oklch(0.32 0.07 210)",
+        stroke: "oklch(0.75 0.12 210)",
+        ink: "oklch(0.93 0.03 210)",
+    },
+    {
+        id: "teal",
+        name: "Teal",
+        fill: "oklch(0.32 0.07 185)",
+        stroke: "oklch(0.74 0.11 185)",
+        ink: "oklch(0.93 0.03 185)",
+    },
+    {
+        id: "green",
+        name: "Green",
+        fill: "oklch(0.32 0.08 150)",
+        stroke: "oklch(0.73 0.15 150)",
+        ink: "oklch(0.93 0.035 150)",
+    },
+    {
+        id: "lime",
+        name: "Lime",
+        fill: "oklch(0.33 0.09 125)",
+        stroke: "oklch(0.78 0.16 125)",
+        ink: "oklch(0.94 0.04 125)",
+    },
+    {
+        id: "amber",
+        name: "Amber",
+        fill: "oklch(0.34 0.09 80)",
+        stroke: "oklch(0.80 0.15 78)",
+        ink: "oklch(0.94 0.045 85)",
+    },
+    {
+        id: "orange",
+        name: "Orange",
+        fill: "oklch(0.33 0.10 52)",
+        stroke: "oklch(0.74 0.16 50)",
+        ink: "oklch(0.94 0.04 55)",
+    },
+    {
+        id: "red",
+        name: "Red",
+        fill: "oklch(0.32 0.10 25)",
+        stroke: "oklch(0.68 0.19 25)",
+        ink: "oklch(0.93 0.04 25)",
+    },
+    {
+        id: "pink",
+        name: "Pink",
+        fill: "oklch(0.33 0.10 350)",
+        stroke: "oklch(0.72 0.17 350)",
+        ink: "oklch(0.93 0.04 350)",
+    },
+    {
+        id: "magenta",
+        name: "Magenta",
+        fill: "oklch(0.33 0.11 330)",
+        stroke: "oklch(0.72 0.19 330)",
+        ink: "oklch(0.93 0.045 330)",
+    },
+];
+
+export const DARK_SWATCH_BY_ID: Record<string, Swatch> = Object.fromEntries(
+    DARK_SWATCHES.map(s => [s.id, s])
+);
+
+/** Which half of the world a document is painted for. */
+export type ThemeMode = "light" | "dark";
+
+/** The tone a swatch takes on in a given document theme. */
+export function swatchFor(id: string, mode: ThemeMode): Swatch {
+    const table = mode === "dark" ? DARK_SWATCH_BY_ID : SWATCH_BY_ID;
+    return table[id] ?? table.slate!;
+}
+
 /** Neutral document defaults: white fill, mid-grey stroke, near-black ink. */
 export const PAPER = "oklch(1 0 0)";
 export const INK = "oklch(0.22 0.015 280)";
 export const INK_SOFT = "oklch(0.45 0.012 280)";
 export const HAIRLINE = "oklch(0.62 0.02 280)";
 export const TRANSPARENT = "none";
+
+/** The same four, for a document painted on dark paper. */
+export const PAPER_DARK = "oklch(0.19 0.018 285)";
+export const INK_DARK = "oklch(0.95 0.004 280)";
+export const INK_SOFT_DARK = "oklch(0.74 0.008 280)";
+export const HAIRLINE_DARK = "oklch(0.52 0.02 280)";
+
+export interface Neutrals {
+    paper: string;
+    ink: string;
+    inkSoft: string;
+    hairline: string;
+}
+
+export function neutralsFor(mode: ThemeMode): Neutrals {
+    return mode === "dark"
+        ? { paper: PAPER_DARK, ink: INK_DARK, inkSoft: INK_SOFT_DARK, hairline: HAIRLINE_DARK }
+        : { paper: PAPER, ink: INK, inkSoft: INK_SOFT, hairline: HAIRLINE };
+}
 
 /** Sticky-note colours — saturated fills that read on a white canvas. */
 export const STICKY_COLORS: readonly string[] = [
@@ -141,6 +289,29 @@ export const STICKY_COLORS: readonly string[] = [
     "oklch(0.91 0.10 40)",
     "oklch(0.93 0.06 285)",
 ];
+
+/**
+ * Stickies on dark paper. Still the brightest thing on the board — a sticky
+ * that recedes is not a sticky — but pulled down far enough that the near-black
+ * ink they keep stays comfortable rather than glaring.
+ */
+export const STICKY_COLORS_DARK: readonly string[] = [
+    "oklch(0.78 0.14 100)",
+    "oklch(0.75 0.13 150)",
+    "oklch(0.74 0.11 210)",
+    "oklch(0.74 0.13 330)",
+    "oklch(0.77 0.13 40)",
+    "oklch(0.76 0.09 285)",
+];
+
+export function stickyColors(mode: ThemeMode): readonly string[] {
+    return mode === "dark" ? STICKY_COLORS_DARK : STICKY_COLORS;
+}
+
+/** Ink that reads on a sticky, whichever set it came from. */
+export function stickyInk(mode: ThemeMode): string {
+    return mode === "dark" ? "oklch(0.20 0.02 90)" : INK;
+}
 
 /**
  * Depth-indexed accent ramp for auto-styled mindmap branches. Index 0 is the
@@ -159,10 +330,82 @@ export const BRANCH_RAMP: readonly string[] = [
     "magenta",
 ];
 
-export function branchSwatch(depth: number): Swatch {
-    if (depth <= 0) return SWATCH_BY_ID.violet!;
+export function branchSwatch(depth: number, mode: ThemeMode = "light"): Swatch {
+    if (depth <= 0) return swatchFor("violet", mode);
     const key = BRANCH_RAMP[(depth - 1) % BRANCH_RAMP.length]!;
-    return SWATCH_BY_ID[key]!;
+    return swatchFor(key, mode);
+}
+
+/**
+ * Relative luminance (WCAG) of a document colour, or null if unparseable.
+ *
+ * Documents only ever hold `oklch()` and hex, so those are the two with real
+ * conversions; the OKLCH path goes through OKLab to linear sRGB, which is the
+ * space luminance is defined in.
+ */
+export function relativeLuminance(css: string): number | null {
+    const value = css.trim().toLowerCase();
+
+    const ok = /^oklch\(\s*([\d.]+%?)\s+([\d.]+)\s+([\d.]+)/.exec(value);
+    if (ok) {
+        const rawL = Number.parseFloat(ok[1]!);
+        const L = ok[1]!.endsWith("%") ? rawL / 100 : rawL;
+        const C = Number.parseFloat(ok[2]!);
+        const h = (Number.parseFloat(ok[3]!) * Math.PI) / 180;
+        if (Number.isNaN(L) || Number.isNaN(C) || Number.isNaN(h)) return null;
+
+        const a = C * Math.cos(h);
+        const b = C * Math.sin(h);
+        const l = (L + 0.3963377774 * a + 0.2158037573 * b) ** 3;
+        const m = (L - 0.1055613458 * a - 0.0638541728 * b) ** 3;
+        const s2 = (L - 0.0894841775 * a - 1.291485548 * b) ** 3;
+
+        const clamp01 = (v: number) => Math.max(0, Math.min(1, v));
+        const r = clamp01(4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s2);
+        const g = clamp01(-1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s2);
+        const bl = clamp01(-0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s2);
+        return 0.2126 * r + 0.7152 * g + 0.0722 * bl;
+    }
+
+    const hex = /^#([0-9a-f]{3}|[0-9a-f]{6})$/.exec(value);
+    if (hex) {
+        const d = hex[1]!;
+        const chan = (i: number) =>
+            (d.length === 3
+                ? Number.parseInt(d[i]!.repeat(2), 16)
+                : Number.parseInt(d.slice(i * 2, i * 2 + 2), 16)) / 255;
+        const decode = (v: number) => (v <= 0.04045 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4);
+        return 0.2126 * decode(chan(0)) + 0.7152 * decode(chan(1)) + 0.0722 * decode(chan(2));
+    }
+
+    return null;
+}
+
+/** WCAG contrast ratio, 1–21. Returns 1 when either colour cannot be read. */
+export function contrastRatio(a: string, b: string): number {
+    const la = relativeLuminance(a);
+    const lb = relativeLuminance(b);
+    if (la === null || lb === null) return 1;
+    const [hi, lo] = la > lb ? [la, lb] : [lb, la];
+    return (hi + 0.05) / (lo + 0.05);
+}
+
+export const INK_ON_LIGHT = INK;
+export const INK_ON_DARK = "oklch(0.99 0.002 285)";
+
+/**
+ * Whichever of the two inks is actually readable on `background`.
+ *
+ * Measured, not assumed. The root topic forced it: its fill is the swatch's
+ * *stroke*, which on a dark board is a bright violet at 0.72 lightness —
+ * near-white on that is 2.6:1 and fails AA even at the large-text threshold,
+ * while near-black is 8:1. No fixed choice per mode gets both boards right,
+ * and any fixed choice is wrong again the moment someone picks their own fill.
+ */
+export function readableInkOn(background: string): string {
+    return contrastRatio(INK_ON_DARK, background) >= contrastRatio(INK_ON_LIGHT, background)
+        ? INK_ON_DARK
+        : INK_ON_LIGHT;
 }
 
 /**
@@ -172,6 +415,8 @@ export function branchSwatch(depth: number): Swatch {
 export interface DocTheme {
     id: string;
     name: string;
+    /** Which swatch table the cycle is read from, and how the paper is lit. */
+    mode: ThemeMode;
     /** Swatch ids cycled across nodes, in order. */
     cycle: string[];
     edgeStroke: string;
@@ -183,6 +428,7 @@ export const THEMES: readonly DocTheme[] = [
     {
         id: "default",
         name: "Launchstack",
+        mode: "light",
         cycle: ["violet", "blue", "teal", "green", "amber", "pink"],
         edgeStroke: "oklch(0.55 0.03 280)",
         background: "oklch(0.992 0.003 80)",
@@ -191,6 +437,7 @@ export const THEMES: readonly DocTheme[] = [
     {
         id: "mono",
         name: "Monochrome",
+        mode: "light",
         cycle: ["slate", "graphite"],
         edgeStroke: "oklch(0.45 0.01 280)",
         background: "oklch(1 0 0)",
@@ -199,6 +446,7 @@ export const THEMES: readonly DocTheme[] = [
     {
         id: "ocean",
         name: "Ocean",
+        mode: "light",
         cycle: ["blue", "cyan", "teal", "indigo"],
         edgeStroke: "oklch(0.52 0.08 235)",
         background: "oklch(0.985 0.008 235)",
@@ -207,6 +455,7 @@ export const THEMES: readonly DocTheme[] = [
     {
         id: "sunset",
         name: "Sunset",
+        mode: "light",
         cycle: ["orange", "amber", "red", "pink", "magenta"],
         edgeStroke: "oklch(0.55 0.10 40)",
         background: "oklch(0.99 0.01 70)",
@@ -215,11 +464,140 @@ export const THEMES: readonly DocTheme[] = [
     {
         id: "forest",
         name: "Forest",
+        mode: "light",
         cycle: ["green", "lime", "teal", "amber"],
         edgeStroke: "oklch(0.48 0.09 150)",
         background: "oklch(0.99 0.008 140)",
         ink: "oklch(0.26 0.05 150)",
     },
+
+    // ── Dark ────────────────────────────────────────────────────────────
+    // One per light theme, so switching a board between them is a change of
+    // lighting rather than a change of identity.
+    {
+        id: "midnight",
+        name: "Midnight",
+        mode: "dark",
+        cycle: ["violet", "blue", "teal", "green", "amber", "pink"],
+        edgeStroke: "oklch(0.66 0.03 285)",
+        background: "oklch(0.19 0.018 285)",
+        ink: INK_DARK,
+    },
+    {
+        id: "carbon",
+        name: "Carbon",
+        mode: "dark",
+        cycle: ["slate", "graphite"],
+        edgeStroke: "oklch(0.68 0.01 280)",
+        background: "oklch(0.17 0.004 280)",
+        ink: INK_DARK,
+    },
+    {
+        id: "abyss",
+        name: "Abyss",
+        mode: "dark",
+        cycle: ["blue", "cyan", "teal", "indigo"],
+        edgeStroke: "oklch(0.68 0.08 235)",
+        background: "oklch(0.19 0.03 240)",
+        ink: "oklch(0.94 0.02 235)",
+    },
+    {
+        id: "ember",
+        name: "Ember",
+        mode: "dark",
+        cycle: ["orange", "amber", "red", "pink", "magenta"],
+        edgeStroke: "oklch(0.70 0.10 45)",
+        background: "oklch(0.19 0.025 40)",
+        ink: "oklch(0.94 0.025 60)",
+    },
+    {
+        id: "pine",
+        name: "Pine",
+        mode: "dark",
+        cycle: ["green", "lime", "teal", "amber"],
+        edgeStroke: "oklch(0.68 0.10 150)",
+        background: "oklch(0.185 0.022 155)",
+        ink: "oklch(0.94 0.02 150)",
+    },
 ];
 
 export const THEME_BY_ID: Record<string, DocTheme> = Object.fromEntries(THEMES.map(t => [t.id, t]));
+
+/**
+ * Is this colour dark enough that chrome drawn on it must be light?
+ *
+ * Answered from the colour itself rather than from the theme id, because the
+ * background is editable: someone can set a custom paper on a light theme and
+ * the selection handles still have to be visible. Parses the two notations the
+ * document ever holds — `oklch()` and hex — and treats anything else as light,
+ * which is the safe guess for an unrecognised value on a canvas that has
+ * historically been white.
+ */
+export function isDarkSurface(css: string): boolean {
+    const value = css.trim().toLowerCase();
+
+    const oklch = /^oklch\(\s*([\d.]+)(%?)/.exec(value);
+    if (oklch) {
+        const raw = Number.parseFloat(oklch[1]!);
+        if (Number.isNaN(raw)) return false;
+        return (oklch[2] === "%" ? raw / 100 : raw) < 0.5;
+    }
+
+    const hex = /^#([0-9a-f]{3}|[0-9a-f]{6})$/.exec(value);
+    if (hex) {
+        const digits = hex[1]!;
+        const pair = (i: number) =>
+            digits.length === 3
+                ? Number.parseInt(digits[i]!.repeat(2), 16)
+                : Number.parseInt(digits.slice(i * 2, i * 2 + 2), 16);
+        // Rec. 601 luma: close enough for a light/dark decision, and it needs
+        // no colour-space conversion.
+        const luma = (0.299 * pair(0) + 0.587 * pair(1) + 0.114 * pair(2)) / 255;
+        return luma < 0.5;
+    }
+
+    const rgb = /^rgba?\(\s*([\d.]+)[,\s]+([\d.]+)[,\s]+([\d.]+)/.exec(value);
+    if (rgb) {
+        const luma =
+            (0.299 * Number.parseFloat(rgb[1]!) +
+                0.587 * Number.parseFloat(rgb[2]!) +
+                0.114 * Number.parseFloat(rgb[3]!)) /
+            255;
+        return luma < 0.5;
+    }
+
+    return false;
+}
+
+/**
+ * The dark board that corresponds to a light one and vice versa, so switching
+ * a document between them is a change of lighting rather than of identity.
+ */
+const THEME_COUNTERPART: Record<string, string> = {
+    default: "midnight",
+    mono: "carbon",
+    ocean: "abyss",
+    sunset: "ember",
+    forest: "pine",
+    midnight: "default",
+    carbon: "mono",
+    abyss: "ocean",
+    ember: "sunset",
+    pine: "forest",
+};
+
+/** The same theme lit the other way, or the input if it has no counterpart. */
+export function counterpartTheme(themeId: string): string {
+    return THEME_COUNTERPART[themeId] ?? themeId;
+}
+
+/** The default board for a viewer currently in this app theme. */
+export function defaultThemeFor(mode: ThemeMode): string {
+    return mode === "dark" ? "midnight" : "default";
+}
+
+/** The mode a theme id names, defaulting to light for an unknown id. */
+export function themeMode(themeId: string | null | undefined): ThemeMode {
+    if (!themeId) return "light";
+    return THEME_BY_ID[themeId]?.mode ?? "light";
+}

--- a/apps/web/src/app/employer/mindmap/_mindmap/model/shapes.ts
+++ b/apps/web/src/app/employer/mindmap/_mindmap/model/shapes.ts
@@ -140,6 +140,13 @@ export interface ShapeDef {
     container?: boolean;
     /** Rendered with no fill/stroke chrome — text or bitmap only. */
     chromeless?: boolean;
+    /**
+     * Whether the shape carries a text label. Defaults to true: nearly every
+     * shape here is a container you put words in, which is the whole point of
+     * dropping one. The exceptions are the shapes with nothing to say — a
+     * bitmap, a pen stroke, a rule.
+     */
+    holdsText?: boolean;
     /** Connectable anchors. Defaults to the four cardinal sides. */
     ports?: readonly Exclude<PortId, "auto">[];
     /** Text area in local coordinates. Defaults to the full box, inset 8px. */
@@ -1114,12 +1121,18 @@ const FLOWCHART: ShapeDef[] = [
     }),
 ];
 
-const MINDMAP: ShapeDef[] = [
+/**
+ * The shapes people reach for first: a box you type in and wire up. They lead
+ * the palette because "which one makes a labelled box I can connect?" is the
+ * question a blank canvas actually poses, and it used to be answerable only by
+ * hovering sixty identical grey outlines.
+ */
+const NODES: ShapeDef[] = [
     def({
         id: "mind-root",
         name: "Central topic",
-        category: "Mindmap",
-        keywords: ["root", "centre", "main idea"],
+        category: "Nodes",
+        keywords: ["root", "centre", "main idea", "node", "box", "container"],
         defaultSize: { w: 200, h: 76 },
         minSize: { w: 60, h: 32 },
         rounded: true,
@@ -1129,8 +1142,8 @@ const MINDMAP: ShapeDef[] = [
     def({
         id: "mind-branch",
         name: "Topic",
-        category: "Mindmap",
-        keywords: ["branch", "node", "idea"],
+        category: "Nodes",
+        keywords: ["branch", "node", "idea", "box", "container", "card", "label"],
         defaultSize: { w: 160, h: 56 },
         minSize: { w: 48, h: 26 },
         rounded: true,
@@ -1140,8 +1153,8 @@ const MINDMAP: ShapeDef[] = [
     def({
         id: "mind-leaf",
         name: "Subtopic",
-        category: "Mindmap",
-        keywords: ["leaf", "detail", "underline"],
+        category: "Nodes",
+        keywords: ["leaf", "detail", "underline", "node"],
         defaultSize: { w: 140, h: 40 },
         minSize: { w: 40, h: 22 },
         ports: ["w", "e", "n", "s"],
@@ -1159,18 +1172,23 @@ const MINDMAP: ShapeDef[] = [
     def({
         id: "sticky",
         name: "Sticky note",
-        category: "Mindmap",
-        keywords: ["post-it", "note", "memo"],
+        category: "Nodes",
+        keywords: ["post-it", "note", "memo", "node"],
         defaultSize: { w: 150, h: 150 },
         minSize: { w: 60, h: 60 },
         ports: ALL8,
         textBox: (w, h) => insetBox(w, h, 14),
         geometry: (w, h) => ({ path: roundedRect(w, h, 3) }),
     }),
+];
+
+/** Marks on the canvas rather than things in the diagram: they carry no text
+ *  box worth connecting to, and auto-layout ignores them. */
+const ANNOTATE: ShapeDef[] = [
     def({
         id: "text",
         name: "Text",
-        category: "Mindmap",
+        category: "Annotate",
         keywords: ["label", "caption", "type"],
         defaultSize: { w: 180, h: 44 },
         minSize: { w: 24, h: 18 },
@@ -1181,7 +1199,8 @@ const MINDMAP: ShapeDef[] = [
     def({
         id: "image",
         name: "Image",
-        category: "Mindmap",
+        category: "Annotate",
+        holdsText: false,
         keywords: ["picture", "photo", "screenshot"],
         defaultSize: { w: 220, h: 160 },
         minSize: { w: 24, h: 24 },
@@ -1192,7 +1211,8 @@ const MINDMAP: ShapeDef[] = [
     def({
         id: "ink",
         name: "Ink",
-        category: "Mindmap",
+        category: "Annotate",
+        holdsText: false,
         keywords: ["pen", "draw", "freehand", "scribble"],
         defaultSize: { w: 160, h: 120 },
         minSize: { w: 4, h: 4 },
@@ -1202,7 +1222,8 @@ const MINDMAP: ShapeDef[] = [
     def({
         id: "line",
         name: "Line",
-        category: "Mindmap",
+        category: "Annotate",
+        holdsText: false,
         keywords: ["rule", "divider", "separator"],
         defaultSize: { w: 200, h: 2 },
         minSize: { w: 8, h: 1 },
@@ -1521,7 +1542,8 @@ export const SHAPES: readonly ShapeDef[] = [
     ...BASIC,
     ...ARROWS,
     ...FLOWCHART,
-    ...MINDMAP,
+    ...NODES,
+    ...ANNOTATE,
     ...UML,
     ...CONTAINERS,
 ];
@@ -1529,7 +1551,8 @@ export const SHAPES: readonly ShapeDef[] = [
 export const SHAPE_BY_ID: Record<string, ShapeDef> = Object.fromEntries(SHAPES.map(s => [s.id, s]));
 
 export const SHAPE_CATEGORIES: readonly ShapeCategory[] = [
-    "Mindmap",
+    "Nodes",
+    "Annotate",
     "Basic",
     "Flowchart",
     "Arrows",
@@ -1544,6 +1567,15 @@ export function shapeDef(id: string): ShapeDef {
 
 export function shapeGeometry(id: string, w: number, h: number, radius = 0): ShapeGeometry {
     return shapeDef(id).geometry(Math.max(w, 0.01), Math.max(h, 0.01), radius);
+}
+
+/**
+ * Does this shape carry a label? Drives whether placing one drops you straight
+ * into its text editor, so a newly created box behaves like the container it
+ * looks like instead of sitting there empty.
+ */
+export function shapeHoldsText(id: string): boolean {
+    return shapeDef(id).holdsText !== false;
 }
 
 /** Local-space text area for a shape, honouring per-shape overrides. */

--- a/apps/web/src/app/employer/mindmap/_mindmap/model/templates.ts
+++ b/apps/web/src/app/employer/mindmap/_mindmap/model/templates.ts
@@ -13,7 +13,14 @@
 
 import { createDoc, createEdge, createNode, createPage } from "./factory";
 import { runAutoLayout } from "./template-helpers";
-import { branchSwatch, STICKY_COLORS, SWATCH_BY_ID } from "./palette";
+import {
+    branchSwatch,
+    defaultThemeFor,
+    STICKY_COLORS,
+    SWATCH_BY_ID,
+    type ThemeMode,
+} from "./palette";
+import { applyThemeToDoc } from "./theme";
 import { TEMPLATE_META, type TemplateMeta } from "./template-meta";
 import type { DiagramEdge, DiagramNode, MindmapDoc, ShapeId } from "./types";
 
@@ -695,7 +702,18 @@ export function buildersMissingMetadata(): string[] {
     return Object.keys(BUILDERS).filter(id => !known.has(id));
 }
 
-export function buildTemplate(id: string, title?: string): MindmapDoc {
+/**
+ * Build a starter document.
+ *
+ * Templates are authored once, in light, and repainted on the way out — one
+ * set of builders to maintain rather than two, and the repaint is the same
+ * code path the Theme picker uses, so a seeded board and a switched board
+ * cannot drift apart. `mode` is the viewer's app theme at creation time: a
+ * choice made once and then stored, not a per-viewer render, so the board
+ * looks the same to whoever it is shared with afterwards.
+ */
+export function buildTemplate(id: string, title?: string, mode: ThemeMode = "light"): MindmapDoc {
     const t = TEMPLATE_BY_ID[id] ?? TEMPLATE_BY_ID.blank!;
-    return t.build(title);
+    const doc = t.build(title);
+    return applyThemeToDoc(doc, defaultThemeFor(mode));
 }

--- a/apps/web/src/app/employer/mindmap/_mindmap/model/theme.ts
+++ b/apps/web/src/app/employer/mindmap/_mindmap/model/theme.ts
@@ -1,0 +1,132 @@
+import { graphIndex, nodeById } from "./doc";
+import {
+    neutralsFor,
+    readableInkOn,
+    stickyColors,
+    stickyInk,
+    swatchFor,
+    THEME_BY_ID,
+} from "./palette";
+import type { DiagramPage, MindmapDoc } from "./types";
+
+/**
+ * Repainting a document in a named theme.
+ *
+ * Pure, and separate from `commands.ts`, because two callers need it: the
+ * Theme picker (through the store, so it lands in history as one step) and
+ * template seeding (before a store exists at all). Keeping it here also keeps
+ * it unit-testable without React.
+ */
+
+/**
+ * Depth of every shape that sits in a topic tree, walking up incoming edges.
+ * Absent from the map means "not a topic" — a flowchart box, a loose sticky.
+ */
+function topicDepths(page: DiagramPage): Map<string, number> {
+    const idx = graphIndex(page);
+    const depths = new Map<string, number>();
+    const isTopic = (id: string) => nodeById(page, id)?.shape.startsWith("mind-") === true;
+
+    for (const nd of page.nodes) {
+        if (!nd.shape.startsWith("mind-")) continue;
+        let level = 0;
+        let cur = nd.id;
+        const seen = new Set<string>([cur]);
+        while (level < 64) {
+            const parent = (idx.in.get(cur) ?? []).find(p => isTopic(p) && !seen.has(p));
+            if (!parent) break;
+            seen.add(parent);
+            cur = parent;
+            level += 1;
+        }
+        depths.set(nd.id, level);
+    }
+    return depths;
+}
+
+/** Repaint one page: paper, every shape, every connector. */
+export function applyThemeToPage(page: DiagramPage, themeId: string): DiagramPage {
+    const theme = THEME_BY_ID[themeId];
+    if (!theme) return page;
+    const mode = theme.mode;
+    const n = neutralsFor(mode);
+    const stickies = stickyColors(mode);
+
+    const depth = topicDepths(page);
+    let cycleIndex = 0;
+    const nodes = page.nodes.map(nd => {
+        // A group is a bracket around other shapes and an image is its own
+        // picture; neither has a surface to paint.
+        if (nd.shape === "group" || nd.shape === "image") return nd;
+
+        // Shapes with no fill are read straight off the paper — a caption, a
+        // pen stroke, a rule, a subtopic's underline. They take the theme's
+        // ink rather than a swatch. This is the case that made a dark board
+        // unreadable: their ink used to be skipped and stayed near-black.
+        if (nd.style.fill === "none") {
+            return {
+                ...nd,
+                style: {
+                    ...nd.style,
+                    stroke: nd.style.stroke === "none" ? "none" : n.hairline,
+                },
+                textStyle: { ...nd.textStyle, color: n.ink },
+            };
+        }
+
+        if (nd.shape === "sticky") {
+            const pick = stickies[cycleIndex % stickies.length]!;
+            cycleIndex += 1;
+            return {
+                ...nd,
+                style: { ...nd.style, fill: pick },
+                textStyle: { ...nd.textStyle, color: stickyInk(mode) },
+            };
+        }
+
+        // A mindmap is coloured by *depth*, not by document order: a branch
+        // and its details belong together, and cycling the palette down the
+        // node array instead turns a tidy map into confetti. Anything not in
+        // the topic tree — a flowchart's boxes — keeps the running cycle.
+        const level = depth.get(nd.id);
+        const key =
+            level === undefined
+                ? theme.cycle[cycleIndex++ % theme.cycle.length]!
+                : theme.cycle[level % theme.cycle.length]!;
+        const sw = swatchFor(key, mode);
+        // A root topic is filled with the swatch's *stroke* — the saturated
+        // tone — so it reads as the anchor of the map.
+        const isRoot = nd.shape === "mind-root";
+        const fill = isRoot ? sw.stroke : sw.fill;
+        return {
+            ...nd,
+            style: { ...nd.style, fill, stroke: isRoot ? "none" : sw.stroke },
+            // The root's ink is measured against the fill it actually got,
+            // which differs per theme — Ocean's root is blue, Ember's is
+            // orange, and near-white is only right on some of them.
+            textStyle: { ...nd.textStyle, color: isRoot ? readableInkOn(fill) : sw.ink },
+        };
+    });
+
+    const edges = page.edges.map(e => ({
+        ...e,
+        style: { ...e.style, stroke: theme.edgeStroke },
+        textStyle: { ...e.textStyle, color: n.inkSoft },
+    }));
+
+    return { ...page, nodes, edges, background: { ...page.background, color: theme.background } };
+}
+
+/**
+ * Repaint the whole document. Every page, not just the active one — a theme is
+ * a property of the document, and leaving page 2 on the old palette is not a
+ * choice anyone makes on purpose; it stays invisible until they switch pages.
+ */
+export function applyThemeToDoc(doc: MindmapDoc, themeId: string): MindmapDoc {
+    if (!THEME_BY_ID[themeId]) return doc;
+    return {
+        ...doc,
+        pages: doc.pages.map(page => applyThemeToPage(page, themeId)),
+        settings: { ...doc.settings, paletteId: themeId },
+    };
+}

--- a/apps/web/src/app/employer/mindmap/_mindmap/model/types.ts
+++ b/apps/web/src/app/employer/mindmap/_mindmap/model/types.ts
@@ -333,10 +333,18 @@ export type ShapeId =
     | "swimlane-h"
     | "swimlane-v";
 
+/**
+ * Palette grouping. `Nodes` and `Annotate` split what used to be one
+ * "Mindmap" bucket: the difference people actually need to see is not which
+ * diagram type a shape belongs to but whether it is a *thing you type in and
+ * connect* or a mark you leave on the canvas. A sticky note is a node; a
+ * caption is not.
+ */
 export type ShapeCategory =
+    | "Nodes"
+    | "Annotate"
     | "Basic"
     | "Flowchart"
-    | "Mindmap"
     | "UML & ERD"
     | "Containers"
     | "Arrows";

--- a/apps/web/src/app/employer/mindmap/_mindmap/ui/BottomBar.tsx
+++ b/apps/web/src/app/employer/mindmap/_mindmap/ui/BottomBar.tsx
@@ -19,8 +19,10 @@ import {
     fitToScreen,
     renamePage,
     setActivePage,
+    setZoom,
+    zoomByStep,
+    zoomToSelection,
 } from "../model/commands";
-import { nextZoomStep } from "../model/geometry";
 import type { EditorState } from "../model/store";
 import { useCommittedDoc, useEditor, useStore } from "./EditorContext";
 import { Minimap } from "./Minimap";
@@ -102,7 +104,12 @@ export function BottomBar({ canvasSize }: { canvasSize: { w: number; h: number }
                                         <button
                                             type="button"
                                             aria-label={`${page.name} options`}
-                                            className="text-ink-3 hover:text-ink px-1"
+                                            // ink-2, not ink-3: this sits on
+                                            // the active tab's brand-soft
+                                            // background, which is lighter
+                                            // than the panel ink-3 is tuned
+                                            // against.
+                                            className="text-ink-2 hover:text-ink px-1"
                                         >
                                             ⋯
                                         </button>
@@ -169,8 +176,8 @@ export function BottomBar({ canvasSize }: { canvasSize: { w: number; h: number }
                     </button>
                     <button
                         type="button"
-                        onClick={() => store.setViewport({ zoom: nextZoomStep(zoom, -1) })}
-                        title="Zoom out (⌘-)"
+                        onClick={() => zoomByStep(store, -1, canvasSize)}
+                        title="Zoom out (− or ⌘-)"
                         aria-label="Zoom out"
                         className="text-ink-3 hover:bg-panel-2 hover:text-ink flex size-7 items-center justify-center rounded-md"
                     >
@@ -189,21 +196,36 @@ export function BottomBar({ canvasSize }: { canvasSize: { w: number; h: number }
                             {[0.25, 0.5, 0.75, 1, 1.5, 2, 4].map(value => (
                                 <DropdownMenuItem
                                     key={value}
-                                    onSelect={() => store.setViewport({ zoom: value })}
+                                    onSelect={() => setZoom(store, value, canvasSize)}
                                 >
                                     {Math.round(value * 100)}%
                                 </DropdownMenuItem>
                             ))}
                             <DropdownMenuSeparator />
+                            <DropdownMenuItem onSelect={() => setZoom(store, 1, canvasSize)}>
+                                Zoom to 100%
+                                <span className="text-ink-3 ml-auto pl-6 font-mono text-[11px]">
+                                    ⌘0
+                                </span>
+                            </DropdownMenuItem>
                             <DropdownMenuItem onSelect={() => fitToScreen(store, canvasSize)}>
                                 Fit to screen
+                                <span className="text-ink-3 ml-auto pl-6 font-mono text-[11px]">
+                                    ⌘1
+                                </span>
+                            </DropdownMenuItem>
+                            <DropdownMenuItem onSelect={() => zoomToSelection(store, canvasSize)}>
+                                Zoom to selection
+                                <span className="text-ink-3 ml-auto pl-6 font-mono text-[11px]">
+                                    ⌘2
+                                </span>
                             </DropdownMenuItem>
                         </DropdownMenuContent>
                     </DropdownMenu>
                     <button
                         type="button"
-                        onClick={() => store.setViewport({ zoom: nextZoomStep(zoom, 1) })}
-                        title="Zoom in (⌘=)"
+                        onClick={() => zoomByStep(store, 1, canvasSize)}
+                        title="Zoom in (+ or ⌘=)"
                         aria-label="Zoom in"
                         className="text-ink-3 hover:bg-panel-2 hover:text-ink flex size-7 items-center justify-center rounded-md"
                     >

--- a/apps/web/src/app/employer/mindmap/_mindmap/ui/Canvas.module.css
+++ b/apps/web/src/app/employer/mindmap/_mindmap/ui/Canvas.module.css
@@ -1,0 +1,41 @@
+/* The drawing surface does not follow the viewer's theme — its colours are
+   document data, so the same board looks the same to everyone (see the feature
+   README). The chrome drawn on top of it therefore cannot follow the viewer's
+   theme either; it has to follow *the paper*. `data-paper` is set from the
+   page background's own lightness, so a custom background works as well as a
+   named theme does.
+
+   Rebinding the semantic names here rather than editing ~50 call sites means
+   new canvas chrome is correct by default, and those components go on reading
+   `var(--accent)` like everything else in the app instead of learning a second
+   vocabulary.
+
+   Scoped to the <svg>: the rulers and the text-editing field are siblings
+   outside it and answer to the app's theme instead. */
+.paper {
+    --panel: var(--paper-panel);
+    --panel-2: var(--paper-panel-2);
+    --ink: var(--paper-ink);
+    --ink-2: var(--paper-ink-2);
+    --ink-3: var(--paper-ink-3);
+    --ink-4: var(--paper-ink-4);
+    --line: var(--paper-line);
+    --line-2: var(--paper-line-2);
+    --line-dot: var(--paper-line-dot);
+    --accent: var(--paper-accent);
+    --warn: var(--paper-warn);
+}
+
+.paper[data-paper="dark"] {
+    --paper-panel: var(--paper-dark-panel);
+    --paper-panel-2: var(--paper-dark-panel-2);
+    --paper-ink: var(--paper-dark-ink);
+    --paper-ink-2: var(--paper-dark-ink-2);
+    --paper-ink-3: var(--paper-dark-ink-3);
+    --paper-ink-4: var(--paper-dark-ink-4);
+    --paper-line: var(--paper-dark-line);
+    --paper-line-2: var(--paper-dark-line-2);
+    --paper-line-dot: var(--paper-dark-line-dot);
+    --paper-accent: var(--paper-dark-accent);
+    --paper-warn: var(--paper-dark-warn);
+}

--- a/apps/web/src/app/employer/mindmap/_mindmap/ui/Canvas.tsx
+++ b/apps/web/src/app/employer/mindmap/_mindmap/ui/Canvas.tsx
@@ -6,6 +6,7 @@ import { toggleCollapse } from "../model/commands";
 import { graphIndex, nodeById, nodeLookup, visibleEdges, visibleNodes } from "../model/doc";
 import { nodeBounds, nodesBounds } from "../model/geometry";
 import { routeEdgeCached, type RoutedEdge } from "../model/routing";
+import { isDarkSurface } from "../model/palette";
 import { shapeDef } from "../model/shapes";
 import type { EditorState } from "../model/store";
 import type { DiagramEdge, DiagramNode, Point, Rect } from "../model/types";
@@ -18,6 +19,7 @@ import { NodePorts, SelectionOverlay } from "./SelectionOverlay";
 import { CanvasDefs, ShapeView } from "./ShapeView";
 import { useCanvasInteractions, type CanvasCallbacks } from "./useCanvasInteractions";
 import { useElementSize } from "./useElementSize";
+import styles from "./Canvas.module.css";
 
 /**
  * The drawing surface.
@@ -146,6 +148,7 @@ export function Canvas({ callbacks, peers, onCursorMove, children }: CanvasProps
         return map;
     }, [nodes]);
 
+    const darkPaper = useMemo(() => isDarkSurface(page.background.color), [page.background.color]);
     const showRulers = doc.settings.showRulers && !render.presenting;
     const selectionRect = useMemo(
         () => (selectedNodes.length > 0 ? nodesBounds(selectedNodes) : null),
@@ -166,10 +169,24 @@ export function Canvas({ callbacks, peers, onCursorMove, children }: CanvasProps
         >
             <svg
                 ref={svgRef}
+                className={styles.paper}
+                // Canvas chrome is bound to the paper, not to the app theme —
+                // read from the background's own lightness so a custom colour
+                // works as well as a named theme.
+                data-paper={darkPaper ? "dark" : "light"}
                 width="100%"
                 height="100%"
                 viewBox={viewBox}
                 style={{
+                    // Absolute, so the canvas can only ever *read* its size and
+                    // never set it. An in-flow `<svg>` with a viewBox is
+                    // intrinsically sized: put one in a parent whose own height
+                    // is content-derived and the two size each other in a loop
+                    // that settles at whatever the viewBox aspect ratio asks
+                    // for. Taking it out of flow makes that unrepresentable —
+                    // the wrapper's `flex: 1` is then the only thing with a say.
+                    position: "absolute",
+                    inset: 0,
                     display: "block",
                     touchAction: "none",
                     cursor: cursorFor(render.tool, interactions.isPanning(), render.drag.kind),

--- a/apps/web/src/app/employer/mindmap/_mindmap/ui/CommentsPanel.tsx
+++ b/apps/web/src/app/employer/mindmap/_mindmap/ui/CommentsPanel.tsx
@@ -108,7 +108,7 @@ export function CommentsPanel({
                 </button>
             </div>
 
-            <ScrollArea className="flex-1">
+            <ScrollArea className="min-h-0 flex-1">
                 <div className="space-y-2 p-3">
                     {threads.length === 0 && (
                         <p className="text-ink-3 py-6 text-center text-[13px]">No comments yet.</p>

--- a/apps/web/src/app/employer/mindmap/_mindmap/ui/HistoryPanel.tsx
+++ b/apps/web/src/app/employer/mindmap/_mindmap/ui/HistoryPanel.tsx
@@ -95,7 +95,7 @@ export function HistoryPanel({
                 </Button>
             </div>
 
-            <ScrollArea className="flex-1">
+            <ScrollArea className="min-h-0 flex-1">
                 <div className="p-2">
                     {loading && (
                         <div className="text-ink-3 flex items-center justify-center gap-2 py-8 text-[13px]">

--- a/apps/web/src/app/employer/mindmap/_mindmap/ui/Inspector.tsx
+++ b/apps/web/src/app/employer/mindmap/_mindmap/ui/Inspector.tsx
@@ -61,8 +61,8 @@ import {
     ungroupSelection,
 } from "../model/commands";
 import { activePage, mapNodes, nodeById } from "../model/doc";
-import { SWATCH_BY_ID, THEMES } from "../model/palette";
 import { SHAPES } from "../model/shapes";
+import { ThemePicker } from "./ThemePicker";
 import type { EditorState } from "../model/store";
 import type {
     ArrowId,
@@ -672,27 +672,10 @@ function PageSettings() {
     return (
         <>
             <Section title="Theme">
-                <div className="grid grid-cols-2 gap-1.5">
-                    {THEMES.map(theme => (
-                        <button
-                            key={theme.id}
-                            type="button"
-                            onClick={() => applyTheme(store, theme.id)}
-                            className="border-line text-ink-2 hover:border-brand hover:bg-brand-soft flex items-center gap-2 rounded-md border px-2 py-1.5 text-left text-[12px] transition-colors"
-                        >
-                            <span className="flex gap-0.5">
-                                {theme.cycle.slice(0, 3).map(id => (
-                                    <span
-                                        key={id}
-                                        className="size-2.5 rounded-full"
-                                        style={{ background: SWATCH_BY_ID[id]?.stroke }}
-                                    />
-                                ))}
-                            </span>
-                            {theme.name}
-                        </button>
-                    ))}
-                </div>
+                <ThemePicker
+                    activeId={doc.settings.paletteId}
+                    onPick={id => applyTheme(store, id)}
+                />
             </Section>
 
             <Section title="Canvas">

--- a/apps/web/src/app/employer/mindmap/_mindmap/ui/MindmapEditor.tsx
+++ b/apps/web/src/app/employer/mindmap/_mindmap/ui/MindmapEditor.tsx
@@ -11,12 +11,14 @@ import {
     X,
 } from "lucide-react";
 
+import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "~/components/ui/resizable";
 import { TooltipProvider } from "~/components/ui/tooltip";
 import { cn } from "~/lib/utils";
 
-import { fitToScreen, setActivePage, viewportCentre } from "../model/commands";
+import { docMode, fitToScreen, setActivePage, viewportCentre } from "../model/commands";
 import { createNodeAt } from "../model/factory";
 import { isImageFile } from "../lib/images";
+import { shapeHoldsText } from "../model/shapes";
 import { parseDoc } from "../model/serialize";
 import { EditorStore, type EditorState } from "../model/store";
 import type { Point, ShapeId } from "../model/types";
@@ -235,11 +237,14 @@ export function MindmapEditor(props: MindmapEditorProps) {
             const world = worldPointAt(e.clientX, e.clientY);
 
             if (shape) {
-                const node = createNodeAt(shape as ShapeId, world);
+                const node = createNodeAt(shape as ShapeId, world, { mode: docMode(store) });
                 store.updatePage(p => ({ ...p, nodes: [...p.nodes, node] }), {
                     label: "Add shape",
                 });
                 store.selectNodes([node.id]);
+                // Same as placing one with the shape tool: land in the label,
+                // so a dropped box asks to be named rather than sitting blank.
+                if (shapeHoldsText(shape)) store.setEditing({ kind: "node", id: node.id });
                 return;
             }
 
@@ -283,100 +288,145 @@ export function MindmapEditor(props: MindmapEditorProps) {
                             />
                         )}
 
-                        {!presenting && leftOpen && (
-                            <aside className="border-line bg-panel flex w-[264px] shrink-0 flex-col border-r">
-                                <nav className="border-line flex shrink-0 border-b">
-                                    <PanelTab
-                                        active={leftTab === "shapes"}
-                                        onClick={() => setLeftTab("shapes")}
-                                        icon={<Shapes className="size-3.5" />}
-                                        label="Shapes"
-                                    />
-                                    <PanelTab
-                                        active={leftTab === "outline"}
-                                        onClick={() => setLeftTab("outline")}
-                                        icon={<Layers className="size-3.5" />}
-                                        label="Outline"
-                                    />
-                                    <PanelTab
-                                        active={leftTab === "comments"}
-                                        onClick={() => setLeftTab("comments")}
-                                        icon={<MessageSquare className="size-3.5" />}
-                                        label="Comments"
-                                    />
-                                    <PanelTab
-                                        active={leftTab === "history"}
-                                        onClick={() => setLeftTab("history")}
-                                        icon={<HistoryIcon className="size-3.5" />}
-                                        label="History"
-                                    />
-                                </nav>
-                                <div className="min-h-0 flex-1">
-                                    {leftTab === "shapes" && <ShapePalette />}
-                                    {leftTab === "outline" && (
-                                        <OutlinePanel canvasSize={stageSize} />
-                                    )}
-                                    {leftTab === "comments" && (
-                                        <CommentsPanel
-                                            author={props.author}
-                                            canvasSize={stageSize}
-                                        />
-                                    )}
-                                    {leftTab === "history" && (
-                                        <HistoryPanel
-                                            mindmapId={props.mindmapId}
-                                            onRestored={autosave.setRevision}
-                                        />
-                                    )}
-                                </div>
-                            </aside>
-                        )}
-
-                        <div
-                            ref={stageRef}
-                            className="relative flex min-h-0 min-w-0 flex-1"
-                            onDragOver={e => {
-                                const types = e.dataTransfer.types;
-                                if (
-                                    types.includes("application/x-launchstack-shape") ||
-                                    types.includes("Files")
-                                ) {
-                                    e.preventDefault();
-                                    e.dataTransfer.dropEffect = "copy";
-                                }
-                            }}
-                            onDrop={onDrop}
+                        {/* The rail stays a fixed strip; only the two panels and
+                            the canvas share the remaining width. `autoSaveId`
+                            persists the split per browser, and the explicit
+                            `id`/`order` are what let a panel be unmounted by its
+                            toggle and come back the same size. */}
+                        <ResizablePanelGroup
+                            direction="horizontal"
+                            autoSaveId="mindmap-editor-panels"
+                            className="min-h-0 flex-1"
                         >
-                            <CanvasContextMenu>
-                                <div className="flex min-h-0 min-w-0 flex-1">
-                                    <Canvas
-                                        callbacks={canvasCallbacks}
-                                        peers={presence.peers}
-                                        onCursorMove={presence.reportCursor}
+                            {!presenting && leftOpen && (
+                                <>
+                                    <ResizablePanel
+                                        id="left"
+                                        order={1}
+                                        defaultSize={19}
+                                        minSize={13}
+                                        maxSize={36}
+                                        className="flex min-h-0 flex-col"
                                     >
-                                        <TextEditorOverlay />
-                                    </Canvas>
-                                </div>
-                            </CanvasContextMenu>
-
-                            <ConnectedStaleBanner staleBy={presence.staleBy} />
-
-                            <FindBar
-                                open={findOpen}
-                                onClose={() => setFindOpen(false)}
-                                canvasSize={stageSize}
-                            />
-
-                            {presenting && (
-                                <PresentationControls onExit={togglePresent} onStep={stepPage} />
+                                        <aside className="border-line bg-panel flex min-h-0 min-w-0 flex-1 flex-col border-r">
+                                            <nav className="border-line flex shrink-0 border-b">
+                                                <PanelTab
+                                                    active={leftTab === "shapes"}
+                                                    onClick={() => setLeftTab("shapes")}
+                                                    icon={<Shapes className="size-3.5" />}
+                                                    label="Shapes"
+                                                />
+                                                <PanelTab
+                                                    active={leftTab === "outline"}
+                                                    onClick={() => setLeftTab("outline")}
+                                                    icon={<Layers className="size-3.5" />}
+                                                    label="Outline"
+                                                />
+                                                <PanelTab
+                                                    active={leftTab === "comments"}
+                                                    onClick={() => setLeftTab("comments")}
+                                                    icon={<MessageSquare className="size-3.5" />}
+                                                    label="Comments"
+                                                />
+                                                <PanelTab
+                                                    active={leftTab === "history"}
+                                                    onClick={() => setLeftTab("history")}
+                                                    icon={<HistoryIcon className="size-3.5" />}
+                                                    label="History"
+                                                />
+                                            </nav>
+                                            <div className="min-h-0 flex-1">
+                                                {leftTab === "shapes" && <ShapePalette />}
+                                                {leftTab === "outline" && (
+                                                    <OutlinePanel canvasSize={stageSize} />
+                                                )}
+                                                {leftTab === "comments" && (
+                                                    <CommentsPanel
+                                                        author={props.author}
+                                                        canvasSize={stageSize}
+                                                    />
+                                                )}
+                                                {leftTab === "history" && (
+                                                    <HistoryPanel
+                                                        mindmapId={props.mindmapId}
+                                                        onRestored={autosave.setRevision}
+                                                    />
+                                                )}
+                                            </div>
+                                        </aside>
+                                    </ResizablePanel>
+                                    <ResizableHandle />
+                                </>
                             )}
-                        </div>
 
-                        {!presenting && rightOpen && (
-                            <aside className="border-line bg-panel w-[268px] shrink-0 border-l">
-                                <Inspector />
-                            </aside>
-                        )}
+                            <ResizablePanel
+                                id="canvas"
+                                order={2}
+                                minSize={30}
+                                className="flex min-h-0"
+                            >
+                                <div
+                                    ref={stageRef}
+                                    className="relative flex min-h-0 min-w-0 flex-1"
+                                    onDragOver={e => {
+                                        const types = e.dataTransfer.types;
+                                        if (
+                                            types.includes("application/x-launchstack-shape") ||
+                                            types.includes("Files")
+                                        ) {
+                                            e.preventDefault();
+                                            e.dataTransfer.dropEffect = "copy";
+                                        }
+                                    }}
+                                    onDrop={onDrop}
+                                >
+                                    <CanvasContextMenu>
+                                        <div className="flex min-h-0 min-w-0 flex-1">
+                                            <Canvas
+                                                callbacks={canvasCallbacks}
+                                                peers={presence.peers}
+                                                onCursorMove={presence.reportCursor}
+                                            >
+                                                <TextEditorOverlay />
+                                            </Canvas>
+                                        </div>
+                                    </CanvasContextMenu>
+
+                                    <ConnectedStaleBanner staleBy={presence.staleBy} />
+
+                                    <FindBar
+                                        open={findOpen}
+                                        onClose={() => setFindOpen(false)}
+                                        canvasSize={stageSize}
+                                    />
+
+                                    {presenting && (
+                                        <PresentationControls
+                                            onExit={togglePresent}
+                                            onStep={stepPage}
+                                        />
+                                    )}
+                                </div>
+                            </ResizablePanel>
+
+                            {!presenting && rightOpen && (
+                                <>
+                                    <ResizableHandle />
+                                    <ResizablePanel
+                                        id="right"
+                                        order={3}
+                                        defaultSize={19}
+                                        minSize={13}
+                                        maxSize={36}
+                                        className="flex min-h-0"
+                                    >
+                                        <aside className="border-line bg-panel min-h-0 min-w-0 flex-1 border-l">
+                                            <Inspector />
+                                        </aside>
+                                    </ResizablePanel>
+                                </>
+                            )}
+                        </ResizablePanelGroup>
                     </div>
 
                     {!presenting && <BottomBar canvasSize={stageSize} />}

--- a/apps/web/src/app/employer/mindmap/_mindmap/ui/ShapePalette.tsx
+++ b/apps/web/src/app/employer/mindmap/_mindmap/ui/ShapePalette.tsx
@@ -7,26 +7,46 @@ import { Input } from "~/components/ui/input";
 import { ScrollArea } from "~/components/ui/scroll-area";
 import { cn } from "~/lib/utils";
 
+import { createNode } from "../model/factory";
+import { themeMode, type ThemeMode } from "../model/palette";
 import { SHAPES, SHAPE_CATEGORIES, shapeGeometry, type ShapeDef } from "../model/shapes";
 import type { EditorState } from "../model/store";
-import type { ShapeCategory, ShapeId } from "../model/types";
-import { useEditor, useStore } from "./EditorContext";
+import type { NodeStyle, ShapeCategory, ShapeId } from "../model/types";
+import { useCommittedDoc, useEditor, useStore } from "./EditorContext";
 
 /**
  * The shape library.
  *
- * Previews are generated from the same `shapeGeometry` the canvas uses, so a
- * thumbnail can never show a shape the canvas would draw differently. Clicking
- * arms the shape tool; dragging drops it straight onto the canvas at the
- * pointer (handled by the editor shell's drop target).
+ * Previews are generated from the same `shapeGeometry` *and* the same
+ * `createNode` presets the canvas uses, so a thumbnail can never show a shape
+ * the canvas would draw differently — a Topic looks like a Topic here, not
+ * like the rounded rectangle it shares an outline with. Clicking arms the
+ * shape tool; dragging drops it straight onto the canvas at the pointer
+ * (handled by the editor shell's drop target).
+ *
+ * Every tile is captioned. Sixty untitled grey outlines is not a library, it
+ * is a memory test — and the two shapes people most need to tell apart
+ * (`Topic` and `Rounded rectangle`) are exactly the two an outline cannot
+ * distinguish.
  */
 
 const selectPending = (s: EditorState) => (s.tool === "shape" ? s.pendingShape : null);
 
+/** Said once per group, where the grouping is doing real work. */
+const CATEGORY_BLURB: Partial<Record<ShapeCategory, string>> = {
+    Nodes: "Type in them, connect them, let auto-layout arrange them.",
+    Annotate: "Marks on the canvas. Not part of the diagram's structure.",
+};
+
 export function ShapePalette() {
     const store = useStore();
     const pending = useEditor(selectPending);
+    const doc = useCommittedDoc();
     const [query, setQuery] = useState("");
+
+    // Previews carry the board's own theme, so a tile shows the colour you are
+    // about to get rather than a light-mode idea of it.
+    const mode = themeMode(doc.settings.paletteId);
 
     const grouped = useMemo(() => {
         const q = query.trim().toLowerCase();
@@ -62,7 +82,7 @@ export function ShapePalette() {
                 />
             </div>
 
-            <ScrollArea className="flex-1">
+            <ScrollArea className="min-h-0 flex-1">
                 <div className="px-3 pb-6 pt-3">
                     {grouped.length === 0 && (
                         <p className="text-ink-3 px-1 py-6 text-center text-[13px]">
@@ -70,15 +90,26 @@ export function ShapePalette() {
                         </p>
                     )}
                     {grouped.map(group => (
-                        <section key={group.category} className="mb-4">
-                            <h3 className="text-ink-3 mb-2 font-mono text-[10px] font-semibold uppercase tracking-[0.08em]">
+                        <section key={group.category} className="mb-5">
+                            <h3 className="text-ink-3 font-mono text-[10px] font-semibold uppercase tracking-[0.08em]">
                                 {group.category}
                             </h3>
-                            <div className="grid grid-cols-4 gap-1">
+                            {CATEGORY_BLURB[group.category] && (
+                                <p className="text-ink-3 mb-2 mt-0.5 text-[11px] leading-snug">
+                                    {CATEGORY_BLURB[group.category]}
+                                </p>
+                            )}
+                            <div
+                                className={cn(
+                                    "grid grid-cols-3 gap-1",
+                                    !CATEGORY_BLURB[group.category] && "mt-2"
+                                )}
+                            >
                                 {group.shapes.map(shape => (
                                     <ShapeTile
                                         key={shape.id}
                                         shape={shape}
+                                        mode={mode}
                                         active={pending === shape.id}
                                         onSelect={() => store.setTool("shape", shape.id)}
                                     />
@@ -97,10 +128,12 @@ const TILE_H = 32;
 
 const ShapeTile = memo(function ShapeTile({
     shape,
+    mode,
     active,
     onSelect,
 }: {
     shape: ShapeDef;
+    mode: ThemeMode;
     active: boolean;
     onSelect: () => void;
 }) {
@@ -117,40 +150,72 @@ const ShapeTile = memo(function ShapeTile({
             }}
             onClick={onSelect}
             className={cn(
-                "flex aspect-square items-center justify-center rounded-md border transition-colors",
+                "flex flex-col items-center gap-1 rounded-md border px-1 pb-1 pt-1.5 transition-colors",
                 active
                     ? "border-brand bg-brand-soft"
                     : "hover:border-line hover:bg-panel-2 border-transparent"
             )}
         >
-            <ShapePreview shapeId={shape.id} />
+            <ShapePreview shapeId={shape.id} mode={mode} />
+            {/* Two lines rather than an ellipsis: "Rounded rect…" and
+                "Predefined pro…" are the names most in need of reading. */}
+            <span className="text-ink-3 line-clamp-2 w-full text-center text-[10px] leading-tight">
+                {shape.name}
+            </span>
         </button>
     );
 });
 
-/** Small outline preview, drawn from the real shape geometry. */
-export function ShapePreview({ shapeId, size = 1 }: { shapeId: ShapeId; size?: number }) {
+/**
+ * The style a freshly created node of this shape gets. Read from `createNode`
+ * rather than restated, so the swatch on the tile is the colour that will
+ * land on the canvas. Cached because `createNode` mints an id each call.
+ */
+const previewStyleCache = new Map<string, { style: NodeStyle }>();
+function previewStyle(shapeId: ShapeId, mode: ThemeMode): { style: NodeStyle } {
+    const key = `${shapeId}:${mode}`;
+    let cached = previewStyleCache.get(key);
+    if (!cached) {
+        cached = { style: createNode({ shape: shapeId, mode, x: 0, y: 0 }).style };
+        previewStyleCache.set(key, cached);
+    }
+    return cached;
+}
+
+/** Small preview, drawn from the real shape geometry and its real preset. */
+export function ShapePreview({
+    shapeId,
+    mode = "light",
+    size = 1,
+}: {
+    shapeId: ShapeId;
+    mode?: ThemeMode;
+    size?: number;
+}) {
     const w = TILE_W * size;
     const h = TILE_H * size;
     const geometry = useMemo(() => shapeGeometry(shapeId, w - 8, h - 8, 4), [shapeId, w, h]);
+    const { style } = previewStyle(shapeId, mode);
+
+    // A tile sits on the panel, not on the board, so an unfilled or unstroked
+    // preset falls back to *chrome* ink rather than the document's. Painting
+    // the board's paper behind each preview was the faithful alternative and
+    // looked like sixty loose cards; the theme still shows through every
+    // shape that has a fill of its own.
+    const fill = style.fill === "none" ? "var(--panel-2)" : style.fill;
+    const stroke = style.stroke === "none" ? "var(--ink-3)" : style.stroke;
 
     return (
         <svg width={w} height={h} viewBox={`0 0 ${w} ${h}`} aria-hidden>
             <g transform="translate(4 4)">
                 {geometry.backing?.map((d, i) => (
-                    <path
-                        key={`b${i}`}
-                        d={d}
-                        fill="var(--panel-2)"
-                        stroke="var(--ink-3)"
-                        strokeWidth={1}
-                    />
+                    <path key={`b${i}`} d={d} fill={fill} stroke={stroke} strokeWidth={1} />
                 ))}
                 {geometry.path ? (
                     <path
                         d={geometry.path}
-                        fill="var(--panel-2)"
-                        stroke="var(--ink-2)"
+                        fill={fill}
+                        stroke={stroke}
                         strokeWidth={1.2}
                         strokeLinejoin="round"
                     />
@@ -160,7 +225,7 @@ export function ShapePreview({ shapeId, size = 1 }: { shapeId: ShapeId; size?: n
                         key={`d${i}`}
                         d={d}
                         fill="none"
-                        stroke="var(--ink-2)"
+                        stroke={stroke}
                         strokeWidth={1.2}
                         strokeLinecap="round"
                     />

--- a/apps/web/src/app/employer/mindmap/_mindmap/ui/TemplateThumbnail.tsx
+++ b/apps/web/src/app/employer/mindmap/_mindmap/ui/TemplateThumbnail.tsx
@@ -2,11 +2,14 @@
 
 import React, { useMemo } from "react";
 
+import { useAppThemeMode } from "./useAppThemeMode";
+
 import { nodeLookup, pageBounds } from "../model/doc";
 import { expandRect } from "../model/geometry";
 import { routeEdge } from "../model/routing";
 import { shapeGeometry } from "../model/shapes";
 import { buildTemplate } from "../model/templates";
+import type { ThemeMode } from "../model/palette";
 import type { MindmapDoc } from "../model/types";
 
 /**
@@ -23,17 +26,21 @@ import type { MindmapDoc } from "../model/types";
 
 const cache = new Map<string, MindmapDoc>();
 
-function templateDoc(templateId: string): MindmapDoc {
-    const cached = cache.get(templateId);
+function templateDoc(templateId: string, mode: ThemeMode): MindmapDoc {
+    const key = `${templateId}:${mode}`;
+    const cached = cache.get(key);
     if (cached) return cached;
-    const doc = buildTemplate(templateId);
-    cache.set(templateId, doc);
+    const doc = buildTemplate(templateId, undefined, mode);
+    cache.set(key, doc);
     return doc;
 }
 
 export function TemplateThumbnail({ templateId }: { templateId: string }) {
+    // Previews are built in the same mode a new document would be seeded in,
+    // so the card is not a light board that turns dark the moment you open it.
+    const mode = useAppThemeMode();
     const { viewBox, nodes, edges, background } = useMemo(() => {
-        const doc = templateDoc(templateId);
+        const doc = templateDoc(templateId, mode);
         const page = doc.pages[0];
         if (!page) {
             return { viewBox: "0 0 100 75", nodes: [], edges: [], background: "var(--panel-2)" };
@@ -47,7 +54,7 @@ export function TemplateThumbnail({ templateId }: { templateId: string }) {
             edges: page.edges.map(e => routeEdge(e, lookup)),
             background: page.background.color,
         };
-    }, [templateId]);
+    }, [templateId, mode]);
 
     if (nodes.length === 0) {
         return (

--- a/apps/web/src/app/employer/mindmap/_mindmap/ui/TextEditorOverlay.tsx
+++ b/apps/web/src/app/employer/mindmap/_mindmap/ui/TextEditorOverlay.tsx
@@ -119,6 +119,15 @@ export function TextEditorOverlay() {
     if (!style) return null;
     const fontSize = style.size * viewport.zoom;
 
+    // The field stands in for the shape, so it has to be painted in the
+    // shape's colours — not the chrome's. `style.color` is document data and
+    // is always a dark ink, because a diagram lives on light paper; pairing it
+    // with `var(--panel)` meant dark-on-near-black in dark theme, i.e. you
+    // could not see what you were typing. An unfilled shape (text, ink,
+    // brackets) and an edge label both sit directly on the paper, so that is
+    // what they get.
+    const surface = node && node.style.fill !== "none" ? node.style.fill : page.background.color;
+
     return (
         <textarea
             ref={ref}
@@ -163,7 +172,7 @@ export function TextEditorOverlay() {
                 borderRadius: 3,
                 resize: "none",
                 overflow: "hidden",
-                background: "var(--panel)",
+                background: surface,
                 color: style.color,
                 fontSize,
                 fontFamily: fontFamilyCss(style.family),

--- a/apps/web/src/app/employer/mindmap/_mindmap/ui/ThemePicker.tsx
+++ b/apps/web/src/app/employer/mindmap/_mindmap/ui/ThemePicker.tsx
@@ -1,0 +1,161 @@
+"use client";
+
+import React from "react";
+import { Check, MoonStar, Sun } from "lucide-react";
+
+import { cn } from "~/lib/utils";
+
+import {
+    counterpartTheme,
+    swatchFor,
+    THEME_BY_ID,
+    THEMES,
+    themeMode,
+    type DocTheme,
+    type ThemeMode,
+} from "../model/palette";
+import { useAppThemeMode } from "./useAppThemeMode";
+
+/**
+ * Document theme picker.
+ *
+ * Each tile is a miniature of the board it will produce — the theme's own
+ * paper, three of its node colours at the fill and stroke they will actually
+ * get, and a connector in its edge colour. Name-plus-three-dots told you a
+ * theme existed but not what it would do, which is why five near-identical
+ * pale themes read as placeholders.
+ *
+ * Light and dark are separated because that is the choice being made. The
+ * board's paper is document data: picking Midnight makes it dark for everyone
+ * who opens the file, not just for the person who is in dark mode right now.
+ */
+
+export interface ThemePickerProps {
+    /** Currently applied theme id, from `doc.settings.paletteId`. */
+    activeId: string | null | undefined;
+    onPick: (themeId: string) => void;
+}
+
+export function ThemePicker({ activeId, onPick }: ThemePickerProps) {
+    const groups: { mode: ThemeMode; label: string; themes: DocTheme[] }[] = [
+        { mode: "light", label: "Light", themes: THEMES.filter(t => t.mode === "light") },
+        { mode: "dark", label: "Dark", themes: THEMES.filter(t => t.mode === "dark") },
+    ];
+
+    return (
+        <div className="flex flex-col gap-3">
+            <MatchAppThemeHint activeId={activeId} onPick={onPick} />
+            {groups.map(group => (
+                <div key={group.mode}>
+                    <p className="text-ink-3 mb-1.5 font-mono text-[10px] uppercase tracking-[0.08em]">
+                        {group.label}
+                    </p>
+                    <div className="grid grid-cols-2 gap-1.5">
+                        {group.themes.map(theme => (
+                            <ThemeTile
+                                key={theme.id}
+                                theme={theme}
+                                active={theme.id === activeId}
+                                onPick={() => onPick(theme.id)}
+                            />
+                        ))}
+                    </div>
+                </div>
+            ))}
+        </div>
+    );
+}
+
+function ThemeTile({
+    theme,
+    active,
+    onPick,
+}: {
+    theme: DocTheme;
+    active: boolean;
+    onPick: () => void;
+}) {
+    const swatches = theme.cycle.slice(0, 3).map(id => swatchFor(id, theme.mode));
+
+    return (
+        <button
+            type="button"
+            onClick={onPick}
+            aria-pressed={active}
+            title={`${theme.name} — ${theme.mode} board`}
+            className={cn(
+                "group flex flex-col gap-1 rounded-md border p-1 text-left transition-colors",
+                active
+                    ? "border-brand ring-brand/30 ring-1"
+                    : "border-line hover:border-ink-4 hover:bg-panel-2"
+            )}
+        >
+            <span
+                className="relative flex h-9 w-full items-center justify-center gap-1 overflow-hidden rounded-[4px]"
+                style={{ background: theme.background }}
+            >
+                {/* A connector behind the nodes, exactly as the canvas paints it. */}
+                <span
+                    aria-hidden
+                    className="absolute left-2 right-2 top-1/2 h-px"
+                    style={{ background: theme.edgeStroke }}
+                />
+                {swatches.map((sw, i) => (
+                    <span
+                        key={`${theme.id}-${i}`}
+                        className="relative h-3.5 w-5 rounded-[3px]"
+                        style={{
+                            background: i === 0 ? sw.stroke : sw.fill,
+                            border: `1px solid ${sw.stroke}`,
+                        }}
+                    />
+                ))}
+            </span>
+            <span className="flex items-center gap-1 px-0.5">
+                <span
+                    className={cn(
+                        "truncate text-[11px]",
+                        active ? "text-brand-ink font-medium" : "text-ink-2"
+                    )}
+                >
+                    {theme.name}
+                </span>
+                {active && <Check className="text-brand ml-auto size-3 shrink-0" />}
+            </span>
+        </button>
+    );
+}
+
+/**
+ * Offered only when the board disagrees with the app around it.
+ *
+ * New documents are already seeded to match, so this is for the ones that
+ * existed before — a white board in a dark app is the single most jarring
+ * thing about opening an old file, and switching it should not require
+ * knowing that Midnight is the dark twin of Launchstack.
+ */
+function MatchAppThemeHint({ activeId, onPick }: ThemePickerProps) {
+    const appMode = useAppThemeMode();
+    if (!activeId) return null;
+    const boardMode = themeMode(activeId);
+    if (boardMode === appMode) return null;
+
+    const target = counterpartTheme(activeId);
+    const targetTheme = THEME_BY_ID[target];
+    if (!targetTheme || targetTheme.mode !== appMode) return null;
+
+    const Icon = appMode === "dark" ? MoonStar : Sun;
+    return (
+        <button
+            type="button"
+            onClick={() => onPick(target)}
+            className="border-line hover:border-brand hover:bg-brand-soft text-ink-2 flex items-center gap-2 rounded-md border border-dashed px-2 py-1.5 text-left text-[11px] leading-snug transition-colors"
+        >
+            <Icon className="text-ink-3 size-3.5 shrink-0" />
+            <span>
+                This board is {boardMode}. Switch it to{" "}
+                <span className="text-ink font-medium">{targetTheme.name}</span> to match the app.
+            </span>
+        </button>
+    );
+}

--- a/apps/web/src/app/employer/mindmap/_mindmap/ui/Toolbar.tsx
+++ b/apps/web/src/app/employer/mindmap/_mindmap/ui/Toolbar.tsx
@@ -12,6 +12,7 @@ import {
     Shapes,
     Spline,
     Square,
+    RectangleHorizontal,
     StickyNote,
     Type,
     type LucideIcon,
@@ -44,6 +45,16 @@ interface ToolEntry {
 const TOOLS: readonly ToolEntry[] = [
     { id: "select", tool: "select", Icon: MousePointer2, label: "Select", hint: "V" },
     { id: "hand", tool: "hand", Icon: Hand, label: "Pan", hint: "H · hold Space" },
+    // The node and the connector are the two halves of "draw me a diagram", so
+    // they sit together at the top rather than the topic hiding in the library.
+    {
+        id: "topic",
+        tool: "shape",
+        shape: "mind-branch",
+        Icon: RectangleHorizontal,
+        label: "Topic",
+        hint: "Box you type in",
+    },
     { id: "connector", tool: "connector", Icon: Spline, label: "Connector", hint: "C" },
     { id: "text", tool: "text", Icon: Type, label: "Text", hint: "T" },
     { id: "sticky", tool: "sticky", Icon: StickyNote, label: "Sticky note", hint: "N" },
@@ -74,7 +85,11 @@ export function Toolbar({ onOpenShapes }: { onOpenShapes: () => void }) {
     const isActive = (entry: ToolEntry) => active === `${entry.tool}:${entry.shape ?? ""}`;
 
     return (
-        <div className="border-line bg-panel flex flex-col items-center gap-1 border-r px-1.5 py-2">
+        // The editor is pinned to the viewport, so on a short window this strip
+        // is the first thing that runs out of room. Scrolling it keeps every
+        // tool reachable; without `shrink-0` on the buttons flex would instead
+        // squash 13 icons into whatever height is left.
+        <div className="border-line bg-panel flex shrink-0 flex-col items-center gap-1 overflow-y-auto border-r px-1.5 py-2">
             {TOOLS.map(entry => (
                 <ToolButton
                     key={entry.id}
@@ -84,7 +99,7 @@ export function Toolbar({ onOpenShapes }: { onOpenShapes: () => void }) {
                 />
             ))}
 
-            <div className="bg-line my-1 h-px w-6" />
+            <div className="bg-line my-1 h-px w-6 shrink-0" />
 
             {QUICK_SHAPES.map(entry => (
                 <ToolButton
@@ -100,7 +115,7 @@ export function Toolbar({ onOpenShapes }: { onOpenShapes: () => void }) {
                     <button
                         type="button"
                         onClick={onOpenShapes}
-                        className="text-ink-2 hover:bg-brand-soft hover:text-brand-ink flex size-9 items-center justify-center rounded-md transition-colors"
+                        className="text-ink-2 hover:bg-brand-soft hover:text-brand-ink flex size-9 shrink-0 items-center justify-center rounded-md transition-colors"
                         aria-label="All shapes"
                     >
                         <Shapes className="size-[18px]" />
@@ -131,7 +146,7 @@ function ToolButton({
                     aria-pressed={active}
                     aria-label={entry.label}
                     className={cn(
-                        "flex size-9 items-center justify-center rounded-md transition-colors",
+                        "flex size-9 shrink-0 items-center justify-center rounded-md transition-colors",
                         active
                             ? "bg-brand text-brand-fg"
                             : "text-ink-2 hover:bg-brand-soft hover:text-brand-ink"

--- a/apps/web/src/app/employer/mindmap/_mindmap/ui/controls.tsx
+++ b/apps/web/src/app/employer/mindmap/_mindmap/ui/controls.tsx
@@ -6,7 +6,7 @@ import { Check, ChevronDown, Minus } from "lucide-react";
 import { Input } from "~/components/ui/input";
 import { cn } from "~/lib/utils";
 
-import { SWATCHES } from "../model/palette";
+import { DARK_SWATCHES, SWATCHES, THEMES } from "../model/palette";
 
 /**
  * Small inspector controls.
@@ -137,7 +137,7 @@ export function NumberField({
                 inputMode="decimal"
             />
             {suffix && (
-                <span className="text-ink-4 pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[10px]">
+                <span className="text-ink-3 pointer-events-none absolute right-2 top-1/2 -translate-y-1/2 text-[10px]">
                     {suffix}
                 </span>
             )}
@@ -233,12 +233,16 @@ export function ColorField({ value, onChange, allowNone, tone = "fill", label }:
                 <span
                     className="border-line size-4 shrink-0 rounded-[3px] border"
                     style={{
-                        background: value === "none" ? "transparent" : value,
+                        // All longhand: React warns when a shorthand and a
+                        // longhand for the same property are both updated on a
+                        // rerender, and the shorthand can silently reset the
+                        // longhand depending on which lands first.
+                        backgroundColor: value === "none" ? "transparent" : value,
                         backgroundImage:
                             value === "none"
                                 ? "linear-gradient(45deg, var(--line) 25%, transparent 25%, transparent 75%, var(--line) 75%)"
-                                : undefined,
-                        backgroundSize: value === "none" ? "6px 6px" : undefined,
+                                : "none",
+                        backgroundSize: value === "none" ? "6px 6px" : "auto",
                     }}
                 />
                 <span className="text-ink-2 flex-1 truncate text-left text-[11px]">
@@ -308,14 +312,21 @@ export function ColorField({ value, onChange, allowNone, tone = "fill", label }:
 }
 
 function nameForColor(value: string, tone: "fill" | "stroke" | "ink"): string {
-    const match = SWATCHES.find(s =>
-        tone === "fill"
-            ? s.fill === value
-            : tone === "stroke"
-              ? s.stroke === value
-              : s.ink === value
-    );
-    return match?.name ?? value.replace(/^oklch\(|\)$/g, "").slice(0, 16);
+    for (const set of [SWATCHES, DARK_SWATCHES]) {
+        const match = set.find(s =>
+            tone === "fill"
+                ? s.fill === value
+                : tone === "stroke"
+                  ? s.stroke === value
+                  : s.ink === value
+        );
+        if (match) return match.name;
+    }
+    // A theme's paper, or a colour someone typed in. Either way the OKLCH
+    // components are not a name — "0.992 0.003 80" tells nobody anything.
+    const theme = THEMES.find(t => t.background === value);
+    if (theme) return `${theme.name} paper`;
+    return "Custom";
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/app/employer/mindmap/_mindmap/ui/useAppThemeMode.ts
+++ b/apps/web/src/app/employer/mindmap/_mindmap/ui/useAppThemeMode.ts
@@ -1,0 +1,34 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import type { ThemeMode } from "../model/palette";
+
+/**
+ * The app's current light/dark setting, read from the `data-theme` attribute
+ * next-themes stamps on `<html>`.
+ *
+ * Starts at "light" and corrects on mount rather than reading during render:
+ * the attribute does not exist on the server, and branching on it during the
+ * first client render is a hydration mismatch. Watching for changes keeps
+ * previews honest when someone flips the app theme with the editor open.
+ */
+export function useAppThemeMode(): ThemeMode {
+    const [mode, setMode] = useState<ThemeMode>("light");
+
+    useEffect(() => {
+        const read = () =>
+            setMode(
+                document.documentElement.getAttribute("data-theme") === "dark" ? "dark" : "light"
+            );
+        read();
+        const observer = new MutationObserver(read);
+        observer.observe(document.documentElement, {
+            attributes: true,
+            attributeFilter: ["data-theme"],
+        });
+        return () => observer.disconnect();
+    }, []);
+
+    return mode;
+}

--- a/apps/web/src/app/employer/mindmap/_mindmap/ui/useCanvasInteractions.ts
+++ b/apps/web/src/app/employer/mindmap/_mindmap/ui/useCanvasInteractions.ts
@@ -16,7 +16,7 @@ import {
     visibleNodes,
     withDescendants,
 } from "../model/doc";
-import { insertShape, scaleNodesToBounds } from "../model/commands";
+import { docMode, insertShape, scaleNodesToBounds } from "../model/commands";
 import { createEdge, createNode, createNodeAt } from "../model/factory";
 import {
     MAX_ZOOM,
@@ -32,7 +32,7 @@ import {
     snap as snapValue,
     zoomAt,
 } from "../model/geometry";
-import { isContainer, shapeDef } from "../model/shapes";
+import { isContainer, shapeDef, shapeHoldsText } from "../model/shapes";
 import { routeEdge, waypointInsertIndex } from "../model/routing";
 import { angleFromCentre, resizeBounds, resizeNode, type ResizeHandle } from "../model/resize";
 import { computeSnap, SNAP_THRESHOLD } from "../model/snapping";
@@ -163,6 +163,22 @@ export function useCanvasInteractions(
 ): CanvasInteractions {
     const gesture = useRef<Gesture>({ ...IDLE });
     const spaceHeld = useRef(false);
+    /**
+     * What the last pointerdown actually landed on.
+     *
+     * `dblclick` cannot be trusted to say: per the DOM spec it fires on the
+     * *nearest common inclusive ancestor* of the two clicks' targets, and the
+     * first click of a double-click selects the shape, which re-renders the
+     * canvas and swaps the element under the cursor. The two targets then
+     * differ and the browser reports their common ancestor — the `<svg>` —
+     * so the handler concluded "empty canvas" and dropped a new topic on top
+     * of the shape you were trying to rename. Pointer events have no such
+     * rule, so the second pointerdown is the honest answer.
+     */
+    const lastHit = useRef<{ nodeId: string | null; edgeId: string | null }>({
+        nodeId: null,
+        edgeId: null,
+    });
     // Callbacks come from the editor shell and change identity every render;
     // routing them through a ref keeps every handler below stable.
     const cb = useRef(callbacks);
@@ -270,6 +286,15 @@ export function useCanvasInteractions(
             const screen = toScreen(e.clientX, e.clientY);
             const target = e.target as Element | null;
             const additive = e.shiftKey || e.metaKey || e.ctrlKey;
+
+            // Before any branch below can return early: a resize handle, a
+            // port and a pan all end the gesture without reaching the general
+            // hit test, and the double-click handler still needs to know what
+            // was under the pointer.
+            lastHit.current = {
+                nodeId: target?.closest("[data-node-id]")?.getAttribute("data-node-id") ?? null,
+                edgeId: target?.closest("[data-edge-id]")?.getAttribute("data-edge-id") ?? null,
+            };
 
             svgRef.current?.setPointerCapture(e.pointerId);
             store.setEditing(null);
@@ -426,6 +451,7 @@ export function useCanvasInteractions(
             if (state.tool === "ink") {
                 const node = createNode({
                     shape: "ink",
+                    mode: docMode(store),
                     x: world.x,
                     y: world.y,
                     w: 1,
@@ -932,9 +958,11 @@ export function useCanvasInteractions(
                     const rect = state.marquee;
                     store.setMarquee(null);
                     const shape = g.insertShape ?? "rectangle";
+                    let insertedId: string;
                     if (g.moved && rect && rect.w > 8 && rect.h > 8) {
                         const node = createNode({
                             shape,
+                            mode: docMode(store),
                             x: rect.x,
                             y: rect.y,
                             w: rect.w,
@@ -945,17 +973,23 @@ export function useCanvasInteractions(
                         });
                         store.selectNodes([node.id]);
                         store.endInteraction();
-                        if (shape === "text" || shape === "sticky") {
-                            cb.current.onEditText({ kind: "node", id: node.id });
-                        }
+                        insertedId = node.id;
                     } else {
                         store.cancelInteraction();
-                        const id = insertShape(store, shape, g.origin);
-                        if (shape === "text" || shape === "sticky") {
-                            cb.current.onEditText({ kind: "node", id });
-                        }
+                        insertedId = insertShape(store, shape, g.origin);
                     }
+                    // Disarm first: `setTool` clears `editing`, so opening the
+                    // label above this line would silently undo it — which is
+                    // why placing a text box or a sticky never did land you in
+                    // the field the way double-clicking one does.
                     store.setTool("select");
+                    // Drop into the label straight away. A box you have to
+                    // discover is double-clickable does not read as a container
+                    // you put words in; one with a caret in it does, and it
+                    // saves the second gesture besides.
+                    if (shapeHoldsText(shape)) {
+                        cb.current.onEditText({ kind: "node", id: insertedId });
+                    }
                     break;
                 }
 
@@ -996,8 +1030,16 @@ export function useCanvasInteractions(
         (e: ReactMouseEvent<SVGSVGElement>) => {
             const state = store.getState();
             if (state.presenting) return;
+
+            // `lastHit` first, `e.target` only as a fallback: see the ref's
+            // docblock for why the event's own target lies here. Reading the
+            // event too covers the case where a double-click arrives without a
+            // preceding pointerdown we saw (synthetic events, some a11y tools).
             const target = e.target as Element | null;
-            const nodeId = target?.closest("[data-node-id]")?.getAttribute("data-node-id");
+            const nodeId =
+                lastHit.current.nodeId ??
+                target?.closest("[data-node-id]")?.getAttribute("data-node-id") ??
+                null;
             if (nodeId) {
                 const page = activePage(state.doc);
                 const node = nodeById(page, nodeId);
@@ -1006,7 +1048,10 @@ export function useCanvasInteractions(
                 cb.current.onEditText({ kind: "node", id: nodeId });
                 return;
             }
-            const edgeId = target?.closest("[data-edge-id]")?.getAttribute("data-edge-id");
+            const edgeId =
+                lastHit.current.edgeId ??
+                target?.closest("[data-edge-id]")?.getAttribute("data-edge-id") ??
+                null;
             if (edgeId) {
                 store.setSelection([{ kind: "edge", id: edgeId }]);
                 cb.current.onEditText({ kind: "edge-label", id: edgeId, index: 0 });
@@ -1014,7 +1059,7 @@ export function useCanvasInteractions(
             }
             // Empty canvas: drop a topic where they clicked and start typing.
             const world = toWorld(e.clientX, e.clientY);
-            const node = createNodeAt("mind-branch", world);
+            const node = createNodeAt("mind-branch", world, { mode: docMode(store) });
             store.updatePage(p => ({ ...p, nodes: [...p.nodes, node] }), { label: "Add topic" });
             store.selectNodes([node.id]);
             cb.current.onEditText({ kind: "node", id: node.id });
@@ -1177,6 +1222,7 @@ function finishConnect(store: EditorStore, g: Gesture, world: Point): void {
         // The new topic inherits its parent's look unless the parent is the
         // root, whose filled-pill styling would swamp a child.
         created = createNodeAt("mind-branch", world, {
+            mode: docMode(store),
             w: source && source.shape !== "mind-root" ? source.w : 160,
             h: source && source.shape !== "mind-root" ? source.h : 54,
         });

--- a/apps/web/src/app/employer/mindmap/_mindmap/ui/useClipboardPaste.ts
+++ b/apps/web/src/app/employer/mindmap/_mindmap/ui/useClipboardPaste.ts
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 import { fitImageBox, isImageFile, loadImageFile } from "../lib/images";
 import { instantiate, parsePayload } from "../model/clipboard";
 import { createNodeAt } from "../model/factory";
+import { docMode } from "../model/commands";
 import { parseDoc } from "../model/serialize";
 import type { EditorStore } from "../model/store";
 import type { Point } from "../model/types";
@@ -121,6 +122,7 @@ function insertText(store: EditorStore, text: string, at: Point): void {
     const trimmed = text.trim();
     const multiline = trimmed.includes("\n");
     const node = createNodeAt(multiline ? "sticky" : "text", at, {
+        mode: docMode(store),
         text: trimmed.slice(0, 5000),
         ...(multiline ? {} : { w: Math.min(Math.max(trimmed.length * 8, 80), 520), h: 40 }),
     });

--- a/apps/web/src/app/employer/mindmap/_mindmap/ui/useKeyboard.ts
+++ b/apps/web/src/app/employer/mindmap/_mindmap/ui/useKeyboard.ts
@@ -19,10 +19,11 @@ import {
     tidyUp,
     toggleLock,
     ungroupSelection,
+    setZoom,
+    zoomByStep,
     zoomToSelection,
 } from "../model/commands";
 import { activePage, nodeById } from "../model/doc";
-import { nextZoomStep } from "../model/geometry";
 import type { EditorStore } from "../model/store";
 import type { ShapeId, ToolId } from "../model/types";
 
@@ -194,7 +195,7 @@ export function useKeyboard(store: EditorStore, actions: KeyboardActions): void 
                         return;
                     case "0":
                         e.preventDefault();
-                        store.setViewport({ zoom: 1 });
+                        setZoom(store, 1, ref.current.getViewportSize());
                         return;
                     case "1":
                         e.preventDefault();
@@ -207,11 +208,12 @@ export function useKeyboard(store: EditorStore, actions: KeyboardActions): void 
                     case "=":
                     case "+":
                         e.preventDefault();
-                        store.setViewport({ zoom: nextZoomStep(state.viewport.zoom, 1) });
+                        zoomByStep(store, 1, ref.current.getViewportSize());
                         return;
                     case "-":
+                    case "_":
                         e.preventDefault();
-                        store.setViewport({ zoom: nextZoomStep(state.viewport.zoom, -1) });
+                        zoomByStep(store, -1, ref.current.getViewportSize());
                         return;
                     default:
                         break;
@@ -287,6 +289,20 @@ export function useKeyboard(store: EditorStore, actions: KeyboardActions): void 
             if (key === "/") {
                 e.preventDefault();
                 ref.current.onFind();
+                return;
+            }
+
+            // Bare +/- zoom, the way every canvas app does it. Safe here
+            // because this whole handler already bailed out for typing
+            // targets, so it cannot eat a minus sign someone is writing.
+            if (lower === "+" || lower === "=") {
+                e.preventDefault();
+                zoomByStep(store, 1, ref.current.getViewportSize());
+                return;
+            }
+            if (lower === "-" || lower === "_") {
+                e.preventDefault();
+                zoomByStep(store, -1, ref.current.getViewportSize());
                 return;
             }
 
@@ -371,8 +387,10 @@ export const SHORTCUTS: readonly ShortcutGroup[] = [
             { keys: "⌘0", label: "Zoom to 100%" },
             { keys: "⌘1", label: "Fit to screen" },
             { keys: "⌘2", label: "Zoom to selection" },
+            { keys: "+ / −", label: "Zoom in / out" },
             { keys: "⌘= / ⌘-", label: "Zoom in / out" },
             { keys: "⌘-scroll", label: "Zoom at the cursor" },
+            { keys: "Scroll", label: "Pan · ⇧ for sideways" },
             { keys: "⌘F or /", label: "Find on canvas" },
             { keys: "⌘K", label: "Command palette" },
             { keys: "⌘S", label: "Save now" },

--- a/packages/design-tokens/tokens.css
+++ b/packages/design-tokens/tokens.css
@@ -88,10 +88,16 @@
     --bg-sunk: oklch(0.972 0.005 80);
     --panel: #ffffff;
     --panel-2: oklch(0.985 0.004 280);
-    --ink: oklch(0.22 0.015 280);
-    --ink-2: oklch(0.42 0.01 280);
-    --ink-3: oklch(0.6 0.008 280);
-    --ink-4: oklch(0.78 0.006 280);
+    /* The ink ladder is a contrast contract, not just a lightness ramp.
+       Measured against every surface in this block (--panel, --panel-2, --bg,
+       --bg-2): ink and ink-2 are body copy and clear AA comfortably; ink-3 is
+       the smallest tier still used for real prose and must clear 4.5:1; ink-4
+       is de-emphasised UI and must clear 3:1. The old 0.60/0.78 pair measured
+       3.9:1 and 2.0:1 on white — captions nobody could read. */
+    --ink: oklch(0.22 0.015 280); /* 17.3:1 on --panel */
+    --ink-2: oklch(0.42 0.01 280); /* 8.4:1 */
+    --ink-3: oklch(0.55 0.008 280); /* 4.9:1 */
+    --ink-4: oklch(0.63 0.006 280); /* 3.4:1 — never body text */
     --line: oklch(0.9 0.006 280);
     --line-2: oklch(0.955 0.004 280);
     --line-dot: oklch(0.78 0.012 285);
@@ -120,6 +126,48 @@
     --code-line: oklch(0.32 0.03 280);
     --code-accent: oklch(0.75 0.16 285);
     --code-accent-soft: oklch(0.75 0.16 285 / 0.12);
+
+    /* ── Semantic: paper surface (follows the document, not the app) ─
+        A diagram's background and shape colours are stored in the
+        document so every viewer sees the same picture, which means the
+        mindmap canvas cannot follow the viewer's theme. Chrome painted
+        *onto* that paper — selection handles, ports, guides, arrowheads,
+        grid dots — must not follow it either: in dark theme `--ink-2`
+        rises to 0.80 lightness and would vanish against a board that
+        happens to be white.
+
+        So there are two complete sets and the canvas picks between them
+        from the page background's own lightness. Both live here and
+        neither is overridden in the dark block below — the app theme has
+        no vote. Same idea as the code surface above, which stays dark
+        whichever way the app is pointing. */
+    --paper-panel: #ffffff;
+    --paper-panel-2: oklch(0.97 0.004 280);
+    --paper-ink: oklch(0.22 0.015 280);
+    --paper-ink-2: oklch(0.42 0.01 280);
+    --paper-ink-3: oklch(0.6 0.008 280);
+    --paper-ink-4: oklch(0.78 0.006 280);
+    --paper-line: oklch(0.9 0.006 280);
+    --paper-line-2: oklch(0.955 0.004 280);
+    --paper-line-dot: oklch(0.78 0.012 285);
+    --paper-accent: oklch(0.54 0.24 var(--accent-h));
+    --paper-warn: oklch(0.7 0.16 75);
+
+    /* …and the set for a board whose own paper is dark. Selected by the
+       canvas from the page background's lightness, not by the app theme:
+       a dark board stays dark for a viewer in light mode, because the
+       background is the document's, not theirs. */
+    --paper-dark-panel: oklch(0.28 0.02 285);
+    --paper-dark-panel-2: oklch(0.24 0.018 285);
+    --paper-dark-ink: oklch(0.96 0.004 280);
+    --paper-dark-ink-2: oklch(0.84 0.008 280);
+    --paper-dark-ink-3: oklch(0.68 0.01 280);
+    --paper-dark-ink-4: oklch(0.52 0.012 280);
+    --paper-dark-line: oklch(0.42 0.02 285);
+    --paper-dark-line-2: oklch(0.32 0.018 285);
+    --paper-dark-line-dot: oklch(0.42 0.02 285);
+    --paper-dark-accent: oklch(0.76 0.18 var(--accent-h));
+    --paper-dark-warn: oklch(0.82 0.16 75);
 
     /* ── Shadows ────────────────────────────────────────────────── */
     --shadow-1: 0 1px 2px oklch(0.2 0.02 285 / 0.04);
@@ -151,10 +199,12 @@
     --bg-sunk: oklch(0.12 0.02 290);
     --panel: oklch(0.2 0.025 290);
     --panel-2: oklch(0.235 0.03 290);
-    --ink: oklch(0.97 0.005 280);
-    --ink-2: oklch(0.8 0.008 280);
-    --ink-3: oklch(0.62 0.008 280);
-    --ink-4: oklch(0.45 0.008 280);
+    /* Same contract as the light ladder above. 0.45 measured 2.4:1 on
+       --panel, which is why small labels were effectively invisible here. */
+    --ink: oklch(0.97 0.005 280); /* 16.7:1 on --panel */
+    --ink-2: oklch(0.8 0.008 280); /* 9.7:1 */
+    --ink-3: oklch(0.66 0.008 280); /* 5.9:1 */
+    --ink-4: oklch(0.54 0.008 280); /* 3.6:1 — never body text */
     --line: oklch(0.32 0.04 290);
     --line-2: oklch(0.26 0.035 290);
     --line-dot: oklch(0.55 0.02 285);


### PR DESCRIPTION
Five things were wrong with the mindmap editor, and one of them was also wrong for the rest of the app.

**The editor did not fit the screen.** Nothing between <body> and the canvas had a *definite* height: DriftShell used `min-height: 100vh`, and its `flex: 1` on immersive children resolved to `flex-basis: 0%`, which silently discarded ToolsStudioShell's own `height: 100vh`. That left the canvas `<svg width="100%" height="100%" viewBox=…>` intrinsically sized inside a content-sized parent, and the two sized each other in a loop — the page measured 969,948px tall on a 720px viewport. Fit-to-screen then framed the diagram against a million-pixel stage, which is why the canvas looked empty. Pinning the immersive branch fixes it; making the svg absolute makes the loop unrepresentable. Three panels were missing `min-h-0` and pushed past the viewport too.

**The palette could not be read.** Sixty unlabelled grey outlines, with `Topic` and `Rounded rectangle` sharing one. The "Mindmap" group was a grab-bag of topics plus Sticky/Text/Image/Ink/Line. Split into `Nodes` (type in them, connect them) and `Annotate` (marks on the canvas), captioned every tile, and previewed each with the colour `createNode` will actually give it. Placing any shape now opens its label — which turned out to be broken for text and stickies too, because `setTool` clears `editing` and ran *after* `onEditText`.

**Panels were fixed-width.** Now ResizablePanelGroup, persisted per browser.

**The board stayed white in dark mode.** Board colours are document data, so dark mode has to be a document theme: ten of them now, five light and five dark, paired as counterparts. New documents are seeded from the viewer's app theme; existing ones get a one-click switch. The picker shows a real miniature of each board and marks the active one — the old name-plus-three-dots gave no way to tell five pale themes apart, which is why they read as placeholders. Chrome drawn *on* the paper now follows the paper via a `--paper-*` token set selected by the background's own lightness, so selection handles and arrowheads stop inverting.

**Contrast was failing, app-wide.** The ink ladder in tokens.css was never checked: light `--ink-3` measured 3.9:1 and `--ink-4` 2.0:1 on white; dark `--ink-4` 2.4:1. Those are the captions nobody could read. Both ladders now carry a stated contract — ink-3 ≥4.5:1 for prose, ink-4 ≥3:1 — and a full-page sweep reports zero failures in either theme. Two swatches moved (green and amber strokes) to satisfy the same rule on the canvas, and root-topic ink is now chosen by measurement rather than by mode.

**Zoom scaled about the world origin,** so the board flew off screen. Now centre-anchored, with +/-, ⌘±, ⌘0/1/2 and a menu that names them.

**Double-click created a box instead of editing one.** `dblclick` fires on the nearest common ancestor of the two clicks' targets, and selecting the shape on the first click re-renders the canvas, so the reported target was the `<svg>` and the handler concluded "empty canvas". It now reads what pointerdown actually hit.

Contrast is a tested property over the whole palette rather than a matter of taste, so a new swatch or theme cannot quietly ship something unreadable. 465 tests pass (38 new); tsc and eslint clean, with no new lint warnings.

`/dev/mindmap` mounts the editor in the real chrome chain without a Clerk session, following the existing `dev/source-rail` pattern; it 404s in production.

## Summary

<!-- Why is this change needed? What does it do? 1-3 bullets. -->

## Related

<!-- Closes #123, Fixes #456, etc. -->

## Checklist

- [ ] `pnpm check` passes (lint + typecheck)
- [ ] `pnpm --filter @launchstack/web test` passes
- [ ] Changeset added (if `packages/core/` changed — `pnpm changeset`)
- [ ] New env vars documented in `.env.example` and `apps/web/src/env.ts`
- [ ] UI changes exercised in a browser (not just a green build)
- [ ] Docs updated if behavior changed

## Testing

<!-- How did you verify this works? Commands run, scenarios covered, screenshots for UI. -->

## Notes for reviewers

<!-- Anything non-obvious: design trade-offs, follow-ups deferred, risky areas. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared immersive layout (`DriftShell`, `ToolsStudioShell`, documents workspace) and persisted document colors. Layout regressions could affect other full-viewport tools; theme changes rewrite node/edge colors when a theme is applied.
> 
> **Overview**
> Pins immersive tools to a **definite viewport height** so the mindmap canvas no longer inflates to hundreds of thousands of pixels. `DriftShell` now uses `height: 100dvh` when a `data-drift-immersive` child is present, immersive flex-basis is `auto`, and the canvas `<svg>` is absolutely positioned. `ToolsStudioShell` and the documents workspace switch from `vh` to `dvh`.
> 
> **Document themes** are now stored board lighting, not the viewer’s app theme: five dark counterparts (Midnight, Carbon, Abyss, Ember, Pine), dark swatches, and `applyThemeToDoc` that repaints every page (including unfilled captions). New maps seed from the creator’s app theme. Canvas chrome follows the paper via `--paper-*` tokens and `data-paper`. App-wide `--ink-3`/`--ink-4` are darkened to meet AA.
> 
> Editor UX: resizable side panels, captioned **Nodes / Annotate** palette with real presets, Topic on the tool rail, place-to-edit (after disarming the tool), centre-anchored zoom (`+/-`, ⌘0/1/2), and double-click that uses the last pointer hit so renaming a shape no longer drops a new topic. Adds a non-prod `/dev/mindmap` harness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c493acb5da70d694ee0de2d4cc06a1e47d040f44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->