### PR TITLE
fix: unbreak document ingestion (docling to_formats) and OpenRouter chat model ids

### DIFF
--- a/apps/web/config/chat-models.yaml
+++ b/apps/web/config/chat-models.yaml
@@ -17,27 +17,29 @@
 version: 1
 
 models:
-  # Default: Google Gemini. Reached at
-  # CHAT_BASE_URL=https://generativelanguage.googleapis.com/v1beta/openai,
-  # which is also where chat falls back when CHAT_BASE_URL is unset.
+  # Default: Google Gemini, reached through OpenRouter
+  # (CHAT_BASE_URL=https://openrouter.ai/api/v1).
   #
-  # Model ids here are the BARE ids Google's endpoint expects. The `google/`
-  # prefix belongs only to the `preset:` field, which names a bundled behavior
-  # entry — see packages/core/src/llm/presets.ts.
+  # Ids are sent to the endpoint verbatim, so they carry OpenRouter's `google/`
+  # vendor prefix. Talking to Google's own compatibility endpoint
+  # (https://generativelanguage.googleapis.com/v1beta/openai, also the fallback
+  # when CHAT_BASE_URL is unset) instead? Drop the prefix from `id:` — it
+  # expects the bare ids. The `preset:` field is unaffected either way: it names
+  # a bundled behavior entry, not a model on the endpoint.
   primary:
-    id: gemini-2.5-flash
+    id: google/gemini-2.5-flash
     preset: google/gemini-2.5-flash
 
   # The cheap tier. Its preset sets reasoning `default: none`, so routine work
   # does not pay for thinking tokens.
   fast:
-    id: gemini-2.5-flash-lite
+    id: google/gemini-2.5-flash-lite
     preset: google/gemini-2.5-flash-lite
 
   # The reasoning tier. 2.5 Pro always reasons, so its preset omits the `none`
   # level rather than claiming a capability the endpoint would reject.
   deep:
-    id: gemini-2.5-pro
+    id: google/gemini-2.5-pro
     preset: google/gemini-2.5-pro
 
   # Talking to something else instead? Any OpenAI-compatible endpoint works —

--- a/services/document-converter/src/docling.ts
+++ b/services/document-converter/src/docling.ts
@@ -1,6 +1,6 @@
 /**
  * docling-serve client — the consolidation of the old ocr-worker's
- * docling_runner.py. Same conversion parameters (to_formats=["md"], do_ocr,
+ * docling_runner.py. Same conversion parameters (to_formats=md, do_ocr,
  * do_table_structure, image_export_mode=placeholder); failures surface as
  * typed ServiceErrors instead of opaque 500s.
  */
@@ -25,7 +25,10 @@ export const doclingConvertFile: DoclingConvert = async (config, file, filename)
 
     const form = new FormData();
     form.append("files", new Blob([new Uint8Array(file)]), filename);
-    form.append("to_formats", '["md"]');
+    // One repeated form field per format. docling-serve validates each entry
+    // against its OutputFormat enum, so a JSON-encoded array ("[\"md\"]")
+    // arrives as a single bogus member and the request fails 422.
+    form.append("to_formats", "md");
     form.append("do_ocr", "true");
     form.append("do_table_structure", "true");
     form.append("image_export_mode", "placeholder");

--- a/services/document-converter/test/docling.test.ts
+++ b/services/document-converter/test/docling.test.ts
@@ -39,7 +39,7 @@ describe("doclingConvertFile outgoing request", () => {
         expect(form).toBeInstanceOf(FormData);
         expect(form!.get("md_page_break_placeholder")).toBe(PAGE_BREAK_PLACEHOLDER);
         // Pre-existing conversion parameters stay intact.
-        expect(form!.get("to_formats")).toBe('["md"]');
+        expect(form!.get("to_formats")).toBe("md");
         expect(form!.get("do_ocr")).toBe("true");
         expect(form!.get("do_table_structure")).toBe("true");
         expect(form!.get("image_export_mode")).toBe("placeholder");


### PR DESCRIPTION
Two independent bugs found while bringing the Compose stack up and testing document ingestion end to end. Both broke a core path silently, and both were verified against the running stack rather than reasoned about.

## 1. Document ingestion was completely broken (`services/document-converter`)

Every Office/PDF upload failed. `docling-serve` validates each `to_formats` entry against its `OutputFormat` enum, but the client sent the JSON string `'["md"]'`, so the entire string arrived as one bogus enum member:

```json
{"detail":[{"type":"enum","loc":["body","to_formats",0],
 "msg":"Input should be 'md', 'json', 'yaml', 'html', ..."}]}
```

The failure chain, and why it was hard to spot:

1. `POST /v1/convert/file` → **422**
2. Converter surfaced a typed `502 docling-failed`
3. Worker retried 3×, then parked the outbox event with backoff
4. Zero chunks produced
5. Retrieval found nothing, and the QA route answered **"No relevant content found for the given question."** — byte-identical to the message for an empty workspace

So a fully broken ingestion pipeline was indistinguishable from a workspace with no documents. Diagnosing it required querying `pdr_ai_v2_event_outbox.last_error` directly, because the client discards docling's response body and logs only the status code.

**Verified both directions against the running service:** `'["md"]'` → 422, `"md"` → 200 with the expected `md_content`. After the fix the parked event processed on first retry and produced **8 embedded retrieval chunks** from a real `.docx`.

The unit test asserted the JSON-array form, so it had pinned the broken shape and would have blocked this fix in CI. Updated to match.

## 2. Chat 404'd on every request (`apps/web/config/chat-models.yaml`)

`chat-models.yaml` declared bare Gemini ids (`gemini-2.5-flash`) while `CHAT_BASE_URL` points at `https://openrouter.ai/api/v1`. Ids go to the endpoint verbatim and OpenRouter serves `google/gemini-2.5-flash`, not the bare name — so every chat request failed.

Only the `id:` fields change. The `preset:` keys already carried the `google/` prefix, because they name a bundled behavior entry rather than a model on the endpoint — they were correct as written.

The comment above the block described the ids as "the BARE ids Google's endpoint expects" and no longer matched, so it now explains both directions: keep the prefix for OpenRouter, drop it for Google's own compatibility endpoint.

## Reviewer notes

- **The docling break was not caused by anything in this repo.** `docker-compose.yml:240` is `image: ghcr.io/docling-project/docling-serve` with **no tag**, so it resolves to `latest` and the image moved underneath us. Every `docker compose pull` re-rolls that dice. **Pinning it to a tag or digest is deliberately not in this PR** — it's a separate call about how this project wants to handle upstream image drift, but it's the fix for the whole class of problem.
- **Consider logging docling's response body** on non-2xx in `docling.ts`. The 422 detail names the exact offending field; discarding it turned a one-line bug into a database-archaeology session.
- The two commits are independent and can be split if preferred.
- `services/*` is outside the pnpm workspace, so its vitest suite was not run locally — the `document-converter` CI job covers it. The behavioral fix was verified directly against the live service instead.

Related: #355 (the empty-state message that made this so hard to diagnose).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches document conversion and default chat model routing—core user paths—but the edits are small, well-scoped contract/config fixes with an updated unit assertion.
> 
> **Overview**
> Restores two broken core paths: document ingestion and default chat.
> 
> **Ingestion:** `docling-serve` now receives `to_formats` as the enum value `md` instead of the JSON string `["md"]`, which was rejected as 422 and left uploads looking like an empty workspace. The converter unit test is updated to pin the correct form field.
> 
> **Chat:** Default Gemini `id`s in `chat-models.yaml` get OpenRouter’s `google/` prefix so they match `CHAT_BASE_URL`. Presets are unchanged. Comments now say to drop the prefix if talking to Google’s own compatibility endpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b42225d0fb7cf7542165c303f8377bdd2cad7df9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->