### PR TITLE
Lau 22 document storage port

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -199,7 +199,27 @@ INNGEST_EVENT_KEY="local"
 # "database" → base64 in Postgres (no-S3 fallback)
 # Unset → auto-detect based on S3 vars
 
+# S3-compatible variable reference (B5):
+#   STORAGE_S3_ENDPOINT              Required. Provider/API endpoint used by server SDK.
+#   STORAGE_S3_PUBLIC_ENDPOINT       Optional. URL base used when minting object URLs.
+#   STORAGE_S3_REGION                Required for S3 mode (use provider region or "us-east-1").
+#   STORAGE_S3_ACCESS_KEY            Required. Access key id for SDK auth.
+#   STORAGE_S3_SECRET_KEY            Required. Secret access key for SDK auth.
+#   STORAGE_S3_BUCKET_NAME           Required. Bucket/container name.
+#   STORAGE_S3_FORCE_PATH_STYLE      Optional. true|false, default true.
+#   STORAGE_S3_ENSURE_BUCKET_EXISTS  Optional. true|false, default false (opt-in create/head).
+
 # NEXT_PUBLIC_STORAGE_PROVIDER="s3"
+# STORAGE_S3_ENDPOINT="http://localhost:8333"      # preferred alias (falls back to NEXT_PUBLIC_S3_ENDPOINT)
+# STORAGE_S3_PUBLIC_ENDPOINT=""                     # preferred alias (falls back to S3_PUBLIC_ENDPOINT or endpoint)
+# STORAGE_S3_REGION="us-east-1"                     # preferred alias (falls back to S3_REGION)
+# STORAGE_S3_ACCESS_KEY="pdr_local_key"             # preferred alias (falls back to S3_ACCESS_KEY)
+# STORAGE_S3_SECRET_KEY="pdr_local_secret"          # preferred alias (falls back to S3_SECRET_KEY)
+# STORAGE_S3_BUCKET_NAME="pdr-documents"            # preferred alias (falls back to S3_BUCKET_NAME)
+# STORAGE_S3_FORCE_PATH_STYLE="true"                # default true; set false for virtual-host requests
+# STORAGE_S3_ENSURE_BUCKET_EXISTS="false"           # default false; set true only when auto-create is desired
+#
+# Legacy names (still supported):
 # NEXT_PUBLIC_S3_ENDPOINT="http://localhost:8333"
 # S3_PUBLIC_ENDPOINT=""   # Browser-facing S3 URL (defaults to NEXT_PUBLIC_S3_ENDPOINT)
 # S3_REGION="us-east-1"

--- a/.env.example
+++ b/.env.example
@@ -177,9 +177,10 @@ ADEU_SERVICE_URL="http://localhost:8000"
 
 # ── File Upload (optional) ──────────────────────────────────────────
 
+# UploadThing browser-upload feature flag.
 NEXT_PUBLIC_UPLOADTHING_ENABLED="true"
-# UPLOADTHING_TOKEN="..."
-# BLOB_READ_WRITE_TOKEN="..."
+# UPLOADTHING_TOKEN="..."       # UploadThing server token for uploads/storage (app/region identity)
+# BLOB_READ_WRITE_TOKEN="..."   # Vercel Blob server token for object storage (store identity)
 
 # ── Background Jobs ─────────────────────────────────────────────────
 
@@ -196,8 +197,13 @@ INNGEST_EVENT_KEY="local"
 
 # ── File Storage ────────────────────────────────────────────────────
 # "s3" → any S3-compatible endpoint (AWS, MinIO, SeaweedFS)
-# "database" → base64 in Postgres (no-S3 fallback)
+# "vercel-blob" → Vercel Blob object storage; requires BLOB_READ_WRITE_TOKEN
+# "uploadthing" → UploadThing object storage; requires UPLOADTHING_TOKEN
+# "database" → base64 in Postgres (no-S3 fallback; location: database:pdr_file_uploads_v1)
 # Unset → auto-detect based on S3 vars
+#
+# Fixed-intent writes (GitHub repositories, video transcripts, and processDocument
+# artifacts) target Vercel Blob explicitly through forAdapter("vercel-blob").
 
 # S3-compatible variable reference (B5):
 #   STORAGE_S3_ENDPOINT              Required. Provider/API endpoint used by server SDK.

--- a/apps/web/__tests__/api/adeu/modifyDocument.bugcondition.test.ts
+++ b/apps/web/__tests__/api/adeu/modifyDocument.bugcondition.test.ts
@@ -12,6 +12,17 @@ import * as fs from "fs";
 import * as path from "path";
 
 const mockVercelBlobPut = jest.fn();
+const mockStorageGet = jest.fn();
+const mockDocumentRef = {
+    adapter: "vercel-blob" as const,
+    storageLocationId: "vercel-blob:test-store",
+    key: "documents/original.docx",
+};
+const mockPromoteLegacyUrlToRef = jest.fn((_input: unknown) => ({
+    ok: true as const,
+    ref: mockDocumentRef,
+    confidence: "medium" as const,
+}));
 const mockForAdapter = jest.fn((_adapter: unknown) => ({ put: mockVercelBlobPut }));
 
 // ---------------------------------------------------------------------------
@@ -49,13 +60,15 @@ jest.mock("~/server/services/storage-manifest", () => ({
 jest.mock("~/server/engine", () => ({
     getEngine: jest.fn(() => ({
         storage: {
+            get: (input: unknown, init?: RequestInit) =>
+                init === undefined ? mockStorageGet(input) : mockStorageGet(input, init),
             forAdapter: (adapter: unknown) => mockForAdapter(adapter),
         },
     })),
 }));
 
-jest.mock("~/server/storage/vercel-blob", () => ({
-    fetchBlob: jest.fn(),
+jest.mock("~/server/storage/legacy-promote", () => ({
+    promoteLegacyUrlToRef: (input: unknown) => mockPromoteLegacyUrlToRef(input),
 }));
 
 jest.mock("@launchstack/features/adeu", () => ({
@@ -74,7 +87,6 @@ jest.mock("@launchstack/features/adeu", () => ({
 
 import { modifyDocument } from "~/server/inngest/functions/modifyDocument";
 import { db } from "~/server/db";
-import { fetchBlob } from "~/server/storage/vercel-blob";
 import { processDocumentBatch } from "@launchstack/features/adeu";
 
 // ---------------------------------------------------------------------------
@@ -101,7 +113,7 @@ describe("Fix 1.1: Step output uses blob storage — large DOCX stored as blob U
         // Create a ~3 MB buffer. Base64 encoding inflates by ~33%, so 3 MB → ~4 MB base64.
         const largeFakeDocx = Buffer.alloc(3 * 1024 * 1024, 0x41); // 3 MB of 'A'
 
-        (fetchBlob as jest.Mock).mockResolvedValueOnce({
+        mockStorageGet.mockResolvedValueOnce({
             ok: true,
             arrayBuffer: () =>
                 Promise.resolve(

--- a/apps/web/__tests__/api/adeu/modifyDocument.bugcondition.test.ts
+++ b/apps/web/__tests__/api/adeu/modifyDocument.bugcondition.test.ts
@@ -11,6 +11,9 @@
 import * as fs from "fs";
 import * as path from "path";
 
+const mockVercelBlobPut = jest.fn();
+const mockForAdapter = jest.fn((_adapter: unknown) => ({ put: mockVercelBlobPut }));
+
 // ---------------------------------------------------------------------------
 // We import the real modifyDocument to inspect its config/structure.
 // Mocks are only needed for tests that actually execute the handler.
@@ -20,12 +23,39 @@ jest.mock("~/server/db", () => ({
     db: {
         update: jest.fn(),
         select: jest.fn(),
+        transaction: jest.fn(async (callback: (tx: unknown) => unknown) =>
+            callback({
+                select: jest.fn(() => ({
+                    from: jest.fn(() => ({
+                        where: jest.fn().mockResolvedValue([{ companyId: 1n }]),
+                    })),
+                })),
+                update: jest.fn(() => ({
+                    set: jest.fn(() => ({
+                        where: jest.fn().mockResolvedValue([]),
+                    })),
+                })),
+            }),
+        ),
     },
+}));
+
+jest.mock("~/server/services/storage-manifest", () => ({
+    findObjectByRef: jest.fn().mockResolvedValue(undefined),
+    registerArtifactEdge: jest.fn().mockResolvedValue(undefined),
+    registerObject: jest.fn().mockResolvedValue({ id: 1, companyId: 1n }),
+}));
+
+jest.mock("~/server/engine", () => ({
+    getEngine: jest.fn(() => ({
+        storage: {
+            forAdapter: (adapter: unknown) => mockForAdapter(adapter),
+        },
+    })),
 }));
 
 jest.mock("~/server/storage/vercel-blob", () => ({
     fetchBlob: jest.fn(),
-    putFile: jest.fn(),
 }));
 
 jest.mock("@launchstack/features/adeu", () => ({
@@ -44,7 +74,7 @@ jest.mock("@launchstack/features/adeu", () => ({
 
 import { modifyDocument } from "~/server/inngest/functions/modifyDocument";
 import { db } from "~/server/db";
-import { fetchBlob, putFile } from "~/server/storage/vercel-blob";
+import { fetchBlob } from "~/server/storage/vercel-blob";
 import { processDocumentBatch } from "@launchstack/features/adeu";
 
 // ---------------------------------------------------------------------------
@@ -93,9 +123,14 @@ describe("Fix 1.1: Step output uses blob storage — large DOCX stored as blob U
             file: modifiedBlob,
         });
 
-        (putFile as jest.Mock).mockResolvedValueOnce({
+        mockVercelBlobPut.mockResolvedValueOnce({
             url: "https://blob.store/modified.docx",
             pathname: "modified.docx",
+            ref: {
+                adapter: "vercel-blob",
+                storageLocationId: "vercel-blob:test-store",
+                key: "documents/modified.docx",
+            },
         });
 
         const mockWhere = jest.fn().mockResolvedValue([]);
@@ -254,18 +289,20 @@ describe("Fix 1.15: Idempotent replay — db.update is in a separate step.run", 
         expect(modifyStepChunk).not.toMatch(/db\s*\.\s*update\s*\(/);
     });
 
-    it("update-document-record step contains the db.update call", () => {
+    it("update-document-record step contains the database update call", () => {
         const sourceFile = fs.readFileSync(
             path.resolve(__dirname, "../../../src/server/inngest/functions/modifyDocument.ts"),
             "utf-8",
         );
 
-        // FIX: The dedicated update step should contain db.update
+        // FIX: The dedicated update step should contain the transaction update
         const updateStepStart = sourceFile.indexOf('step.run("update-document-record"');
         expect(updateStepStart).toBeGreaterThan(-1);
 
-        const updateStepChunk = sourceFile.slice(updateStepStart, updateStepStart + 400);
-        expect(updateStepChunk).toMatch(/db\s*\.\s*update\s*\(/);
+        const updateStepEnd = sourceFile.indexOf("return nextBlobUrl;", updateStepStart);
+        expect(updateStepEnd).toBeGreaterThan(updateStepStart);
+        const updateStepChunk = sourceFile.slice(updateStepStart, updateStepEnd);
+        expect(updateStepChunk).toMatch(/(?:db|tx)\s*\.\s*update\s*\(/);
     });
 });
 

--- a/apps/web/__tests__/api/adeu/modifyDocument.preservation.test.ts
+++ b/apps/web/__tests__/api/adeu/modifyDocument.preservation.test.ts
@@ -13,16 +13,47 @@
  * Requirements: 3.1, 3.2, 3.4
  */
 
+const mockVercelBlobPut = jest.fn();
+const mockForAdapter = jest.fn((_adapter: unknown) => ({ put: mockVercelBlobPut }));
+const mockTransactionSet = jest.fn().mockReturnValue({
+    where: jest.fn().mockResolvedValue([]),
+});
+
 jest.mock("~/server/db", () => ({
     db: {
         update: jest.fn(),
         select: jest.fn(),
+        transaction: jest.fn(async (callback: (tx: unknown) => unknown) =>
+            callback({
+                select: jest.fn(() => ({
+                    from: jest.fn(() => ({
+                        where: jest.fn().mockResolvedValue([{ companyId: 1n }]),
+                    })),
+                })),
+                update: jest.fn(() => ({
+                    set: mockTransactionSet,
+                })),
+            }),
+        ),
     },
+}));
+
+jest.mock("~/server/services/storage-manifest", () => ({
+    findObjectByRef: jest.fn().mockResolvedValue(undefined),
+    registerArtifactEdge: jest.fn().mockResolvedValue(undefined),
+    registerObject: jest.fn().mockResolvedValue({ id: 1, companyId: 1n }),
+}));
+
+jest.mock("~/server/engine", () => ({
+    getEngine: jest.fn(() => ({
+        storage: {
+            forAdapter: (adapter: unknown) => mockForAdapter(adapter),
+        },
+    })),
 }));
 
 jest.mock("~/server/storage/vercel-blob", () => ({
     fetchBlob: jest.fn(),
-    putFile: jest.fn(),
 }));
 
 jest.mock("@launchstack/features/adeu", () => ({
@@ -41,7 +72,7 @@ jest.mock("@launchstack/features/adeu", () => ({
 
 import { modifyDocument } from "~/server/inngest/functions/modifyDocument";
 import { db } from "~/server/db";
-import { fetchBlob, putFile } from "~/server/storage/vercel-blob";
+import { fetchBlob } from "~/server/storage/vercel-blob";
 import { processDocumentBatch } from "@launchstack/features/adeu";
 
 // ---------------------------------------------------------------------------
@@ -98,10 +129,15 @@ function setupSuccessfulPipeline(docBuffer: Buffer) {
         file: modifiedBlob,
     });
 
-    // Step 3: putFile stores the modified DOCX
-    (putFile as jest.Mock).mockResolvedValueOnce({
+    // Step 3: the targeted Vercel Blob port stores the modified DOCX
+    mockVercelBlobPut.mockResolvedValueOnce({
         url: "https://blob.store/documents/modified-42.docx",
         pathname: "documents/modified-42.docx",
+        ref: {
+            adapter: "vercel-blob",
+            storageLocationId: "vercel-blob:test-store",
+            key: "documents/modified-42.docx",
+        },
     });
 
     // DB update succeeds
@@ -233,9 +269,9 @@ describe("Preservation: Normal-sized DOCX (< 1 MB) processes through modifyDocum
         );
     });
 
-    it("stores modified DOCX via putFile and updates DB with url and updatedAt", async () => {
+    it("stores modified DOCX via the targeted Vercel Blob port and updates DB", async () => {
         const docBuffer = makeSmallDocxBuffer();
-        const { mockSet } = setupSuccessfulPipeline(docBuffer);
+        setupSuccessfulPipeline(docBuffer);
 
         const step = createMockStep();
         const handler = (modifyDocument as unknown as { fn: Function }).fn;
@@ -252,8 +288,9 @@ describe("Preservation: Normal-sized DOCX (< 1 MB) processes through modifyDocum
             step,
         });
 
-        // Preservation: putFile is called to store the modified DOCX
-        expect(putFile).toHaveBeenCalledWith(
+        // Preservation: the targeted Vercel Blob port stores the modified DOCX
+        expect(mockForAdapter).toHaveBeenCalledWith("vercel-blob");
+        expect(mockVercelBlobPut).toHaveBeenCalledWith(
             expect.objectContaining({
                 filename: expect.stringContaining("modified-42"),
                 contentType:
@@ -261,9 +298,8 @@ describe("Preservation: Normal-sized DOCX (< 1 MB) processes through modifyDocum
             }),
         );
 
-        // Preservation: DB is updated with url and updatedAt
-        expect(db.update).toHaveBeenCalled();
-        expect(mockSet).toHaveBeenCalledWith(
+        // Preservation: the transaction updates the DB with url and updatedAt
+        expect(mockTransactionSet).toHaveBeenCalledWith(
             expect.objectContaining({
                 url: "https://blob.store/documents/modified-42.docx",
                 updatedAt: expect.any(Date),
@@ -328,9 +364,14 @@ describe("Preservation: Single-user document edit completes correctly", () => {
             file: new Blob([Buffer.from("modified")]),
         });
 
-        (putFile as jest.Mock).mockResolvedValueOnce({
+        mockVercelBlobPut.mockResolvedValueOnce({
             url: "https://blob.store/modified.docx",
             pathname: "modified.docx",
+            ref: {
+                adapter: "vercel-blob",
+                storageLocationId: "vercel-blob:test-store",
+                key: "documents/modified.docx",
+            },
         });
 
         const mockWhere = jest.fn().mockResolvedValue([]);

--- a/apps/web/__tests__/api/adeu/modifyDocument.preservation.test.ts
+++ b/apps/web/__tests__/api/adeu/modifyDocument.preservation.test.ts
@@ -14,6 +14,17 @@
  */
 
 const mockVercelBlobPut = jest.fn();
+const mockStorageGet = jest.fn();
+const mockDocumentRef = {
+    adapter: "vercel-blob" as const,
+    storageLocationId: "vercel-blob:test-store",
+    key: "documents/original.docx",
+};
+const mockPromoteLegacyUrlToRef = jest.fn((_input: unknown) => ({
+    ok: true as const,
+    ref: mockDocumentRef,
+    confidence: "medium" as const,
+}));
 const mockForAdapter = jest.fn((_adapter: unknown) => ({ put: mockVercelBlobPut }));
 const mockTransactionSet = jest.fn().mockReturnValue({
     where: jest.fn().mockResolvedValue([]),
@@ -47,13 +58,15 @@ jest.mock("~/server/services/storage-manifest", () => ({
 jest.mock("~/server/engine", () => ({
     getEngine: jest.fn(() => ({
         storage: {
+            get: (input: unknown, init?: RequestInit) =>
+                init === undefined ? mockStorageGet(input) : mockStorageGet(input, init),
             forAdapter: (adapter: unknown) => mockForAdapter(adapter),
         },
     })),
 }));
 
-jest.mock("~/server/storage/vercel-blob", () => ({
-    fetchBlob: jest.fn(),
+jest.mock("~/server/storage/legacy-promote", () => ({
+    promoteLegacyUrlToRef: (input: unknown) => mockPromoteLegacyUrlToRef(input),
 }));
 
 jest.mock("@launchstack/features/adeu", () => ({
@@ -72,7 +85,6 @@ jest.mock("@launchstack/features/adeu", () => ({
 
 import { modifyDocument } from "~/server/inngest/functions/modifyDocument";
 import { db } from "~/server/db";
-import { fetchBlob } from "~/server/storage/vercel-blob";
 import { processDocumentBatch } from "@launchstack/features/adeu";
 
 // ---------------------------------------------------------------------------
@@ -104,8 +116,8 @@ function makeSmallDocxBuffer(): Buffer {
 }
 
 function setupSuccessfulPipeline(docBuffer: Buffer) {
-    // Step 1: fetchBlob returns the document
-    (fetchBlob as jest.Mock).mockResolvedValueOnce({
+    // Step 1: the storage port returns the document
+    mockStorageGet.mockResolvedValueOnce({
         ok: true,
         arrayBuffer: () =>
             Promise.resolve(
@@ -232,8 +244,11 @@ describe("Preservation: Normal-sized DOCX (< 1 MB) processes through modifyDocum
             step,
         });
 
-        // Preservation: fetchBlob called with the correct URL
-        expect(fetchBlob).toHaveBeenCalledWith("https://blob.store/original.docx");
+        // Preservation: the URL is promoted before the storage-port read
+        expect(mockPromoteLegacyUrlToRef).toHaveBeenCalledWith({
+            value: "https://blob.store/original.docx",
+        });
+        expect(mockStorageGet).toHaveBeenCalledWith(mockDocumentRef);
     });
 
     it("passes author name and edits to processDocumentBatch", async () => {
@@ -342,7 +357,7 @@ describe("Preservation: Single-user document edit completes correctly", () => {
     it("processes edits with actions successfully", async () => {
         const docBuffer = makeSmallDocxBuffer();
 
-        (fetchBlob as jest.Mock).mockResolvedValueOnce({
+        mockStorageGet.mockResolvedValueOnce({
             ok: true,
             arrayBuffer: () =>
                 Promise.resolve(
@@ -406,7 +421,7 @@ describe("Preservation: Single-user document edit completes correctly", () => {
         const { AdeuServiceError: MockAdeuServiceError } =
             jest.requireMock("@launchstack/features/adeu");
 
-        (fetchBlob as jest.Mock).mockResolvedValueOnce({
+        mockStorageGet.mockResolvedValueOnce({
             ok: true,
             arrayBuffer: () =>
                 Promise.resolve(
@@ -452,7 +467,7 @@ describe("Preservation: Single-user document edit completes correctly", () => {
         const { AdeuServiceError: MockAdeuServiceError } =
             jest.requireMock("@launchstack/features/adeu");
 
-        (fetchBlob as jest.Mock).mockResolvedValueOnce({
+        mockStorageGet.mockResolvedValueOnce({
             ok: true,
             arrayBuffer: () =>
                 Promise.resolve(

--- a/apps/web/__tests__/api/adeu/modifyDocument.test.ts
+++ b/apps/web/__tests__/api/adeu/modifyDocument.test.ts
@@ -3,16 +3,46 @@
  * Tests event registration, step execution, error handling, and DB updates.
  */
 
+const mockVercelBlobPut = jest.fn();
+const mockForAdapter = jest.fn((_adapter: unknown) => ({ put: mockVercelBlobPut }));
+
 jest.mock("~/server/db", () => ({
   db: {
     update: jest.fn(),
     select: jest.fn(),
+    transaction: jest.fn(async (callback: (tx: unknown) => unknown) =>
+      callback({
+        select: jest.fn(() => ({
+          from: jest.fn(() => ({
+            where: jest.fn().mockResolvedValue([{ companyId: 1n }]),
+          })),
+        })),
+        update: jest.fn(() => ({
+          set: jest.fn(() => ({
+            where: jest.fn().mockResolvedValue([]),
+          })),
+        })),
+      }),
+    ),
   },
+}));
+
+jest.mock("~/server/services/storage-manifest", () => ({
+  findObjectByRef: jest.fn().mockResolvedValue(undefined),
+  registerArtifactEdge: jest.fn().mockResolvedValue(undefined),
+  registerObject: jest.fn().mockResolvedValue({ id: 1, companyId: 1n }),
+}));
+
+jest.mock("~/server/engine", () => ({
+  getEngine: jest.fn(() => ({
+    storage: {
+      forAdapter: (adapter: unknown) => mockForAdapter(adapter),
+    },
+  })),
 }));
 
 jest.mock("~/server/storage/vercel-blob", () => ({
   fetchBlob: jest.fn(),
-  putFile: jest.fn(),
 }));
 
 jest.mock("@launchstack/features/adeu", () => ({
@@ -31,7 +61,7 @@ jest.mock("@launchstack/features/adeu", () => ({
 
 import { modifyDocument } from "~/server/inngest/functions/modifyDocument";
 import { db } from "~/server/db";
-import { fetchBlob, putFile } from "~/server/storage/vercel-blob";
+import { fetchBlob } from "~/server/storage/vercel-blob";
 import { processDocumentBatch, AdeuServiceError } from "@launchstack/features/adeu";
 
 // ---------------------------------------------------------------------------
@@ -122,9 +152,14 @@ describe("modifyDocument Inngest function", () => {
         file: modifiedBlob,
       });
 
-      (putFile as jest.Mock).mockResolvedValueOnce({
+      mockVercelBlobPut.mockResolvedValueOnce({
         url: "https://blob.store/modified.docx",
         pathname: "documents/modified.docx",
+        ref: {
+          adapter: "vercel-blob",
+          storageLocationId: "vercel-blob:test-store",
+          key: "documents/modified.docx",
+        },
       });
 
       const mockSet = jest.fn().mockReturnValue({ where: jest.fn().mockResolvedValue([]) });
@@ -147,6 +182,7 @@ describe("modifyDocument Inngest function", () => {
       await handler({ event, step });
 
       expect(fetchBlob).toHaveBeenCalledWith("https://blob.store/original.docx");
+      expect(mockForAdapter).toHaveBeenCalledWith("vercel-blob");
     });
 
     it("throws when Blob fetch returns non-ok", async () => {
@@ -302,9 +338,14 @@ describe("modifyDocument Inngest function", () => {
   describe("store-result step", () => {
     it("uploads modified DOCX to Blob and updates DB", async () => {
       const storedUrl = "https://blob.store/documents/modified-42.docx";
-      (putFile as jest.Mock).mockResolvedValueOnce({
+      mockVercelBlobPut.mockResolvedValueOnce({
         url: storedUrl,
         pathname: "documents/modified-42.docx",
+        ref: {
+          adapter: "vercel-blob",
+          storageLocationId: "vercel-blob:test-store",
+          key: "documents/modified-42.docx",
+        },
       });
 
       const mockWhere = jest.fn().mockResolvedValue([]);
@@ -317,7 +358,7 @@ describe("modifyDocument Inngest function", () => {
       const result = await step.run("store-result", async () => {
         const modifiedBuffer = Buffer.from(fileBase64, "base64");
 
-        const stored = await putFile({
+        const stored = await mockVercelBlobPut({
           filename: "modified-42.docx",
           data: modifiedBuffer,
           contentType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
@@ -329,7 +370,7 @@ describe("modifyDocument Inngest function", () => {
       });
 
       expect(result).toBe(storedUrl);
-      expect(putFile).toHaveBeenCalledWith(
+      expect(mockVercelBlobPut).toHaveBeenCalledWith(
         expect.objectContaining({
           filename: "modified-42.docx",
           contentType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
@@ -339,13 +380,13 @@ describe("modifyDocument Inngest function", () => {
     });
 
     it("throws when Blob upload fails", async () => {
-      (putFile as jest.Mock).mockRejectedValueOnce(new Error("Upload quota exceeded"));
+      mockVercelBlobPut.mockRejectedValueOnce(new Error("Upload quota exceeded"));
 
       const step = createMockStep();
 
       await expect(
         step.run("store-result", async () => {
-          await putFile({
+          await mockVercelBlobPut({
             filename: "test.docx",
             data: Buffer.from("data"),
           });

--- a/apps/web/__tests__/api/adeu/modifyDocument.test.ts
+++ b/apps/web/__tests__/api/adeu/modifyDocument.test.ts
@@ -4,6 +4,22 @@
  */
 
 const mockVercelBlobPut = jest.fn();
+const mockStorageGet = jest.fn();
+const mockDocumentRef = {
+  adapter: "vercel-blob" as const,
+  storageLocationId: "vercel-blob:test-store",
+  key: "documents/original.docx",
+};
+type MockPromotion =
+  | { ok: true; ref: typeof mockDocumentRef; confidence: "medium" }
+  | { ok: false; reason: "unsupported"; quarantine: true };
+const mockPromoteLegacyUrlToRef = jest.fn(
+  (_input: unknown): MockPromotion => ({
+    ok: true,
+    ref: mockDocumentRef,
+    confidence: "medium",
+  }),
+);
 const mockForAdapter = jest.fn((_adapter: unknown) => ({ put: mockVercelBlobPut }));
 
 jest.mock("~/server/db", () => ({
@@ -36,13 +52,15 @@ jest.mock("~/server/services/storage-manifest", () => ({
 jest.mock("~/server/engine", () => ({
   getEngine: jest.fn(() => ({
     storage: {
+      get: (input: unknown, init?: RequestInit) =>
+        init === undefined ? mockStorageGet(input) : mockStorageGet(input, init),
       forAdapter: (adapter: unknown) => mockForAdapter(adapter),
     },
   })),
 }));
 
-jest.mock("~/server/storage/vercel-blob", () => ({
-  fetchBlob: jest.fn(),
+jest.mock("~/server/storage/legacy-promote", () => ({
+  promoteLegacyUrlToRef: (input: unknown) => mockPromoteLegacyUrlToRef(input),
 }));
 
 jest.mock("@launchstack/features/adeu", () => ({
@@ -61,7 +79,7 @@ jest.mock("@launchstack/features/adeu", () => ({
 
 import { modifyDocument } from "~/server/inngest/functions/modifyDocument";
 import { db } from "~/server/db";
-import { fetchBlob } from "~/server/storage/vercel-blob";
+import { getEngine } from "~/server/engine";
 import { processDocumentBatch, AdeuServiceError } from "@launchstack/features/adeu";
 
 // ---------------------------------------------------------------------------
@@ -135,9 +153,9 @@ describe("modifyDocument Inngest function", () => {
   // Step 1: fetch-document
   // =========================================================================
   describe("fetch-document step", () => {
-    it("fetches document from Blob URL", async () => {
+    it("promotes the document URL and fetches it through the storage port", async () => {
       const docContent = Buffer.from("test-docx-content");
-      (fetchBlob as jest.Mock).mockResolvedValueOnce({
+      mockStorageGet.mockResolvedValueOnce({
         ok: true,
         arrayBuffer: () => Promise.resolve(docContent.buffer.slice(
           docContent.byteOffset,
@@ -181,27 +199,54 @@ describe("modifyDocument Inngest function", () => {
       expect(handler).toBeDefined();
       await handler({ event, step });
 
-      expect(fetchBlob).toHaveBeenCalledWith("https://blob.store/original.docx");
+      expect(mockPromoteLegacyUrlToRef).toHaveBeenCalledWith({
+        value: "https://blob.store/original.docx",
+      });
+      expect(mockStorageGet).toHaveBeenCalledWith(mockDocumentRef);
       expect(mockForAdapter).toHaveBeenCalledWith("vercel-blob");
     });
 
-    it("throws when Blob fetch returns non-ok", async () => {
-      (fetchBlob as jest.Mock).mockResolvedValueOnce({
+    it("throws when a storage-port fetch returns non-ok", async () => {
+      mockStorageGet.mockResolvedValueOnce({
         ok: false,
         status: 404,
       });
 
       const step = createMockStep();
 
-      // The step.run should throw when fetchBlob returns non-ok
+      // The step.run should throw when the storage port returns non-ok
       await expect(
         step.run("fetch-document", async () => {
-          const res = await fetchBlob("https://blob.store/missing.docx");
+          const res = await getEngine().storage.get(mockDocumentRef);
           if (!(res as Response).ok) {
             throw new Error(`Failed to fetch document: HTTP ${(res as Response).status}`);
           }
         })
       ).rejects.toThrow("Failed to fetch document: HTTP 404");
+    });
+
+    it("fails closed when the document URL cannot be promoted", async () => {
+      mockPromoteLegacyUrlToRef.mockReturnValueOnce({
+        ok: false,
+        reason: "unsupported",
+        quarantine: true,
+      });
+
+      const handler = (modifyDocument as unknown as { fn: Function }).fn;
+      await expect(
+        handler({
+          event: {
+            data: {
+              documentId: 42,
+              documentUrl: "https://unknown.example/original.docx",
+              authorName: "Test Author",
+              edits: [],
+            },
+          },
+          step: createMockStep(),
+        }),
+      ).rejects.toThrow("Failed to resolve document storage reference: unsupported");
+      expect(mockStorageGet).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/__tests__/api/fetchDocument/fetchDocument.test.ts
+++ b/apps/web/__tests__/api/fetchDocument/fetchDocument.test.ts
@@ -1,7 +1,26 @@
-jest.mock("~/server/storage/vercel-blob", () => ({
-  isPrivateBlobUrl: jest.fn(() => false),
-  fetchBlob: jest.fn(),
-  putFile: jest.fn(),
+const mockIsS3Storage = jest.fn(() => false);
+const mockPromoteLegacyUrlToRef = jest.fn((_input: unknown) => ({
+  ok: false as const,
+  reason: "unsupported" as const,
+  quarantine: true as const,
+}));
+
+jest.mock("~/lib/storage", () => ({
+  isS3Storage: () => mockIsS3Storage(),
+}));
+
+jest.mock("~/server/storage/legacy-promote", () => ({
+  promoteLegacyUrlToRef: (input: unknown) => mockPromoteLegacyUrlToRef(input),
+}));
+
+jest.mock("~/lib/active-workspace", () => ({
+  resolveActiveCompanyForUser: jest.fn(
+    async (_userId: unknown, defaultCompanyId: number) => defaultCompanyId,
+  ),
+}));
+
+jest.mock("~/server/services/document-servable", () => ({
+  checkDocumentServable: jest.fn().mockResolvedValue({ servable: true }),
 }));
 
 jest.mock("@clerk/nextjs/server", () => ({
@@ -38,9 +57,9 @@ describe("POST /api/fetchDocument", () => {
     (auth as unknown as jest.Mock).mockResolvedValue({ userId: "test-user-123" });
 
     const mockDocuments = [
-      { id: 1, name: "Document 1", companyId: 1, content: "Content 1", currentVersionId: null },
-      { id: 2, name: "Document 2", companyId: 1, content: "Content 2", currentVersionId: null },
-      { id: 3, name: "Document 3", companyId: 1, content: "Content 3", currentVersionId: null },
+      { id: 1, name: "Document 1", companyId: 1, content: "Content 1", currentVersionId: null, url: "https://public.example/document-1" },
+      { id: 2, name: "Document 2", companyId: 1, content: "Content 2", currentVersionId: null, url: "https://public.example/document-2" },
+      { id: 3, name: "Document 3", companyId: 1, content: "Content 3", currentVersionId: null, url: "https://public.example/document-3" },
     ];
 
     // First call: user lookup
@@ -308,8 +327,8 @@ describe("POST /api/fetchDocument", () => {
 
     // Documents for company 1 only
     const mockDocuments = [
-      { id: 1, name: "Company 1 Doc", companyId: 1 },
-      { id: 2, name: "Another Company 1 Doc", companyId: 1 },
+      { id: 1, name: "Company 1 Doc", companyId: 1, url: "https://public.example/company-1-doc" },
+      { id: 2, name: "Another Company 1 Doc", companyId: 1, url: "https://public.example/company-1-doc-2" },
     ];
 
     const mockSelect = jest.fn()
@@ -353,8 +372,8 @@ describe("POST /api/fetchDocument", () => {
     (auth as unknown as jest.Mock).mockResolvedValue({ userId: "test-user-789" });
 
     const mockDocuments = [
-      { id: 10, name: "Company 5 Doc", companyId: 5 },
-      { id: 11, name: "Another Company 5 Doc", companyId: 5 },
+      { id: 10, name: "Company 5 Doc", companyId: 5, url: "https://public.example/company-5-doc" },
+      { id: 11, name: "Another Company 5 Doc", companyId: 5, url: "https://public.example/company-5-doc-2" },
     ];
 
     const mockSelect = jest.fn()
@@ -398,7 +417,7 @@ describe("POST /api/fetchDocument", () => {
     (auth as unknown as jest.Mock).mockResolvedValue({ userId: "employee-user-111" });
 
     const mockDocuments = [
-      { id: 20, name: "Employee Doc", companyId: 3, currentVersionId: null },
+      { id: 20, name: "Employee Doc", companyId: 3, currentVersionId: null, url: "https://public.example/employee-doc" },
     ];
 
     const mockSelect = jest.fn()

--- a/apps/web/__tests__/api/storage/adapters/database-adapter.test.ts
+++ b/apps/web/__tests__/api/storage/adapters/database-adapter.test.ts
@@ -1,0 +1,211 @@
+/**
+ * C4 — database adapter unit tests.
+ *
+ * Drizzle and fetch are mocked here so the adapter's own decisions are what is
+ * under test: row-id parsing, the stale-location guard, and — the reason this
+ * adapter exists in its current shape — that reads go out as an authenticated
+ * internal HTTP call rather than a direct row read.
+ *
+ * The put/get/delete round trip against a real Postgres belongs in a script
+ * run against the local database, the same way the deletion lifecycle was
+ * verified. A mocked round trip proves the wiring, not the behaviour.
+ */
+
+const mockEnvData = {
+  server: { APP_PUBLIC_URL: "https://app.example" as string | undefined },
+  client: {},
+};
+
+jest.mock("~/env", () => ({
+  get env() {
+    return mockEnvData;
+  },
+}));
+
+const mockReturning = jest.fn();
+const mockDb = {
+  insert: jest.fn(() => ({
+    values: jest.fn(() => ({ returning: mockReturning })),
+  })),
+  delete: jest.fn(() => ({
+    where: jest.fn(() => ({ returning: mockReturning })),
+  })),
+};
+
+jest.mock("~/server/db", () => ({
+  get db() {
+    return mockDb;
+  },
+}));
+
+import { createDatabaseAdapter } from "~/server/storage/adapters/database-adapter";
+
+const LOCATION = "database:pdr_file_uploads_v1";
+
+function refFor(key: string, location = LOCATION) {
+  return { adapter: "database" as const, storageLocationId: location, key };
+}
+
+describe("database adapter", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockEnvData.server.APP_PUBLIC_URL = "https://app.example";
+    process.env.INTERNAL_SERVICE_TOKEN = "test-internal-token";
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  describe("put", () => {
+    it("mints a ref whose key is the file_uploads row id", async () => {
+      mockReturning.mockResolvedValueOnce([{ id: 42 }]);
+
+      const result = await createDatabaseAdapter().put({
+        filename: "report.pdf",
+        data: Buffer.from("bytes"),
+        contentType: "application/pdf",
+        userId: "user-1",
+      });
+
+      expect(result.ref).toEqual(refFor("42"));
+      expect(result.url).toBe("/api/files/42");
+      expect(result.provider).toBe("database");
+    });
+
+    it("attributes engine-initiated writes to system when no user is given", async () => {
+      mockReturning.mockResolvedValueOnce([{ id: 7 }]);
+
+      await createDatabaseAdapter().put({ filename: "a.txt", data: Buffer.from("b") });
+
+      const values = (mockDb.insert.mock.results[0]?.value as { values: jest.Mock }).values;
+      expect(values).toHaveBeenCalledWith(expect.objectContaining({ userId: "system" }));
+    });
+  });
+
+  describe("delete", () => {
+    it("reports deleted when a row was actually removed", async () => {
+      mockReturning.mockResolvedValueOnce([{ id: 42 }]);
+
+      const result = await createDatabaseAdapter().delete(refFor("42"));
+
+      expect(result).toEqual({ ref: refFor("42"), outcome: "deleted" });
+    });
+
+    it("reports not_found when the row was already gone", async () => {
+      // The whole point of checking the row count. lib/storage.ts's database
+      // branch returns success either way, which makes an already-absent
+      // object indistinguishable from one this call removed (design doc A7).
+      mockReturning.mockResolvedValueOnce([]);
+
+      const result = await createDatabaseAdapter().delete(refFor("999"));
+
+      expect(result.outcome).toBe("not_found");
+    });
+
+    it("blocks a malformed key instead of retrying it forever", async () => {
+      const result = await createDatabaseAdapter().delete(refFor("not-a-row-id"));
+
+      expect(result.outcome).toBe("blocked");
+      expect(result.errorCode).toBe("invalid_database_file_reference");
+      expect(mockDb.delete).not.toHaveBeenCalled();
+    });
+
+    it("blocks a ref from a different store", async () => {
+      const result = await createDatabaseAdapter().delete(refFor("42", "database:retired_store"));
+
+      expect(result.outcome).toBe("blocked");
+      expect(result.errorCode).toBe("storage_location_mismatch");
+      expect(mockDb.delete).not.toHaveBeenCalled();
+    });
+
+    it("treats a database error as retryable", async () => {
+      mockReturning.mockRejectedValueOnce(new Error("connection terminated"));
+
+      const result = await createDatabaseAdapter().delete(refFor("42"));
+
+      expect(result.outcome).toBe("retryable");
+    });
+  });
+
+  describe("deleteMany", () => {
+    it("attributes every outcome exactly, from one statement", async () => {
+      // SQL can say which rows it removed, so unlike the provider adapters
+      // there is no bulk-then-fallback dance and nothing is inferred.
+      mockReturning.mockResolvedValueOnce([{ id: 1 }]);
+
+      const results = await createDatabaseAdapter().deleteMany([refFor("1"), refFor("2")]);
+
+      expect(mockDb.delete).toHaveBeenCalledTimes(1);
+      expect(results).toEqual([
+        { ref: refFor("1"), outcome: "deleted" },
+        { ref: refFor("2"), outcome: "not_found" },
+      ]);
+    });
+
+    it("separates unusable refs from the statement", async () => {
+      mockReturning.mockResolvedValueOnce([{ id: 1 }]);
+
+      const results = await createDatabaseAdapter().deleteMany([
+        refFor("1"),
+        refFor("bad-key"),
+        refFor("3", "database:retired_store"),
+      ]);
+
+      expect(results.filter((r) => r.outcome === "blocked")).toHaveLength(2);
+      expect(results.find((r) => r.ref.key === "1")?.outcome).toBe("deleted");
+    });
+  });
+
+  describe("get", () => {
+    it("calls our own route with internal service credentials", async () => {
+      const fetchMock = jest.fn().mockResolvedValueOnce(new Response("bytes", { status: 200 }));
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      const response = await createDatabaseAdapter().get(refFor("42"));
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        "https://app.example/api/files/42",
+        expect.objectContaining({
+          headers: expect.objectContaining({ "x-launchstack-internal": "test-internal-token" }),
+        }),
+      );
+      expect(await response.text()).toBe("bytes");
+    });
+
+    it("does not let a caller's headers overwrite the internal credentials", async () => {
+      const fetchMock = jest.fn().mockResolvedValueOnce(new Response("bytes"));
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      await createDatabaseAdapter().get(refFor("42"), {
+        headers: { "x-launchstack-internal": "attacker-supplied" },
+      });
+
+      const passed = fetchMock.mock.calls[0]?.[1] as { headers: Record<string, string> };
+      expect(passed.headers["x-launchstack-internal"]).toBe("test-internal-token");
+    });
+
+    it("fails loudly when APP_PUBLIC_URL is missing rather than silently reading the row", async () => {
+      // A silent fallback to a direct row read would mean two code paths where
+      // only one is ever exercised. Dev A chose the HTTP call; if it cannot be
+      // made, that is a configuration error, not a reason to do something else.
+      mockEnvData.server.APP_PUBLIC_URL = undefined;
+
+      await expect(createDatabaseAdapter().get(refFor("42"))).rejects.toThrow(
+        /APP_PUBLIC_URL is required/,
+      );
+    });
+  });
+
+  describe("getSignedUrl", () => {
+    it("returns the canonical serve path", async () => {
+      const url = await createDatabaseAdapter().getSignedUrl(refFor("42"));
+
+      // Not signed, and documented as such: access is decided by the
+      // requester's session at the route, not by anything in the URL.
+      expect(url).toBe("https://app.example/api/files/42");
+    });
+  });
+});

--- a/apps/web/__tests__/api/storage/adapters/uploadthing-adapter.test.ts
+++ b/apps/web/__tests__/api/storage/adapters/uploadthing-adapter.test.ts
@@ -1,0 +1,161 @@
+/**
+ * C4 — UploadThing adapter unit tests.
+ *
+ * UTApi is mocked for the same reason the Blob SDK is: no credentials exist
+ * in CI, and what is worth testing is our own classification and guard logic.
+ */
+
+const mockEnvData = { server: {} as { UPLOADTHING_TOKEN?: string }, client: {} };
+
+jest.mock("~/env", () => ({
+  get env() {
+    return mockEnvData;
+  },
+}));
+
+const mockDeleteFiles = jest.fn();
+const mockGenerateSignedURL = jest.fn();
+
+jest.mock("uploadthing/server", () => ({
+  UTApi: class {
+    deleteFiles = (...args: unknown[]) => mockDeleteFiles(...args);
+    generateSignedURL = (...args: unknown[]) => mockGenerateSignedURL(...args);
+  },
+}));
+
+import { createUploadThingAdapter } from "~/server/storage/adapters/uploadthing-adapter";
+
+/**
+ * A JWT-shaped token whose payload carries appId, which is how
+ * parseUploadThingIdentityFromToken derives the location id.
+ */
+function tokenFor(appId: string): string {
+  const payload = Buffer.from(JSON.stringify({ appId })).toString("base64url");
+  return `header.${payload}.signature`;
+}
+
+const APP_ID = "app-alpha";
+const LOCATION = `uploadthing:${APP_ID}`;
+
+function refFor(key: string, location = LOCATION) {
+  return { adapter: "uploadthing" as const, storageLocationId: location, key };
+}
+
+describe("uploadthing adapter", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockEnvData.server.UPLOADTHING_TOKEN = tokenFor(APP_ID);
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  describe("put", () => {
+    it("refuses loudly instead of silently writing somewhere else", async () => {
+      // The failure mode this prevents: a caller that asked for UploadThing
+      // getting its bytes into S3 or Postgres, compiling clean and passing
+      // tests, and only surfacing when someone looks for a file that was
+      // never there.
+      await expect(
+        createUploadThingAdapter().put({ filename: "a.pdf", data: Buffer.from("b") }),
+      ).rejects.toThrow(/not supported: UploadThing uploads are client-side/);
+    });
+  });
+
+  describe("delete", () => {
+    it("reports deleted when the provider removed a file", async () => {
+      mockDeleteFiles.mockResolvedValueOnce({ success: true, deletedCount: 1 });
+
+      const result = await createUploadThingAdapter().delete(refFor("file-key-1"));
+
+      expect(result).toEqual({ ref: refFor("file-key-1"), outcome: "deleted" });
+    });
+
+    it("reports not_found when the provider removed nothing", async () => {
+      // Unlike Vercel Blob, UploadThing returns a count — so "already gone" is
+      // genuinely observable here and is reported rather than assumed.
+      mockDeleteFiles.mockResolvedValueOnce({ success: true, deletedCount: 0 });
+
+      const result = await createUploadThingAdapter().delete(refFor("file-key-2"));
+
+      expect(result.outcome).toBe("not_found");
+    });
+
+    it("classifies auth failures as blocked and transient ones as retryable", async () => {
+      mockDeleteFiles.mockRejectedValueOnce(new Error("Unauthorized"));
+      expect((await createUploadThingAdapter().delete(refFor("k1"))).outcome).toBe("blocked");
+
+      mockDeleteFiles.mockRejectedValueOnce(new Error("ETIMEDOUT"));
+      expect((await createUploadThingAdapter().delete(refFor("k2"))).outcome).toBe("retryable");
+    });
+
+    it("blocks a ref minted against a different app without calling the provider", async () => {
+      const result = await createUploadThingAdapter().delete(
+        refFor("file-key-1", "uploadthing:some-other-app"),
+      );
+
+      expect(result.outcome).toBe("blocked");
+      expect(result.errorCode).toBe("storage_location_mismatch");
+      expect(mockDeleteFiles).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("deleteMany", () => {
+    it("accepts a bulk result only when the count is a clean sweep", async () => {
+      mockDeleteFiles.mockResolvedValueOnce({ success: true, deletedCount: 2 });
+
+      const results = await createUploadThingAdapter().deleteMany([refFor("a"), refFor("b")]);
+
+      expect(mockDeleteFiles).toHaveBeenCalledTimes(1);
+      expect(results.every((r) => r.outcome === "deleted")).toBe(true);
+    });
+
+    it("falls back per-key when the bulk count is short, rather than guessing", async () => {
+      // Bulk says "2 asked, 1 deleted" — but not which. Attributing that
+      // not_found to either ref would be a coin flip, so each is re-checked.
+      mockDeleteFiles
+        .mockResolvedValueOnce({ success: true, deletedCount: 1 })
+        .mockResolvedValueOnce({ success: true, deletedCount: 1 })
+        .mockResolvedValueOnce({ success: true, deletedCount: 0 });
+
+      const results = await createUploadThingAdapter().deleteMany([refFor("a"), refFor("b")]);
+
+      expect(mockDeleteFiles).toHaveBeenCalledTimes(3);
+      expect(results.map((r) => r.outcome)).toEqual(["deleted", "not_found"]);
+    });
+  });
+
+  describe("get / getSignedUrl", () => {
+    it("reads through a presigned URL rather than a hand-built one", async () => {
+      mockGenerateSignedURL.mockResolvedValueOnce({ ufsUrl: "https://ufs.example/f/file-key-1?sig=x" });
+      const fetchMock = jest.fn().mockResolvedValueOnce(new Response("bytes", { status: 200 }));
+      global.fetch = fetchMock as unknown as typeof fetch;
+
+      const response = await createUploadThingAdapter().get(refFor("file-key-1"));
+
+      expect(mockGenerateSignedURL).toHaveBeenCalledWith("file-key-1", undefined);
+      expect(fetchMock).toHaveBeenCalledWith("https://ufs.example/f/file-key-1?sig=x", undefined);
+      expect(await response.text()).toBe("bytes");
+    });
+
+    it("passes expiresIn through when asked", async () => {
+      mockGenerateSignedURL.mockResolvedValueOnce({ ufsUrl: "https://ufs.example/f/k?sig=y" });
+
+      const url = await createUploadThingAdapter().getSignedUrl(refFor("k"), { expiresIn: 60 });
+
+      expect(mockGenerateSignedURL).toHaveBeenCalledWith("k", { expiresIn: 60 });
+      expect(url).toBe("https://ufs.example/f/k?sig=y");
+    });
+
+    it("refuses a stale-location ref before generating anything", async () => {
+      await expect(
+        createUploadThingAdapter().getSignedUrl(refFor("k", "uploadthing:some-other-app")),
+      ).rejects.toThrow(/does not match the configured UploadThing app/);
+
+      expect(mockGenerateSignedURL).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/__tests__/api/storage/adapters/vercel-blob-adapter.test.ts
+++ b/apps/web/__tests__/api/storage/adapters/vercel-blob-adapter.test.ts
@@ -1,0 +1,304 @@
+/**
+ * C4 — Vercel Blob adapter unit tests.
+ *
+ * The provider SDK is mocked, deliberately. There are no Blob credentials in
+ * CI or on a dev machine, so the choice is between mocking the SDK and testing
+ * nothing at all. What is under test here is *our* logic — ref minting, the
+ * stale-location guard, outcome classification, the bulk-delete fallback — and
+ * none of that needs a real network call to be meaningful.
+ *
+ * What these tests deliberately do NOT prove: that @vercel/blob behaves the
+ * way the mocks say it does. That is what the mock asserts, not what it
+ * verifies. Real-provider behaviour is only ever confirmed by running against
+ * a real store.
+ */
+
+jest.mock("~/env", () => ({
+  get env() {
+    return { server: {}, client: {} };
+  },
+}));
+
+const mockPut = jest.fn();
+const mockGet = jest.fn();
+const mockDel = jest.fn();
+const mockHead = jest.fn();
+
+class MockBlobNotFoundError extends Error {
+  constructor() {
+    super("blob not found");
+    this.name = "BlobNotFoundError";
+  }
+}
+
+jest.mock("@vercel/blob", () => ({
+  put: (...args: unknown[]) => mockPut(...args),
+  get: (...args: unknown[]) => mockGet(...args),
+  del: (...args: unknown[]) => mockDel(...args),
+  head: (...args: unknown[]) => mockHead(...args),
+  BlobNotFoundError: MockBlobNotFoundError,
+}));
+
+/**
+ * Imported fresh in beforeEach rather than statically.
+ *
+ * The adapter caches whether the store is public or private in module scope —
+ * one probe per process, copied from the original vercel-blob.ts. That cache
+ * is correct in production (a long-lived process, one store) but it leaks
+ * across tests: whichever test runs first decides the access mode for every
+ * test after it, so the fallback path becomes unreachable and the suite
+ * silently depends on its own ordering.
+ *
+ * jest.resetModules() gives each test its own copy of that state.
+ */
+type CreateVercelBlobAdapter =
+  typeof import("~/server/storage/adapters/vercel-blob-adapter").createVercelBlobAdapter;
+
+let createVercelBlobAdapter: CreateVercelBlobAdapter;
+
+const TOKEN = "vercel_blob_rw_store-alpha_secret";
+const LOCATION = "vercel-blob:store-alpha";
+
+function refFor(key: string, location = LOCATION) {
+  return { adapter: "vercel-blob" as const, storageLocationId: location, key };
+}
+
+function streamOf(text: string): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(text));
+      controller.close();
+    },
+  });
+}
+
+describe("vercel-blob adapter", () => {
+  beforeEach(async () => {
+    jest.resetModules();
+
+    // resetAllMocks, not clearAllMocks: clearAllMocks only forgets calls, it
+    // leaves queued mockResolvedValueOnce values in place. An unconsumed
+    // queued value from one test then answers the next test's first call —
+    // which is exactly how a test asserting "this should reject" ended up
+    // resolving with the previous test's payload.
+    jest.resetAllMocks();
+
+    process.env.BLOB_READ_WRITE_TOKEN = TOKEN;
+    ({ createVercelBlobAdapter } = await import(
+      "~/server/storage/adapters/vercel-blob-adapter"
+    ));
+  });
+
+  describe("put", () => {
+    it("mints a ref whose key is the provider's pathname, not a URL", async () => {
+      mockPut.mockResolvedValueOnce({
+        url: "https://store-alpha.public.blob.vercel-storage.com/documents/x.pdf",
+        pathname: "documents/x.pdf",
+        contentType: "application/pdf",
+      });
+
+      const result = await createVercelBlobAdapter().put({
+        filename: "x.pdf",
+        data: Buffer.from("bytes"),
+        contentType: "application/pdf",
+      });
+
+      // The key is what the provider called it. Nothing is parsed out of a URL.
+      expect(result.ref).toEqual(refFor("documents/x.pdf"));
+      expect(result.provider).toBe("vercel-blob");
+    });
+
+    it("falls back to a private write when the store rejects a public one", async () => {
+      mockPut
+        .mockRejectedValueOnce(new Error("this is a private store"))
+        .mockResolvedValueOnce({
+          url: "https://store-alpha.private.blob.vercel-storage.com/documents/y.pdf",
+          pathname: "documents/y.pdf",
+        });
+
+      const result = await createVercelBlobAdapter().put({
+        filename: "y.pdf",
+        data: Buffer.from("bytes"),
+      });
+
+      expect(mockPut).toHaveBeenCalledTimes(2);
+      expect(mockPut.mock.calls[0]?.[2]).toMatchObject({ access: "public" });
+      expect(mockPut.mock.calls[1]?.[2]).toMatchObject({ access: "private" });
+      expect(result.ref.key).toBe("documents/y.pdf");
+    });
+
+    it("probes only once per process, then reuses the cached access mode", async () => {
+      // The first write discovers the store is private; the second must not
+      // pay for that discovery again.
+      mockPut
+        .mockRejectedValueOnce(new Error("this is a private store"))
+        .mockResolvedValueOnce({ url: "https://s/a.pdf", pathname: "documents/a.pdf" })
+        .mockResolvedValueOnce({ url: "https://s/b.pdf", pathname: "documents/b.pdf" });
+
+      const adapter = createVercelBlobAdapter();
+      await adapter.put({ filename: "a.pdf", data: Buffer.from("b") });
+      await adapter.put({ filename: "b.pdf", data: Buffer.from("b") });
+
+      // Three calls total, not four: one failed probe plus two real writes.
+      expect(mockPut).toHaveBeenCalledTimes(3);
+      expect(mockPut.mock.calls[2]?.[2]).toMatchObject({ access: "private" });
+    });
+
+    it("rethrows any error that is not the private-store signal", async () => {
+      mockPut.mockRejectedValueOnce(new Error("quota exceeded"));
+
+      await expect(
+        createVercelBlobAdapter().put({ filename: "z.pdf", data: Buffer.from("b") }),
+      ).rejects.toThrow("quota exceeded");
+
+      // One attempt only — a real failure must not be retried as "private".
+      expect(mockPut).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("get", () => {
+    it("streams the object and resolves the pathname through the SDK", async () => {
+      mockGet.mockResolvedValueOnce({
+        statusCode: 200,
+        stream: streamOf("file contents"),
+        headers: new Headers({ "content-type": "application/pdf" }),
+      });
+
+      const response = await createVercelBlobAdapter().get(refFor("documents/x.pdf"));
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toBe("application/pdf");
+      expect(await response.text()).toBe("file contents");
+
+      // The pathname went to the SDK as-is; no URL was constructed anywhere.
+      expect(mockGet).toHaveBeenCalledWith("documents/x.pdf", expect.objectContaining({ token: TOKEN }));
+    });
+
+    it("returns 404 rather than throwing when the blob is gone", async () => {
+      mockGet.mockRejectedValueOnce(new MockBlobNotFoundError());
+
+      const response = await createVercelBlobAdapter().get(refFor("documents/missing.pdf"));
+
+      // Callers check response.ok, exactly as they do with fetch today.
+      expect(response.status).toBe(404);
+    });
+
+    it("refuses a ref minted against a different store (Decision 4)", async () => {
+      await expect(
+        createVercelBlobAdapter().get(refFor("documents/x.pdf", "vercel-blob:retired-store")),
+      ).rejects.toThrow(/does not match the configured store/);
+
+      // Critically: it never reached the provider, so it could not have read
+      // a same-pathname object out of the current store.
+      expect(mockGet).not.toHaveBeenCalled();
+    });
+
+    it("rejects a ref belonging to another adapter", async () => {
+      await expect(
+        createVercelBlobAdapter().get({
+          adapter: "s3",
+          storageLocationId: "s3:endpoint@bucket",
+          key: "documents/x.pdf",
+        }),
+      ).rejects.toThrow(/received a ref for adapter "s3"/);
+    });
+  });
+
+  describe("delete", () => {
+    it("reports deleted on success", async () => {
+      mockDel.mockResolvedValueOnce(undefined);
+
+      const result = await createVercelBlobAdapter().delete(refFor("documents/x.pdf"));
+
+      expect(result).toEqual({ ref: refFor("documents/x.pdf"), outcome: "deleted" });
+    });
+
+    it("blocks a stale-location ref without calling the provider", async () => {
+      const result = await createVercelBlobAdapter().delete(
+        refFor("documents/x.pdf", "vercel-blob:retired-store"),
+      );
+
+      expect(result.outcome).toBe("blocked");
+      expect(result.errorCode).toBe("storage_location_mismatch");
+      expect(mockDel).not.toHaveBeenCalled();
+    });
+
+    it("classifies an auth failure as blocked and anything else as retryable", async () => {
+      mockDel.mockRejectedValueOnce(new Error("Unauthorized: invalid token"));
+      const blocked = await createVercelBlobAdapter().delete(refFor("documents/a.pdf"));
+      expect(blocked.outcome).toBe("blocked");
+
+      mockDel.mockRejectedValueOnce(new Error("socket hang up"));
+      const retryable = await createVercelBlobAdapter().delete(refFor("documents/b.pdf"));
+      expect(retryable.outcome).toBe("retryable");
+    });
+
+    it("blocks when the token is missing entirely", async () => {
+      delete process.env.BLOB_READ_WRITE_TOKEN;
+
+      const result = await createVercelBlobAdapter().delete(refFor("documents/x.pdf"));
+
+      expect(result.outcome).toBe("blocked");
+      expect(mockDel).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("deleteMany", () => {
+    it("deletes in one bulk call when every ref is valid", async () => {
+      mockDel.mockResolvedValueOnce(undefined);
+
+      const refs = [refFor("documents/a.pdf"), refFor("documents/b.pdf")];
+      const results = await createVercelBlobAdapter().deleteMany(refs);
+
+      expect(mockDel).toHaveBeenCalledTimes(1);
+      expect(mockDel).toHaveBeenCalledWith(
+        ["documents/a.pdf", "documents/b.pdf"],
+        expect.objectContaining({ token: TOKEN }),
+      );
+      expect(results.every((r) => r.outcome === "deleted")).toBe(true);
+    });
+
+    it("retries individually when the bulk call fails, so outcomes stay per-ref", async () => {
+      // Bulk fails, then the two individual retries: one works, one does not.
+      mockDel
+        .mockRejectedValueOnce(new Error("bulk failed"))
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error("socket hang up"));
+
+      const results = await createVercelBlobAdapter().deleteMany([
+        refFor("documents/a.pdf"),
+        refFor("documents/b.pdf"),
+      ]);
+
+      // The point of the fallback: a partial failure is reported as partial,
+      // not as total failure (design doc A7).
+      expect(results.map((r) => r.outcome).sort()).toEqual(["deleted", "retryable"]);
+    });
+
+    it("keeps a stale-location ref out of the bulk call entirely", async () => {
+      mockDel.mockResolvedValueOnce(undefined);
+
+      const results = await createVercelBlobAdapter().deleteMany([
+        refFor("documents/good.pdf"),
+        refFor("documents/stale.pdf", "vercel-blob:retired-store"),
+      ]);
+
+      // Only the valid key is sent — otherwise the stale ref's pathname would
+      // be deleted out of the *current* store.
+      expect(mockDel).toHaveBeenCalledWith(["documents/good.pdf"], expect.anything());
+      expect(results.find((r) => r.ref.key === "documents/stale.pdf")?.outcome).toBe("blocked");
+    });
+  });
+
+  describe("getSignedUrl", () => {
+    it("returns the public URL for a public store", async () => {
+      mockHead.mockResolvedValueOnce({
+        url: "https://store-alpha.public.blob.vercel-storage.com/documents/x.pdf",
+      });
+
+      const url = await createVercelBlobAdapter().getSignedUrl(refFor("documents/x.pdf"));
+
+      expect(url).toBe("https://store-alpha.public.blob.vercel-storage.com/documents/x.pdf");
+    });
+  });
+});

--- a/apps/web/__tests__/api/storage/adapters/vercel-blob-adapter.test.ts
+++ b/apps/web/__tests__/api/storage/adapters/vercel-blob-adapter.test.ts
@@ -73,6 +73,17 @@ function streamOf(text: string): ReadableStream<Uint8Array> {
 }
 
 describe("vercel-blob adapter", () => {
+  // process.env is shared by every test file that runs in the same jest
+  // worker. One test here deletes BLOB_READ_WRITE_TOKEN deliberately, and a
+  // deletion that outlives this file would silently change the environment
+  // another file runs in.
+  const originalBlobToken = process.env.BLOB_READ_WRITE_TOKEN;
+
+  afterAll(() => {
+    if (originalBlobToken === undefined) delete process.env.BLOB_READ_WRITE_TOKEN;
+    else process.env.BLOB_READ_WRITE_TOKEN = originalBlobToken;
+  });
+
   beforeEach(async () => {
     jest.resetModules();
 

--- a/apps/web/__tests__/api/storage/create-storage-port.test.ts
+++ b/apps/web/__tests__/api/storage/create-storage-port.test.ts
@@ -1,10 +1,19 @@
+const mockDatabaseTarget = { adapter: "database", provider: "database" };
 const mockS3Target = { adapter: "s3", provider: "s3" };
 const mockVercelBlobTarget = { adapter: "vercel-blob", provider: "vercel-blob" };
 const mockUploadThingTarget = { adapter: "uploadthing", provider: "uploadthing" };
 
+const mockCreateDatabaseAdapter = jest.fn(() => mockDatabaseTarget);
 const mockCreateS3TargetedPort = jest.fn(() => mockS3Target);
 const mockCreateVercelBlobAdapter = jest.fn(() => mockVercelBlobTarget);
 const mockCreateUploadThingAdapter = jest.fn(() => mockUploadThingTarget);
+
+// Without this the real adapter loads, and with it ~/server/db -> engine ->
+// ~/env, whose import.meta.url cannot be parsed under babel-jest's CJS
+// transform. Same reason the other three are mocked here.
+jest.mock("~/server/storage/adapters/database-adapter", () => ({
+  createDatabaseAdapter: () => mockCreateDatabaseAdapter(),
+}));
 
 jest.mock("~/server/storage/adapters/s3-targeted-port", () => ({
   createS3TargetedPort: () => mockCreateS3TargetedPort(),
@@ -31,15 +40,26 @@ describe("createStoragePortTargetFactory", () => {
     expect(factory.forAdapter("s3")).toBe(mockS3Target);
     expect(factory.forAdapter("vercel-blob")).toBe(mockVercelBlobTarget);
     expect(factory.forAdapter("uploadthing")).toBe(mockUploadThingTarget);
+    expect(factory.forAdapter("database")).toBe(mockDatabaseTarget);
     expect(mockCreateS3TargetedPort).toHaveBeenCalledTimes(1);
     expect(mockCreateVercelBlobAdapter).toHaveBeenCalledTimes(1);
     expect(mockCreateUploadThingAdapter).toHaveBeenCalledTimes(1);
+    expect(mockCreateDatabaseAdapter).toHaveBeenCalledTimes(1);
   });
 
-  it("keeps database targeting unwired until the database adapter lands", async () => {
-    const target = createStoragePortTargetFactory("database").forAdapter("database");
+  it("still refuses an adapter it has no implementation for", async () => {
+    // Replaces "keeps database targeting unwired until the database adapter
+    // lands" — that adapter has now landed (C3), so the assertion it made is
+    // no longer true and the case above covers the wiring.
+    //
+    // What is still worth holding: an adapter with no implementation must
+    // fail loudly rather than resolve to whichever backend happens to be
+    // primary. That silent misrouting is the whole reason forAdapter() exists,
+    // so the guard outlives the specific adapter that used to demonstrate it.
+    const target = createStoragePortTargetFactory("database").forAdapter(
+      "not-a-real-adapter" as never,
+    );
 
-    expect(target.adapter).toBe("database");
     await expect(
       target.get({
         adapter: "database",

--- a/apps/web/__tests__/api/storage/create-storage-port.test.ts
+++ b/apps/web/__tests__/api/storage/create-storage-port.test.ts
@@ -1,0 +1,51 @@
+const mockS3Target = { adapter: "s3", provider: "s3" };
+const mockVercelBlobTarget = { adapter: "vercel-blob", provider: "vercel-blob" };
+const mockUploadThingTarget = { adapter: "uploadthing", provider: "uploadthing" };
+
+const mockCreateS3TargetedPort = jest.fn(() => mockS3Target);
+const mockCreateVercelBlobAdapter = jest.fn(() => mockVercelBlobTarget);
+const mockCreateUploadThingAdapter = jest.fn(() => mockUploadThingTarget);
+
+jest.mock("~/server/storage/adapters/s3-targeted-port", () => ({
+  createS3TargetedPort: () => mockCreateS3TargetedPort(),
+}));
+
+jest.mock("~/server/storage/adapters/vercel-blob-adapter", () => ({
+  createVercelBlobAdapter: () => mockCreateVercelBlobAdapter(),
+}));
+
+jest.mock("~/server/storage/adapters/uploadthing-adapter", () => ({
+  createUploadThingAdapter: () => mockCreateUploadThingAdapter(),
+}));
+
+import { createStoragePortTargetFactory } from "~/server/storage/create-storage-port";
+
+describe("createStoragePortTargetFactory", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("resolves each extracted adapter to its targeted port", () => {
+    const factory = createStoragePortTargetFactory("database");
+
+    expect(factory.forAdapter("s3")).toBe(mockS3Target);
+    expect(factory.forAdapter("vercel-blob")).toBe(mockVercelBlobTarget);
+    expect(factory.forAdapter("uploadthing")).toBe(mockUploadThingTarget);
+    expect(mockCreateS3TargetedPort).toHaveBeenCalledTimes(1);
+    expect(mockCreateVercelBlobAdapter).toHaveBeenCalledTimes(1);
+    expect(mockCreateUploadThingAdapter).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps database targeting unwired until the database adapter lands", async () => {
+    const target = createStoragePortTargetFactory("database").forAdapter("database");
+
+    expect(target.adapter).toBe("database");
+    await expect(
+      target.get({
+        adapter: "database",
+        storageLocationId: "database:pdr_file_uploads_v1",
+        key: "42",
+      }),
+    ).rejects.toThrow("not wired");
+  });
+});

--- a/apps/web/__tests__/api/storage/in-memory-storage-port.test.ts
+++ b/apps/web/__tests__/api/storage/in-memory-storage-port.test.ts
@@ -1,0 +1,41 @@
+import { createInMemoryStoragePort } from "@launchstack/core/storage";
+
+describe("createInMemoryStoragePort canonical surface", () => {
+  it("supports put/get/delete via canonical method names", async () => {
+    const port = createInMemoryStoragePort();
+
+    const uploaded = await port.put({
+      filename: "hello.txt",
+      data: Buffer.from("hello world"),
+      contentType: "text/plain",
+    });
+
+    const response = await port.get(uploaded.ref);
+    expect(response.status).toBe(200);
+    expect(await response.text()).toBe("hello world");
+
+    const deleteResult = await port.delete(uploaded.ref);
+    expect(deleteResult).toEqual({ ref: uploaded.ref, outcome: "deleted" });
+
+    const afterDelete = await port.get(uploaded.ref);
+    expect(afterDelete.status).toBe(404);
+  });
+
+  it("supports explicit adapter targeting through forAdapter", async () => {
+    const port = createInMemoryStoragePort();
+    const target = port.forAdapter("vercel-blob");
+
+    const uploaded = await target.put({
+      filename: "blob.txt",
+      data: Buffer.from("blob data"),
+      contentType: "text/plain",
+    });
+
+    expect(target.adapter).toBe("vercel-blob");
+    expect(uploaded.ref.adapter).toBe("vercel-blob");
+
+    const signedUrl = await target.getSignedUrl(uploaded.ref, { expiresIn: 60 });
+    expect(signedUrl).toContain(uploaded.ref.key);
+    expect(signedUrl).toContain("expiresIn=60");
+  });
+});

--- a/apps/web/__tests__/api/storage/in-memory-storage-port.test.ts
+++ b/apps/web/__tests__/api/storage/in-memory-storage-port.test.ts
@@ -1,7 +1,7 @@
 import { createInMemoryStoragePort } from "@launchstack/core/storage";
 
 describe("createInMemoryStoragePort canonical surface", () => {
-  it("supports put/get/delete via canonical method names", async () => {
+  it("preserves object identity across put, signed URL, get, and delete", async () => {
     const port = createInMemoryStoragePort();
 
     const uploaded = await port.put({
@@ -10,19 +10,62 @@ describe("createInMemoryStoragePort canonical surface", () => {
       contentType: "text/plain",
     });
 
+    const signedUrl = await port.getSignedUrl(uploaded.ref, { expiresIn: 300 });
+    expect(signedUrl).toContain(uploaded.ref.key);
+    expect(signedUrl).toContain("expiresIn=300");
+    expect(port.getObject(uploaded.ref)?.ref).toEqual(uploaded.ref);
+
     const response = await port.get(uploaded.ref);
     expect(response.status).toBe(200);
     expect(await response.text()).toBe("hello world");
 
     const deleteResult = await port.delete(uploaded.ref);
     expect(deleteResult).toEqual({ ref: uploaded.ref, outcome: "deleted" });
+    expect(deleteResult.ref).toEqual(uploaded.ref);
 
     const afterDelete = await port.get(uploaded.ref);
     expect(afterDelete.status).toBe(404);
   });
 
+  it("fails closed for wrong adapter and storage location without touching the object", async () => {
+    const port = createInMemoryStoragePort({
+      adapter: "vercel-blob",
+      storageLocationId: "vercel-blob:store-alpha",
+    });
+    const uploaded = await port.put({
+      filename: "identity.txt",
+      data: Buffer.from("identity"),
+      contentType: "text/plain",
+    });
+    const wrongLocationRef = {
+      ...uploaded.ref,
+      storageLocationId: "vercel-blob:store-beta",
+    };
+    const wrongAdapterRef = {
+      ...uploaded.ref,
+      adapter: "uploadthing" as const,
+      storageLocationId: "uploadthing:app-beta",
+    };
+
+    expect((await port.get(wrongLocationRef)).status).toBe(404);
+    expect((await port.get(wrongAdapterRef)).status).toBe(404);
+    expect(await port.delete(wrongLocationRef)).toEqual({
+      ref: wrongLocationRef,
+      outcome: "not_found",
+    });
+    expect(await port.delete(wrongAdapterRef)).toEqual({
+      ref: wrongAdapterRef,
+      outcome: "not_found",
+    });
+    expect(await port.get(uploaded.ref)).toHaveProperty("status", 200);
+    expect(port.getObject(uploaded.ref)?.data.toString()).toBe("identity");
+  });
+
   it("supports explicit adapter targeting through forAdapter", async () => {
-    const port = createInMemoryStoragePort();
+    const port = createInMemoryStoragePort({
+      adapter: "database",
+      storageLocationId: "memory:database",
+    });
     const target = port.forAdapter("vercel-blob");
 
     const uploaded = await target.put({
@@ -33,9 +76,31 @@ describe("createInMemoryStoragePort canonical surface", () => {
 
     expect(target.adapter).toBe("vercel-blob");
     expect(uploaded.ref.adapter).toBe("vercel-blob");
+    expect(uploaded.ref.storageLocationId).toBe("memory:vercel-blob");
 
     const signedUrl = await target.getSignedUrl(uploaded.ref, { expiresIn: 60 });
     expect(signedUrl).toContain(uploaded.ref.key);
     expect(signedUrl).toContain("expiresIn=60");
+
+    const defaultUploaded = await port.put({
+      filename: "database.txt",
+      data: Buffer.from("database data"),
+      contentType: "text/plain",
+    });
+    expect(defaultUploaded.ref.adapter).toBe("database");
+    expect(defaultUploaded.ref.storageLocationId).toBe("memory:database");
+    expect((await target.get(uploaded.ref)).status).toBe(200);
+
+    const defaultIdentityForTarget = {
+      ...uploaded.ref,
+      adapter: "database" as const,
+      storageLocationId: "memory:database",
+    };
+    expect((await port.get(defaultIdentityForTarget)).status).toBe(404);
+    expect(await port.delete(defaultIdentityForTarget)).toEqual({
+      ref: defaultIdentityForTarget,
+      outcome: "not_found",
+    });
+    expect((await target.get(uploaded.ref)).status).toBe(200);
   });
 });

--- a/apps/web/__tests__/api/storage/inventory.test.ts
+++ b/apps/web/__tests__/api/storage/inventory.test.ts
@@ -5,17 +5,35 @@ const mockListObjectsPrivileged = jest.fn();
 
 jest.mock("server-only", () => ({}));
 
+/** JWT-shaped token whose payload carries appId, which is how the location id is derived. */
+function uploadThingTokenFor(appId: string): string {
+  const payload = Buffer.from(JSON.stringify({ appId })).toString("base64url");
+  return `header.${payload}.signature`;
+}
+
+const mockEnvData = {
+  server: {
+    NEXT_PUBLIC_S3_ENDPOINT: TEST_ENDPOINT,
+    S3_BUCKET_NAME: TEST_BUCKET,
+    BLOB_READ_WRITE_TOKEN: "vercel_blob_rw_store-alpha_token-v1",
+    UPLOADTHING_TOKEN: "",
+  },
+  client: {
+    NEXT_PUBLIC_S3_ENDPOINT: TEST_ENDPOINT,
+  },
+};
+
 jest.mock("~/env", () => ({
-  env: {
-    server: {
-      NEXT_PUBLIC_S3_ENDPOINT: TEST_ENDPOINT,
-      S3_BUCKET_NAME: TEST_BUCKET,
-      BLOB_READ_WRITE_TOKEN: "vercel_blob_rw_store-alpha_token-v1",
-      UPLOADTHING_TOKEN: "",
-    },
-    client: {
-      NEXT_PUBLIC_S3_ENDPOINT: TEST_ENDPOINT,
-    },
+  get env() {
+    return mockEnvData;
+  },
+}));
+
+const mockListFiles = jest.fn();
+
+jest.mock("uploadthing/server", () => ({
+  UTApi: class {
+    listFiles = (...args: unknown[]) => mockListFiles(...args);
   },
 }));
 
@@ -36,21 +54,26 @@ import { listObjectsPrivileged } from "~/server/storage/inventory";
 describe("listObjectsPrivileged", () => {
   beforeEach(() => {
     mockListObjectsPrivileged.mockReset();
+    mockListFiles.mockReset();
+    mockEnvData.server.UPLOADTHING_TOKEN = "";
   });
 
-  it("returns explicit unavailable for adapters without listing support", async () => {
+  it("reports unavailable — not blocked — when UploadThing is simply not configured", async () => {
+    // The env mock leaves UPLOADTHING_TOKEN empty. A deployment that does not
+    // use UploadThing has nothing to list, which is "unknown", not "a config
+    // error a human must fix". C3's audit treats unavailable as unknown and
+    // must not mistake it for zero orphans.
     const result = await listObjectsPrivileged({
       adapter: "uploadthing",
       storageLocationId: "uploadthing:app_test@us-east-1",
     });
 
     expect(result.ok).toBe(false);
-    if (result.ok) {
-      throw new Error("Expected unavailable error");
-    }
+    if (result.ok) throw new Error("Expected unavailable error");
 
     expect(result.error.kind).toBe("unavailable");
-    expect(result.error.code).toBe("uploadthing_list_unavailable");
+    expect(result.error.code).toBe("uploadthing_token_missing");
+    expect(mockListFiles).not.toHaveBeenCalled();
   });
 
   it("returns blocked when storage location id mismatches active adapter identity", async () => {
@@ -109,5 +132,107 @@ describe("listObjectsPrivileged", () => {
         etag: '"etag-a"',
       },
     ]);
+  });
+
+  describe("uploadthing listing (C5)", () => {
+    const APP_ID = "app_test";
+    const LOCATION = `uploadthing:${APP_ID}`;
+
+    beforeEach(() => {
+      mockEnvData.server.UPLOADTHING_TOKEN = uploadThingTokenFor(APP_ID);
+    });
+
+    it("lists files as canonical refs and pages by offset", async () => {
+      mockListFiles.mockResolvedValueOnce({
+        files: [
+          { key: "file-key-1", size: 1024, uploadedAt: 1700000000000 },
+          { key: "file-key-2", size: 2048, uploadedAt: 1700000001000 },
+        ],
+        hasMore: true,
+      });
+
+      const result = await listObjectsPrivileged({
+        adapter: "uploadthing",
+        storageLocationId: LOCATION,
+        limit: 2,
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) throw new Error("Expected a successful listing");
+
+      expect(result.objects).toHaveLength(2);
+      expect(result.objects[0]).toMatchObject({
+        key: "file-key-1",
+        ref: { adapter: "uploadthing", storageLocationId: LOCATION, key: "file-key-1" },
+        size: 1024,
+      });
+      // uploadedAt arrives as epoch ms, not a Date.
+      expect(result.objects[0]?.lastModified).toBe(new Date(1700000000000).toISOString());
+
+      // The cursor is the next offset, kept opaque to callers.
+      expect(result.nextCursor).toBe("2");
+      expect(mockListFiles).toHaveBeenCalledWith({ limit: 2, offset: 0 });
+    });
+
+    it("stops paging when the provider says there is no more", async () => {
+      mockListFiles.mockResolvedValueOnce({ files: [{ key: "only" }], hasMore: false });
+
+      const result = await listObjectsPrivileged({
+        adapter: "uploadthing",
+        storageLocationId: LOCATION,
+        cursor: "40",
+      });
+
+      expect(result.ok).toBe(true);
+      if (!result.ok) throw new Error("Expected a successful listing");
+      expect(result.nextCursor).toBeUndefined();
+      expect(mockListFiles).toHaveBeenCalledWith({ limit: 200, offset: 40 });
+    });
+
+    it("refuses a prefix rather than silently ignoring it", async () => {
+      // Ignoring the prefix would hand back objects the caller did not ask
+      // for, and let an audit believe it had scanned a narrower set than it
+      // really did.
+      const result = await listObjectsPrivileged({
+        adapter: "uploadthing",
+        storageLocationId: LOCATION,
+        prefix: "documents/",
+      });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error("Expected prefix to be refused");
+      expect(result.error.kind).toBe("invalid_request");
+      expect(mockListFiles).not.toHaveBeenCalled();
+    });
+
+    it("blocks a location from a different UploadThing app", async () => {
+      const result = await listObjectsPrivileged({
+        adapter: "uploadthing",
+        storageLocationId: "uploadthing:some-other-app",
+      });
+
+      expect(result.ok).toBe(false);
+      if (result.ok) throw new Error("Expected a location mismatch");
+      expect(result.error.code).toBe("storage_location_mismatch");
+      expect(mockListFiles).not.toHaveBeenCalled();
+    });
+
+    it("separates a permanent auth failure from a transient one", async () => {
+      mockListFiles.mockRejectedValueOnce(new Error("Unauthorized"));
+      const blocked = await listObjectsPrivileged({
+        adapter: "uploadthing",
+        storageLocationId: LOCATION,
+      });
+      expect(blocked.ok).toBe(false);
+      if (!blocked.ok) expect(blocked.error.kind).toBe("blocked");
+
+      mockListFiles.mockRejectedValueOnce(new Error("ETIMEDOUT"));
+      const retryable = await listObjectsPrivileged({
+        adapter: "uploadthing",
+        storageLocationId: LOCATION,
+      });
+      expect(retryable.ok).toBe(false);
+      if (!retryable.ok) expect(retryable.error.kind).toBe("retryable");
+    });
   });
 });

--- a/apps/web/__tests__/api/storage/inventory.test.ts
+++ b/apps/web/__tests__/api/storage/inventory.test.ts
@@ -1,7 +1,7 @@
 const TEST_ENDPOINT = "http://localhost:8333";
 const TEST_BUCKET = "pdr-documents";
 
-const mockS3Send = jest.fn();
+const mockListObjectsPrivileged = jest.fn();
 
 jest.mock("server-only", () => ({}));
 
@@ -19,9 +19,10 @@ jest.mock("~/env", () => ({
   },
 }));
 
-jest.mock("~/server/storage/s3-client", () => ({
-  getS3Client: () => ({ send: mockS3Send }),
-  getS3BucketName: () => TEST_BUCKET,
+jest.mock("~/server/storage/adapters/s3-adapter", () => ({
+  getS3StorageAdapter: () => ({
+    listObjectsPrivileged: mockListObjectsPrivileged,
+  }),
 }));
 
 jest.mock("~/server/db", () => ({
@@ -34,7 +35,7 @@ import { listObjectsPrivileged } from "~/server/storage/inventory";
 
 describe("listObjectsPrivileged", () => {
   beforeEach(() => {
-    mockS3Send.mockReset();
+    mockListObjectsPrivileged.mockReset();
   });
 
   it("returns explicit unavailable for adapters without listing support", async () => {
@@ -65,21 +66,20 @@ describe("listObjectsPrivileged", () => {
 
     expect(result.error.kind).toBe("blocked");
     expect(result.error.code).toBe("storage_location_mismatch");
-    expect(mockS3Send).not.toHaveBeenCalled();
+    expect(mockListObjectsPrivileged).not.toHaveBeenCalled();
   });
 
   it("lists S3 objects with canonical refs and pagination cursor", async () => {
-    mockS3Send.mockResolvedValue({
-      Contents: [
+    mockListObjectsPrivileged.mockResolvedValue({
+      objects: [
         {
-          Key: "documents/a.pdf",
-          Size: 123,
-          LastModified: new Date("2026-01-01T00:00:00.000Z"),
-          ETag: '"etag-a"',
+          key: "documents/a.pdf",
+          size: 123,
+          lastModified: "2026-01-01T00:00:00.000Z",
+          etag: '"etag-a"',
         },
       ],
-      IsTruncated: true,
-      NextContinuationToken: "next-1",
+      nextCursor: "next-1",
     });
 
     const result = await listObjectsPrivileged({

--- a/apps/web/__tests__/api/storage/s3-adapter.test.ts
+++ b/apps/web/__tests__/api/storage/s3-adapter.test.ts
@@ -1,0 +1,165 @@
+const mockSend = jest.fn();
+const mockS3ClientCtor = jest.fn();
+
+class MockCommand {
+  public readonly input: unknown;
+
+  constructor(input: unknown) {
+    this.input = input;
+  }
+}
+
+jest.mock("@aws-sdk/client-s3", () => {
+  mockS3ClientCtor.mockImplementation((config: unknown) => ({
+    send: mockSend,
+    __config: config,
+  }));
+
+  return {
+    S3Client: mockS3ClientCtor,
+    PutObjectCommand: MockCommand,
+    GetObjectCommand: MockCommand,
+    DeleteObjectCommand: MockCommand,
+    DeleteObjectsCommand: MockCommand,
+    CreateBucketCommand: MockCommand,
+    HeadBucketCommand: MockCommand,
+    ListObjectsV2Command: MockCommand,
+  };
+});
+
+jest.mock("@aws-sdk/s3-request-presigner", () => ({
+  getSignedUrl: jest.fn(),
+}));
+
+jest.mock("~/env", () => ({
+  env: {
+    server: {
+      NEXT_PUBLIC_S3_ENDPOINT: "http://fallback:8333",
+      S3_PUBLIC_ENDPOINT: undefined,
+      S3_REGION: "us-east-1",
+      S3_ACCESS_KEY: "fallback-key",
+      S3_SECRET_KEY: "fallback-secret",
+      S3_BUCKET_NAME: "fallback-bucket",
+    },
+    client: {
+      NEXT_PUBLIC_S3_ENDPOINT: "http://fallback:8333",
+    },
+  },
+}));
+
+const originalEnv = process.env;
+
+describe("S3StorageAdapter", () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+
+    delete process.env.STORAGE_S3_ENDPOINT;
+    delete process.env.STORAGE_S3_PUBLIC_ENDPOINT;
+    delete process.env.STORAGE_S3_REGION;
+    delete process.env.STORAGE_S3_ACCESS_KEY;
+    delete process.env.STORAGE_S3_SECRET_KEY;
+    delete process.env.STORAGE_S3_BUCKET_NAME;
+    delete process.env.STORAGE_S3_FORCE_PATH_STYLE;
+    delete process.env.STORAGE_S3_ENSURE_BUCKET_EXISTS;
+    delete process.env.NEXT_PUBLIC_S3_ENDPOINT;
+    delete process.env.S3_PUBLIC_ENDPOINT;
+    delete process.env.S3_REGION;
+    delete process.env.S3_ACCESS_KEY;
+    delete process.env.S3_SECRET_KEY;
+    delete process.env.S3_BUCKET_NAME;
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  it("builds Seaweed-style path URLs and trims trailing slashes", async () => {
+    process.env.STORAGE_S3_ENDPOINT = "http://localhost:8333/";
+    process.env.STORAGE_S3_BUCKET_NAME = "pdr-documents";
+    process.env.STORAGE_S3_ACCESS_KEY = "seaweed-key";
+    process.env.STORAGE_S3_SECRET_KEY = "seaweed-secret";
+
+    const { getS3StorageAdapter } = await import("~/server/storage/adapters/s3-adapter");
+    const adapter = getS3StorageAdapter();
+
+    expect(adapter.getObjectUrl("documents/test.pdf")).toBe(
+      "http://localhost:8333/pdr-documents/documents/test.pdf",
+    );
+  });
+
+  it("keeps path-style URL minting when virtual-hosted requests are enabled", async () => {
+    process.env.STORAGE_S3_ENDPOINT = "https://s3.example.com";
+    process.env.STORAGE_S3_BUCKET_NAME = "tenant-a";
+    process.env.STORAGE_S3_ACCESS_KEY = "key";
+    process.env.STORAGE_S3_SECRET_KEY = "secret";
+    process.env.STORAGE_S3_FORCE_PATH_STYLE = "false";
+
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const { getS3StorageAdapter } = await import("~/server/storage/adapters/s3-adapter");
+    const adapter = getS3StorageAdapter();
+
+    expect(adapter.getObjectUrl("docs/a.pdf")).toBe("https://s3.example.com/tenant-a/docs/a.pdf");
+    expect(adapter.getObjectUrl("docs/b.pdf")).toBe("https://s3.example.com/tenant-a/docs/b.pdf");
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0]?.[0]).toContain("path-style URLs");
+
+    warnSpy.mockRestore();
+  });
+
+  it("passes forcePathStyle=true to S3Client by default", async () => {
+    process.env.STORAGE_S3_ENDPOINT = "http://localhost:8333";
+    process.env.STORAGE_S3_BUCKET_NAME = "bucket";
+    process.env.STORAGE_S3_ACCESS_KEY = "key";
+    process.env.STORAGE_S3_SECRET_KEY = "secret";
+
+    const { getS3StorageAdapter } = await import("~/server/storage/adapters/s3-adapter");
+    const adapter = getS3StorageAdapter();
+
+    adapter.getClient();
+
+    expect(mockS3ClientCtor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpoint: "http://localhost:8333",
+        forcePathStyle: true,
+      }),
+    );
+  });
+
+  it("passes forcePathStyle=false to S3Client when configured", async () => {
+    process.env.STORAGE_S3_ENDPOINT = "https://s3.example.com";
+    process.env.STORAGE_S3_BUCKET_NAME = "bucket";
+    process.env.STORAGE_S3_ACCESS_KEY = "key";
+    process.env.STORAGE_S3_SECRET_KEY = "secret";
+    process.env.STORAGE_S3_FORCE_PATH_STYLE = "false";
+
+    const { getS3StorageAdapter } = await import("~/server/storage/adapters/s3-adapter");
+    const adapter = getS3StorageAdapter();
+
+    adapter.getClient();
+
+    expect(mockS3ClientCtor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        endpoint: "https://s3.example.com",
+        forcePathStyle: false,
+      }),
+    );
+  });
+
+  it("supports Seaweed-style public gateway endpoints with path prefixes", async () => {
+    process.env.STORAGE_S3_ENDPOINT = "http://seaweedfs:8333";
+    process.env.STORAGE_S3_PUBLIC_ENDPOINT = "https://cdn.example.com/objects/";
+    process.env.STORAGE_S3_BUCKET_NAME = "launchstack-docs";
+    process.env.STORAGE_S3_ACCESS_KEY = "key";
+    process.env.STORAGE_S3_SECRET_KEY = "secret";
+
+    const { getS3StorageAdapter } = await import("~/server/storage/adapters/s3-adapter");
+    const adapter = getS3StorageAdapter();
+
+    expect(adapter.getObjectUrl("documents/demo.txt")).toBe(
+      "https://cdn.example.com/objects/launchstack-docs/documents/demo.txt",
+    );
+  });
+});

--- a/apps/web/__tests__/api/storage/s3-targeted-port.test.ts
+++ b/apps/web/__tests__/api/storage/s3-targeted-port.test.ts
@@ -1,0 +1,138 @@
+import type { ObjectRef } from "@launchstack/core/storage";
+
+const STORAGE_LOCATION_ID = "s3:http://localhost:8333@bucket";
+const mockPut = jest.fn();
+const mockGetObjectUrl = jest.fn();
+const mockDeleteObject = jest.fn();
+const mockDeleteObjects = jest.fn();
+const mockGetSignedUrl = jest.fn();
+const mockFetch = jest.fn();
+
+const mockAdapter = {
+  put: (...args: unknown[]) => mockPut(...args),
+  getObjectUrl: (...args: unknown[]) => mockGetObjectUrl(...args),
+  deleteObject: (...args: unknown[]) => mockDeleteObject(...args),
+  deleteObjects: (...args: unknown[]) => mockDeleteObjects(...args),
+  getSignedUrl: (...args: unknown[]) => mockGetSignedUrl(...args),
+  mintRef: jest.fn(),
+};
+
+jest.mock("~/server/storage/adapters/s3-adapter", () => ({
+  getS3StorageAdapter: () => mockAdapter,
+}));
+
+jest.mock("~/lib/storage-location-id", () => ({
+  resolveStorageLocationId: jest.fn(() => STORAGE_LOCATION_ID),
+}));
+
+import { createS3TargetedPort } from "~/server/storage/adapters/s3-targeted-port";
+
+function makeRef(key = "documents/file.pdf"): ObjectRef {
+  return {
+    adapter: "s3",
+    storageLocationId: STORAGE_LOCATION_ID,
+    key,
+  };
+}
+
+describe("createS3TargetedPort", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockFetch.mockResolvedValue(new Response("file contents"));
+    global.fetch = mockFetch as unknown as typeof fetch;
+  });
+
+  it("puts an UploadInput through the S3 adapter with a provider key", async () => {
+    const ref = makeRef("documents/generated-report.pdf");
+    mockPut.mockResolvedValue({
+      ref,
+      url: "https://objects.example/bucket/documents/generated-report.pdf",
+      pathname: ref.key,
+      provider: "s3",
+    });
+
+    const port = createS3TargetedPort();
+    const result = await port.put({
+      filename: "generated report.pdf",
+      data: new Uint8Array([1, 2, 3]),
+      contentType: "application/pdf",
+    });
+
+    expect(mockPut).toHaveBeenCalledWith({
+      key: expect.stringMatching(/^documents\/[0-9a-f-]+-generated-report\.pdf$/),
+      body: Buffer.from([1, 2, 3]),
+      contentType: "application/pdf",
+    });
+    expect(result).toMatchObject({
+      ref,
+      url: "https://objects.example/bucket/documents/generated-report.pdf",
+      pathname: ref.key,
+      contentType: "application/pdf",
+      provider: "s3",
+    });
+  });
+
+  it("gets a ref by fetching the S3 object URL", async () => {
+    const ref = makeRef();
+    const init = { headers: { "if-none-match": "etag-value" } };
+    mockGetObjectUrl.mockReturnValue("https://objects.example/bucket/documents/file.pdf");
+
+    const response = await createS3TargetedPort().get(ref, init);
+
+    expect(mockGetObjectUrl).toHaveBeenCalledWith(ref.key);
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://objects.example/bucket/documents/file.pdf",
+      init,
+    );
+    expect(response).toBeInstanceOf(Response);
+  });
+
+  it("returns a stable deleted outcome after deleting one ref", async () => {
+    const ref = makeRef();
+    mockDeleteObject.mockResolvedValue(undefined);
+
+    await expect(createS3TargetedPort().delete(ref)).resolves.toEqual({
+      ref,
+      outcome: "deleted",
+    });
+    expect(mockDeleteObject).toHaveBeenCalledWith(ref.key);
+  });
+
+  it("preserves one outcome per ref for batch deletion", async () => {
+    const refs = [makeRef("documents/a.pdf"), makeRef("documents/b.pdf")];
+    mockDeleteObjects.mockResolvedValue([
+      { key: "documents/a.pdf", outcome: "deleted" },
+      {
+        key: "documents/b.pdf",
+        outcome: "blocked",
+        errorCode: "AccessDenied",
+        message: "access denied",
+      },
+    ]);
+
+    await expect(createS3TargetedPort().deleteMany(refs)).resolves.toEqual([
+      { ref: refs[0], outcome: "deleted" },
+      {
+        ref: refs[1],
+        outcome: "blocked",
+        errorCode: "AccessDenied",
+        message: "access denied",
+      },
+    ]);
+    expect(mockDeleteObjects).toHaveBeenCalledWith(["documents/a.pdf", "documents/b.pdf"]);
+  });
+
+  it("generates a download signed URL for a ref", async () => {
+    const ref = makeRef();
+    mockGetSignedUrl.mockResolvedValue("https://signed.example/file.pdf");
+
+    await expect(
+      createS3TargetedPort().getSignedUrl(ref, { expiresIn: 600 }),
+    ).resolves.toBe("https://signed.example/file.pdf");
+    expect(mockGetSignedUrl).toHaveBeenCalledWith({
+      ref,
+      operation: "get",
+      expiresIn: 600,
+    });
+  });
+});

--- a/apps/web/__tests__/api/storage/storage-adapter.pbt.test.ts
+++ b/apps/web/__tests__/api/storage/storage-adapter.pbt.test.ts
@@ -94,11 +94,11 @@ jest.mock("drizzle-orm", () => ({
   eq: jest.fn((...args: unknown[]) => args),
 }));
 
-// ─── Mock Vercel Blob (legacy read-path compat only) ─────────────────────────
+// ─── Mock Vercel Blob (legacy delete-path compat only) ──────────────────────
 
-const mockFetchBlob = jest.fn().mockResolvedValue(new Response("blob-content"));
-const mockIsPrivateBlobUrl = jest.fn((url: string) => url.includes(".private.blob."));
 const mockDeleteBlobFile = jest.fn().mockResolvedValue(undefined);
+const mockTargetPut = jest.fn();
+const mockTargetGet = jest.fn();
 const mockTargetDelete = jest.fn().mockImplementation(async (ref: unknown) => ({
   ref,
   outcome: "deleted" as const,
@@ -108,14 +108,14 @@ const mockTargetDeleteMany = jest.fn().mockImplementation(async (refs: unknown[]
 );
 
 jest.mock("~/server/storage/vercel-blob", () => ({
-  fetchBlob: (...args: unknown[]) => mockFetchBlob(...args),
-  isPrivateBlobUrl: (...args: unknown[]) => mockIsPrivateBlobUrl(...(args as [string])),
   deleteFile: (...args: unknown[]) => mockDeleteBlobFile(...args),
 }));
 
 jest.mock("~/server/storage/create-storage-port", () => ({
   createStoragePortTargetFactory: () => ({
     forAdapter: () => ({
+      put: (...args: unknown[]) => mockTargetPut(...args),
+      get: (...args: unknown[]) => mockTargetGet(...args),
       delete: (...args: unknown[]) => mockTargetDelete(...args),
       deleteMany: (...args: unknown[]) => mockTargetDeleteMany(...args),
     }),
@@ -172,8 +172,18 @@ beforeEach(() => {
   );
   mockEnsureBucketExists.mockClear().mockResolvedValue(undefined);
   mockInsertReturning.mockClear().mockImplementation(() => Promise.resolve([{ id: 42 }]));
-  mockFetchBlob.mockClear().mockResolvedValue(new Response("blob-content"));
   mockDeleteBlobFile.mockClear().mockResolvedValue(undefined);
+  mockTargetPut.mockClear().mockResolvedValue({
+    url: "/api/files/42",
+    pathname: "documents/mock-upload",
+    ref: {
+      adapter: "database" as const,
+      storageLocationId: "database:pdr_file_uploads_v1",
+      key: "42",
+    },
+    provider: "database",
+  });
+  mockTargetGet.mockClear().mockResolvedValue(new Response("blob-content"));
   mockTargetDelete.mockClear().mockImplementation(async (ref: unknown) => ({
     ref,
     outcome: "deleted" as const,
@@ -202,6 +212,51 @@ import {
   isS3Storage,
 } from "~/lib/storage";
 import { resolveStorageLocationId } from "~/lib/storage-location-id";
+
+describe("Feature: database storage shims", () => {
+  it("routes database uploadFile through the targeted adapter", async () => {
+    setProvider("database");
+
+    const result = await uploadFile({
+      filename: "database.txt",
+      data: Buffer.from("database"),
+      contentType: "text/plain",
+      userId: "user-1",
+    });
+
+    expect(mockTargetPut).toHaveBeenCalledWith({
+      filename: "database.txt",
+      data: expect.any(Buffer),
+      contentType: "text/plain",
+      userId: "user-1",
+    });
+    expect(mockTargetPut).toHaveBeenCalledTimes(1);
+    expect(mockInsertReturning).not.toHaveBeenCalled();
+    expect(result.provider).toBe("database");
+  });
+
+  it("routes database deleteManyByRef through the targeted adapter", async () => {
+    setProvider("database");
+    const refs = [
+      {
+        adapter: "database" as const,
+        storageLocationId: "database:pdr_file_uploads_v1",
+        key: "42",
+      },
+      {
+        adapter: "database" as const,
+        storageLocationId: "database:pdr_file_uploads_v1",
+        key: "43",
+      },
+    ];
+
+    const results = await deleteManyByRef(refs);
+
+    expect(mockTargetDeleteMany).toHaveBeenCalledWith(refs);
+    expect(mockTargetDelete).not.toHaveBeenCalled();
+    expect(results).toEqual(refs.map((ref) => ({ ref, outcome: "deleted" })));
+  });
+});
 
 // ─── Property 5: Upload result shape and persistence consistency ─────────────
 
@@ -302,7 +357,7 @@ describe(
           dataArb,
           userIdArb,
           async (errorMsg, filename, data, userId) => {
-            mockInsertReturning.mockRejectedValue(new Error(errorMsg));
+            mockTargetPut.mockRejectedValue(new Error(errorMsg));
 
             try {
               await uploadFile({ filename, data, userId });
@@ -350,7 +405,7 @@ describe(
       );
     });
 
-    it("fetchFile routes S3 URLs to plain fetch and legacy private-blob URLs to fetchBlob", async () => {
+    it("fetchFile routes S3 URLs to plain fetch and private-blob URLs to the targeted adapter", async () => {
       setProvider("s3");
 
       const originalFetch = global.fetch;
@@ -366,7 +421,14 @@ describe(
 
         const privateBlobUrl = "https://store.private.blob.vercel-storage.com/documents/test.pdf";
         await fetchFile(privateBlobUrl);
-        expect(mockFetchBlob).toHaveBeenCalledWith(privateBlobUrl, undefined);
+        expect(mockTargetGet).toHaveBeenCalledWith(
+          expect.objectContaining({
+            adapter: "vercel-blob",
+            storageLocationId: "vercel-blob:store-alpha",
+            key: "documents/test.pdf",
+          }),
+          undefined,
+        );
       } finally {
         global.fetch = originalFetch;
       }
@@ -571,12 +633,18 @@ describe("Feature: blob deletion routing and identity", () => {
 });
 
 describe("Feature: database deletion by canonical URL", () => {
-  it("deleteFileByUrl('/api/files/{id}') deletes the matching fileUploads row only", async () => {
+  it("deleteFileByUrl('/api/files/{id}') routes through the database adapter", async () => {
     await deleteFileByUrl("/api/files/4242");
 
-    expect(mockDelete).toHaveBeenCalledTimes(1);
-    expect(mockDelete).toHaveBeenCalledWith(["id", 4242]);
-    expect(mockDelete).not.toHaveBeenCalledWith(["id", 9999]);
+    expect(mockTargetDelete).toHaveBeenCalledTimes(1);
+    expect(mockTargetDelete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        adapter: "database",
+        storageLocationId: "database:pdr_file_uploads_v1",
+        key: "4242",
+      }),
+    );
+    expect(mockDelete).not.toHaveBeenCalled();
 
     expect(mockDeleteBlobFile).not.toHaveBeenCalled();
     expect(mockDeleteObject).not.toHaveBeenCalled();

--- a/apps/web/__tests__/api/storage/storage-adapter.pbt.test.ts
+++ b/apps/web/__tests__/api/storage/storage-adapter.pbt.test.ts
@@ -99,11 +99,27 @@ jest.mock("drizzle-orm", () => ({
 const mockFetchBlob = jest.fn().mockResolvedValue(new Response("blob-content"));
 const mockIsPrivateBlobUrl = jest.fn((url: string) => url.includes(".private.blob."));
 const mockDeleteBlobFile = jest.fn().mockResolvedValue(undefined);
+const mockTargetDelete = jest.fn().mockImplementation(async (ref: unknown) => ({
+  ref,
+  outcome: "deleted" as const,
+}));
+const mockTargetDeleteMany = jest.fn().mockImplementation(async (refs: unknown[]) =>
+  refs.map((ref) => ({ ref, outcome: "deleted" as const })),
+);
 
 jest.mock("~/server/storage/vercel-blob", () => ({
   fetchBlob: (...args: unknown[]) => mockFetchBlob(...args),
   isPrivateBlobUrl: (...args: unknown[]) => mockIsPrivateBlobUrl(...(args as [string])),
   deleteFile: (...args: unknown[]) => mockDeleteBlobFile(...args),
+}));
+
+jest.mock("~/server/storage/create-storage-port", () => ({
+  createStoragePortTargetFactory: () => ({
+    forAdapter: () => ({
+      delete: (...args: unknown[]) => mockTargetDelete(...args),
+      deleteMany: (...args: unknown[]) => mockTargetDeleteMany(...args),
+    }),
+  }),
 }));
 
 // ─── Mock UploadThing server SDK ────────────────────────────────────────────
@@ -158,6 +174,13 @@ beforeEach(() => {
   mockInsertReturning.mockClear().mockImplementation(() => Promise.resolve([{ id: 42 }]));
   mockFetchBlob.mockClear().mockResolvedValue(new Response("blob-content"));
   mockDeleteBlobFile.mockClear().mockResolvedValue(undefined);
+  mockTargetDelete.mockClear().mockImplementation(async (ref: unknown) => ({
+    ref,
+    outcome: "deleted" as const,
+  }));
+  mockTargetDeleteMany.mockClear().mockImplementation(async (refs: unknown[]) =>
+    refs.map((ref) => ({ ref, outcome: "deleted" as const })),
+  );
   mockUploadThingDeleteFiles.mockClear().mockResolvedValue({ success: true, deletedCount: 1 });
   mockUploadThingCtor.mockClear();
   mockDelete.mockClear().mockResolvedValue(undefined);
@@ -168,6 +191,7 @@ beforeEach(() => {
 
 import {
   uploadFile,
+  deleteFile,
   deleteFileByUrl,
   deleteFileByRef,
   deleteManyByRef,
@@ -415,6 +439,35 @@ describe(
 describe(
   "Feature: storage unification, Property 12: S3 put/delete key identity",
   () => {
+    it("direct S3 deleteFile promotes a full object URL before deleting", async () => {
+      setProvider("s3");
+      const key = "documents/direct-url.pdf";
+      const url = `${TEST_ENDPOINT}/${TEST_BUCKET}/${key}`;
+
+      await deleteFile(url, "s3");
+
+      expect(mockDeleteObject).toHaveBeenCalledWith(key);
+    });
+
+    it("direct S3 deleteFile preserves an opaque key", async () => {
+      setProvider("s3");
+      const key = "documents/opaque-key.pdf";
+
+      await deleteFile(key, "s3");
+
+      expect(mockDeleteObject).toHaveBeenCalledWith(key);
+    });
+
+    it("direct S3 deleteFile rejects a URL from another origin", async () => {
+      setProvider("s3");
+
+      await expect(
+        deleteFile("https://evil.example/pdr-documents/documents/file.pdf", "s3"),
+      ).rejects.toBeInstanceOf(StorageError);
+
+      expect(mockDeleteObject).not.toHaveBeenCalled();
+    });
+
     it("deleteFileByUrl strips endpoint and bucket, never sending duplicated bucket in DeleteObject Key", async () => {
       setProvider("s3");
 
@@ -427,12 +480,12 @@ describe(
             const url = `${TEST_ENDPOINT}/${TEST_BUCKET}/${key}`;
             await deleteFileByUrl(url);
 
-            expect(mockDeleteObject).toHaveBeenCalled();
-            const calledKey = mockDeleteObject.mock.calls.at(-1)?.[0] as string;
+            expect(mockTargetDelete).toHaveBeenCalled();
+            const calledRef = mockTargetDelete.mock.calls.at(-1)?.[0] as { key: string };
             const expectedFromUrl = new URL(url).pathname.replace(`/${TEST_BUCKET}/`, "").replace(/^\/+/, "");
-            expect(calledKey).toBe(expectedFromUrl);
-            expect(calledKey.startsWith(`${TEST_BUCKET}/`)).toBe(false);
-            expect(calledKey.includes(`${TEST_BUCKET}/${TEST_BUCKET}/`)).toBe(false);
+            expect(calledRef.key).toBe(expectedFromUrl);
+            expect(calledRef.key.startsWith(`${TEST_BUCKET}/`)).toBe(false);
+            expect(calledRef.key.includes(`${TEST_BUCKET}/${TEST_BUCKET}/`)).toBe(false);
           },
         ),
         { numRuns: 50 },
@@ -456,8 +509,8 @@ describe(
 
             await deleteFileByUrl(uploaded.url);
 
-            const deleteKey = mockDeleteObject.mock.calls.at(-1)?.[0] as string;
-            expect(deleteKey).toBe(putKey);
+            const deleteRef = mockTargetDelete.mock.calls.at(-1)?.[0] as { key: string };
+            expect(deleteRef.key).toBe(putKey);
           },
         ),
         { numRuns: 50 },
@@ -472,8 +525,14 @@ describe("Feature: blob deletion routing and identity", () => {
 
     await deleteFileByUrl(blobUrl);
 
-    expect(mockDeleteBlobFile).toHaveBeenCalledTimes(1);
-    expect(mockDeleteBlobFile).toHaveBeenCalledWith("api/files/4242");
+    expect(mockTargetDelete).toHaveBeenCalledTimes(1);
+    expect(mockTargetDelete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        adapter: "vercel-blob",
+        key: "api/files/4242",
+      }),
+    );
+    expect(mockDeleteBlobFile).not.toHaveBeenCalled();
     expect(mockDelete).not.toHaveBeenCalled();
   });
 
@@ -506,6 +565,7 @@ describe("Feature: blob deletion routing and identity", () => {
     const result = await deleteFileByRef(oldRef);
     expect(result.outcome).toBe("blocked");
     expect(result.errorCode).toBe("storage_location_mismatch");
+    expect(mockTargetDelete).not.toHaveBeenCalled();
     expect(mockDeleteBlobFile).not.toHaveBeenCalled();
   });
 });
@@ -538,8 +598,14 @@ describe("Feature: UploadThing adapter routing", () => {
 
     await deleteFileByUrl(utfsUrl);
 
-    expect(mockUploadThingCtor).toHaveBeenCalledWith({ token: TEST_UPLOADTHING_TOKEN });
-    expect(mockUploadThingDeleteFiles).toHaveBeenCalledWith(key);
+    expect(mockTargetDelete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        adapter: "uploadthing",
+        key,
+      }),
+    );
+    expect(mockUploadThingCtor).not.toHaveBeenCalled();
+    expect(mockUploadThingDeleteFiles).not.toHaveBeenCalled();
     expect(mockDeleteObject).not.toHaveBeenCalled();
     expect(mockDeleteBlobFile).not.toHaveBeenCalled();
     expect(mockDelete).not.toHaveBeenCalled();
@@ -555,7 +621,8 @@ describe("Feature: UploadThing adapter routing", () => {
     const result = await deleteFileByRef(ref);
 
     expect(result).toEqual({ ref, outcome: "deleted" });
-    expect(mockUploadThingDeleteFiles).toHaveBeenCalledWith(ref.key);
+    expect(mockTargetDelete).toHaveBeenCalledWith(ref);
+    expect(mockUploadThingDeleteFiles).not.toHaveBeenCalled();
     expect(mockDeleteObject).not.toHaveBeenCalled();
     expect(mockDeleteBlobFile).not.toHaveBeenCalled();
     expect(mockDelete).not.toHaveBeenCalled();
@@ -570,7 +637,7 @@ describe("Feature: adapter acceptance failure matrix (provider slice)", () => {
       key: "documents/transient.pdf",
     };
 
-    mockDeleteBlobFile.mockRejectedValueOnce(new Error("ECONNRESET: upstream transient network failure"));
+    mockTargetDelete.mockRejectedValueOnce(new Error("ECONNRESET: upstream transient network failure"));
 
     const result = await deleteFileByRef(ref);
 
@@ -585,9 +652,10 @@ describe("Feature: adapter acceptance failure matrix (provider slice)", () => {
       key: "ut_blocked_1",
     };
 
-    mockUploadThingDeleteFiles.mockResolvedValueOnce({
-      success: false,
-      deletedCount: 0,
+    mockTargetDelete.mockResolvedValueOnce({
+      ref,
+      outcome: "blocked",
+      errorCode: "uploadthing_auth_or_config_error",
       message: "Unauthorized: token is invalid",
     });
 
@@ -605,10 +673,7 @@ describe("Feature: adapter acceptance failure matrix (provider slice)", () => {
       key: "ut_missing_1",
     };
 
-    mockUploadThingDeleteFiles.mockResolvedValueOnce({
-      success: true,
-      deletedCount: 0,
-    });
+    mockTargetDelete.mockResolvedValueOnce({ ref, outcome: "not_found" });
 
     const result = await deleteFileByRef(ref);
     expect(result).toEqual({ ref, outcome: "not_found" });
@@ -633,11 +698,11 @@ describe("Feature: adapter acceptance failure matrix (provider slice)", () => {
       },
     ];
 
-    mockDeleteObjects.mockResolvedValueOnce([
-      { key: "documents/a.pdf", outcome: "deleted" },
-      { key: "documents/b.pdf", outcome: "not_found" },
+    mockTargetDeleteMany.mockResolvedValueOnce([
+      { ref: refs[0], outcome: "deleted", errorCode: undefined, message: undefined },
+      { ref: refs[1], outcome: "not_found", errorCode: undefined, message: undefined },
       {
-        key: "documents/c.pdf",
+        ref: refs[2],
         outcome: "retryable",
         errorCode: "SlowDown",
         message: "Please reduce your request rate.",

--- a/apps/web/__tests__/api/storage/storage-port.test.ts
+++ b/apps/web/__tests__/api/storage/storage-port.test.ts
@@ -38,6 +38,15 @@ const mockTargets = {
     deleteMany: (...args: unknown[]) => mockTargetDeleteMany(...args),
     getSignedUrl: (...args: unknown[]) => mockTargetGetSignedUrl(...args),
   },
+  database: {
+    adapter: "database",
+    provider: "database",
+    put: (...args: unknown[]) => mockTargetPut(...args),
+    get: (...args: unknown[]) => mockTargetGet(...args),
+    delete: (...args: unknown[]) => mockTargetDelete(...args),
+    deleteMany: (...args: unknown[]) => mockTargetDeleteMany(...args),
+    getSignedUrl: (...args: unknown[]) => mockTargetGetSignedUrl(...args),
+  },
 };
 
 const mockForAdapter = jest.fn();
@@ -79,7 +88,7 @@ describe("createAppStoragePort", () => {
     mockForAdapter.mockReset().mockImplementation((adapter: keyof typeof mockTargets) => mockTargets[adapter]);
   });
 
-  it("deleteRef delegates to deleteFileByRef", async () => {
+  it("deleteRef delegates to the targeted adapter", async () => {
     const ref: ObjectRef = {
       adapter: "s3",
       storageLocationId: "s3:http://localhost:8333@bucket",
@@ -137,14 +146,14 @@ describe("createAppStoragePort", () => {
     expect(mockForAdapter).not.toHaveBeenCalledWith("s3");
   });
 
-  it("keeps the default database put on the legacy database helper", async () => {
+  it("routes the default database put through the targeted adapter", async () => {
     mockResolveStorageBackend.mockReturnValue("database");
     const ref: ObjectRef = {
       adapter: "database",
       storageLocationId: "database:pdr_file_uploads_v1",
       key: "123",
     };
-    mockUploadFile.mockResolvedValue({ ref, provider: "database" });
+    mockTargetPut.mockResolvedValue({ ref, provider: "database" });
 
     const port = createAppStoragePort();
     const input = {
@@ -154,11 +163,9 @@ describe("createAppStoragePort", () => {
     };
     const result = await port.put(input);
 
-    expect(mockUploadFile).toHaveBeenCalledWith({
-      ...input,
-      userId: "system",
-    });
-    expect(mockForAdapter).not.toHaveBeenCalled();
+    expect(mockForAdapter).toHaveBeenCalledWith("database");
+    expect(mockTargetPut).toHaveBeenCalledWith(input);
+    expect(mockUploadFile).not.toHaveBeenCalled();
     expect(result.ref).toEqual(ref);
   });
 
@@ -226,6 +233,39 @@ describe("createAppStoragePort", () => {
     expect(result).toEqual(refs.map((ref) => ({ ref, outcome: "deleted" })));
   });
 
+  it("routes database delete and deleteMany through targeted adapters", async () => {
+    const refs: ObjectRef[] = [
+      {
+        adapter: "database",
+        storageLocationId: "database:pdr_file_uploads_v1",
+        key: "123",
+      },
+      {
+        adapter: "database",
+        storageLocationId: "database:pdr_file_uploads_v1",
+        key: "456",
+      },
+    ];
+    mockTargetDelete.mockResolvedValue({ ref: refs[0], outcome: "deleted" });
+    mockTargetDeleteMany.mockResolvedValue(
+      refs.map((ref) => ({ ref, outcome: "not_found" as const })),
+    );
+
+    const port = createAppStoragePort();
+    const deleteResult = await port.deleteRef(refs[0]!);
+    const deleteManyResult = await port.deleteMany(refs);
+
+    expect(mockForAdapter).toHaveBeenCalledWith("database");
+    expect(mockTargetDelete).toHaveBeenCalledWith(refs[0]!);
+    expect(mockTargetDeleteMany).toHaveBeenCalledWith(refs);
+    expect(mockDeleteFileByRef).not.toHaveBeenCalled();
+    expect(mockDeleteManyByRef).not.toHaveBeenCalled();
+    expect(deleteResult).toEqual({ ref: refs[0]!, outcome: "deleted" });
+    expect(deleteManyResult).toEqual(
+      refs.map((ref) => ({ ref, outcome: "not_found" })),
+    );
+  });
+
   it("legacy delete shim promotes and deletes by canonical ref", async () => {
     const ref: ObjectRef = {
       adapter: "uploadthing",
@@ -251,10 +291,10 @@ describe("createAppStoragePort", () => {
     expect(target.provider).toBe("vercel-blob");
   });
 
-  it("resolves database refs through the authenticated file route", async () => {
+  it("routes database refs through the targeted adapter", async () => {
     mockResolveStorageBackend.mockReturnValue("database");
     const response = new Response("database bytes");
-    mockFetchFile.mockResolvedValue(response);
+    mockTargetGet.mockResolvedValue(response);
     const ref: ObjectRef = {
       adapter: "database",
       storageLocationId: "database:pdr_file_uploads_v1",
@@ -264,7 +304,9 @@ describe("createAppStoragePort", () => {
 
     const result = await createAppStoragePort().get(ref, init);
 
-    expect(mockFetchFile).toHaveBeenCalledWith("/api/files/123", init);
+    expect(mockForAdapter).toHaveBeenCalledWith("database");
+    expect(mockTargetGet).toHaveBeenCalledWith(ref, init);
+    expect(mockFetchFile).not.toHaveBeenCalled();
     expect(result).toBe(response);
   });
 });

--- a/apps/web/__tests__/api/storage/storage-port.test.ts
+++ b/apps/web/__tests__/api/storage/storage-port.test.ts
@@ -4,6 +4,43 @@ const mockDeleteFileByRef = jest.fn();
 const mockDeleteManyByRef = jest.fn();
 const mockResolveStorageBackend = jest.fn(() => "s3");
 const mockPromoteLegacyUrlToRef = jest.fn();
+const mockTargetPut = jest.fn();
+const mockTargetGet = jest.fn();
+const mockTargetDelete = jest.fn();
+const mockTargetDeleteMany = jest.fn();
+const mockTargetGetSignedUrl = jest.fn();
+
+const mockTargets = {
+  s3: {
+    adapter: "s3",
+    provider: "s3",
+    put: (...args: unknown[]) => mockTargetPut(...args),
+    get: (...args: unknown[]) => mockTargetGet(...args),
+    delete: (...args: unknown[]) => mockTargetDelete(...args),
+    deleteMany: (...args: unknown[]) => mockTargetDeleteMany(...args),
+    getSignedUrl: (...args: unknown[]) => mockTargetGetSignedUrl(...args),
+  },
+  "vercel-blob": {
+    adapter: "vercel-blob",
+    provider: "vercel-blob",
+    put: (...args: unknown[]) => mockTargetPut(...args),
+    get: (...args: unknown[]) => mockTargetGet(...args),
+    delete: (...args: unknown[]) => mockTargetDelete(...args),
+    deleteMany: (...args: unknown[]) => mockTargetDeleteMany(...args),
+    getSignedUrl: (...args: unknown[]) => mockTargetGetSignedUrl(...args),
+  },
+  uploadthing: {
+    adapter: "uploadthing",
+    provider: "uploadthing",
+    put: (...args: unknown[]) => mockTargetPut(...args),
+    get: (...args: unknown[]) => mockTargetGet(...args),
+    delete: (...args: unknown[]) => mockTargetDelete(...args),
+    deleteMany: (...args: unknown[]) => mockTargetDeleteMany(...args),
+    getSignedUrl: (...args: unknown[]) => mockTargetGetSignedUrl(...args),
+  },
+};
+
+const mockForAdapter = jest.fn();
 
 jest.mock("~/lib/storage", () => ({
   uploadFile: (...args: unknown[]) => mockUploadFile(...args),
@@ -11,6 +48,12 @@ jest.mock("~/lib/storage", () => ({
   deleteFileByRef: (...args: unknown[]) => mockDeleteFileByRef(...args),
   deleteManyByRef: (...args: unknown[]) => mockDeleteManyByRef(...args),
   resolveStorageBackend: () => mockResolveStorageBackend(),
+}));
+
+jest.mock("~/server/storage/create-storage-port", () => ({
+  createStoragePortTargetFactory: () => ({
+    forAdapter: (...args: unknown[]) => mockForAdapter(...args),
+  }),
 }));
 
 jest.mock("~/server/storage/legacy-promote", () => ({
@@ -28,6 +71,12 @@ describe("createAppStoragePort", () => {
     mockDeleteManyByRef.mockReset();
     mockPromoteLegacyUrlToRef.mockReset();
     mockResolveStorageBackend.mockReset().mockReturnValue("s3");
+    mockTargetPut.mockReset();
+    mockTargetGet.mockReset();
+    mockTargetDelete.mockReset();
+    mockTargetDeleteMany.mockReset();
+    mockTargetGetSignedUrl.mockReset();
+    mockForAdapter.mockReset().mockImplementation((adapter: keyof typeof mockTargets) => mockTargets[adapter]);
   });
 
   it("deleteRef delegates to deleteFileByRef", async () => {
@@ -36,46 +85,95 @@ describe("createAppStoragePort", () => {
       storageLocationId: "s3:http://localhost:8333@bucket",
       key: "documents/a.pdf",
     };
-    mockDeleteFileByRef.mockResolvedValue({ ref, outcome: "deleted" });
+    mockTargetDelete.mockResolvedValue({ ref, outcome: "deleted" });
 
     const port = createAppStoragePort();
     const result = await port.deleteRef(ref);
 
-    expect(mockDeleteFileByRef).toHaveBeenCalledWith(ref);
+    expect(mockForAdapter).toHaveBeenCalledWith("s3");
+    expect(mockTargetDelete).toHaveBeenCalledWith(ref);
     expect(result).toEqual({ ref, outcome: "deleted" });
   });
 
-  it("put delegates to uploadFile using the canonical method name", async () => {
+  it("routes the default S3 put through the targeted adapter", async () => {
     const ref: ObjectRef = {
       adapter: "s3",
       storageLocationId: "s3:http://localhost:8333@bucket",
       key: "documents/a.pdf",
     };
-    mockUploadFile.mockResolvedValue({
-      url: "http://localhost:8333/bucket/documents/a.pdf",
-      pathname: "documents/a.pdf",
-      ref,
-      contentType: "application/pdf",
-      provider: "s3",
-    });
+    mockTargetPut.mockResolvedValue({ ref, provider: "s3" });
 
     const port = createAppStoragePort();
-    const result = await port.put({
+    const input = {
       filename: "a.pdf",
       data: Buffer.from("hello"),
       contentType: "application/pdf",
-    });
+    };
+    const result = await port.put(input);
 
-    expect(mockUploadFile).toHaveBeenCalledWith({
-      filename: "a.pdf",
-      data: Buffer.from("hello"),
-      contentType: "application/pdf",
-      userId: "system",
-    });
+    expect(mockForAdapter).toHaveBeenCalledWith("s3");
+    expect(mockTargetPut).toHaveBeenCalledWith(input);
     expect(result.ref).toEqual(ref);
   });
 
-  it("deleteMany delegates to grouped batch helper", async () => {
+  it("keeps the default database put on the legacy database helper", async () => {
+    mockResolveStorageBackend.mockReturnValue("database");
+    const ref: ObjectRef = {
+      adapter: "database",
+      storageLocationId: "database:pdr_file_uploads_v1",
+      key: "123",
+    };
+    mockUploadFile.mockResolvedValue({ ref, provider: "database" });
+
+    const port = createAppStoragePort();
+    const input = {
+      filename: "a.pdf",
+      data: Buffer.from("hello"),
+      contentType: "application/pdf",
+    };
+    const result = await port.put(input);
+
+    expect(mockUploadFile).toHaveBeenCalledWith({
+      ...input,
+      userId: "system",
+    });
+    expect(mockForAdapter).not.toHaveBeenCalled();
+    expect(result.ref).toEqual(ref);
+  });
+
+  it("routes non-database ref reads through their targeted adapter", async () => {
+    const ref: ObjectRef = {
+      adapter: "vercel-blob",
+      storageLocationId: "vercel-blob:store-alpha",
+      key: "documents/a.pdf",
+    };
+    const response = new Response("blob bytes");
+    const init = { headers: { accept: "application/octet-stream" } };
+    mockTargetGet.mockResolvedValue(response);
+
+    const result = await createAppStoragePort().get(ref, init);
+
+    expect(mockForAdapter).toHaveBeenCalledWith("vercel-blob");
+    expect(mockTargetGet).toHaveBeenCalledWith(ref, init);
+    expect(result).toBe(response);
+  });
+
+  it("routes signed URL requests through the targeted adapter", async () => {
+    const ref: ObjectRef = {
+      adapter: "s3",
+      storageLocationId: "s3:http://localhost:8333@bucket",
+      key: "documents/a.pdf",
+    };
+    mockTargetGetSignedUrl.mockResolvedValue("https://signed.example/a.pdf");
+
+    const result = await createAppStoragePort().getSignedUrl(ref, { expiresIn: 600 });
+
+    expect(mockForAdapter).toHaveBeenCalledWith("s3");
+    expect(mockTargetGetSignedUrl).toHaveBeenCalledWith(ref, { expiresIn: 600 });
+    expect(result).toBe("https://signed.example/a.pdf");
+  });
+
+  it("routes deleteMany groups through their targeted adapters", async () => {
     const refs: ObjectRef[] = [
       {
         adapter: "s3",
@@ -94,13 +192,16 @@ describe("createAppStoragePort", () => {
       },
     ];
 
-    mockDeleteManyByRef.mockResolvedValue(refs.map((ref) => ({ ref, outcome: "deleted" as const })));
+    mockTargetDeleteMany.mockImplementation(async (groupRefs: ObjectRef[]) =>
+      groupRefs.map((ref) => ({ ref, outcome: "deleted" as const })),
+    );
 
     const port = createAppStoragePort();
     const result = await port.deleteMany(refs);
 
-    expect(mockDeleteManyByRef).toHaveBeenCalledTimes(1);
-    expect(mockDeleteManyByRef).toHaveBeenCalledWith(refs);
+    expect(mockForAdapter).toHaveBeenCalledWith("s3");
+    expect(mockForAdapter).toHaveBeenCalledWith("vercel-blob");
+    expect(mockTargetDeleteMany).toHaveBeenCalledTimes(2);
     expect(result).toEqual(refs.map((ref) => ({ ref, outcome: "deleted" })));
   });
 
@@ -111,20 +212,38 @@ describe("createAppStoragePort", () => {
       key: "ut_abc",
     };
     mockPromoteLegacyUrlToRef.mockReturnValue({ ok: true, ref, confidence: "medium" });
-    mockDeleteFileByRef.mockResolvedValue({ ref, outcome: "deleted" });
+    mockTargetDelete.mockResolvedValue({ ref, outcome: "deleted" });
 
     const port = createAppStoragePort();
     await port.delete("https://utfs.io/f/ut_abc");
 
     expect(mockPromoteLegacyUrlToRef).toHaveBeenCalledWith({ value: "https://utfs.io/f/ut_abc" });
-    expect(mockDeleteFileByRef).toHaveBeenCalledWith(ref);
+    expect(mockForAdapter).toHaveBeenCalledWith("uploadthing");
+    expect(mockTargetDelete).toHaveBeenCalledWith(ref);
   });
 
-  it("forAdapter exposes the targeted adapter surface before concrete adapters land", () => {
+  it("exposes the targeted adapter surface", () => {
     const port = createAppStoragePort();
     const target = port.forAdapter("vercel-blob");
 
     expect(target.adapter).toBe("vercel-blob");
-    expect(target.provider).toBe("s3");
+    expect(target.provider).toBe("vercel-blob");
+  });
+
+  it("resolves database refs through the authenticated file route", async () => {
+    mockResolveStorageBackend.mockReturnValue("database");
+    const response = new Response("database bytes");
+    mockFetchFile.mockResolvedValue(response);
+    const ref: ObjectRef = {
+      adapter: "database",
+      storageLocationId: "database:pdr_file_uploads_v1",
+      key: "123",
+    };
+    const init = { headers: { accept: "application/octet-stream" } };
+
+    const result = await createAppStoragePort().get(ref, init);
+
+    expect(mockFetchFile).toHaveBeenCalledWith("/api/files/123", init);
+    expect(result).toBe(response);
   });
 });

--- a/apps/web/__tests__/api/storage/storage-port.test.ts
+++ b/apps/web/__tests__/api/storage/storage-port.test.ts
@@ -116,6 +116,27 @@ describe("createAppStoragePort", () => {
     expect(result.ref).toEqual(ref);
   });
 
+  it("requires explicit forAdapter targeting for fixed-intent Vercel Blob writes", async () => {
+    const input = {
+      filename: "artifact.md",
+      data: Buffer.from("artifact"),
+      contentType: "text/markdown",
+    };
+    const ref: ObjectRef = {
+      adapter: "vercel-blob",
+      storageLocationId: "vercel-blob:store-alpha",
+      key: "documents/artifact.md",
+    };
+    mockTargetPut.mockResolvedValue({ ref, provider: "vercel-blob" });
+
+    const port = createAppStoragePort();
+    await port.forAdapter("vercel-blob").put(input);
+
+    expect(mockForAdapter).toHaveBeenCalledWith("vercel-blob");
+    expect(mockTargetPut).toHaveBeenCalledWith(input);
+    expect(mockForAdapter).not.toHaveBeenCalledWith("s3");
+  });
+
   it("keeps the default database put on the legacy database helper", async () => {
     mockResolveStorageBackend.mockReturnValue("database");
     const ref: ObjectRef = {

--- a/apps/web/__tests__/api/storage/storage-port.test.ts
+++ b/apps/web/__tests__/api/storage/storage-port.test.ts
@@ -45,6 +45,36 @@ describe("createAppStoragePort", () => {
     expect(result).toEqual({ ref, outcome: "deleted" });
   });
 
+  it("put delegates to uploadFile using the canonical method name", async () => {
+    const ref: ObjectRef = {
+      adapter: "s3",
+      storageLocationId: "s3:http://localhost:8333@bucket",
+      key: "documents/a.pdf",
+    };
+    mockUploadFile.mockResolvedValue({
+      url: "http://localhost:8333/bucket/documents/a.pdf",
+      pathname: "documents/a.pdf",
+      ref,
+      contentType: "application/pdf",
+      provider: "s3",
+    });
+
+    const port = createAppStoragePort();
+    const result = await port.put({
+      filename: "a.pdf",
+      data: Buffer.from("hello"),
+      contentType: "application/pdf",
+    });
+
+    expect(mockUploadFile).toHaveBeenCalledWith({
+      filename: "a.pdf",
+      data: Buffer.from("hello"),
+      contentType: "application/pdf",
+      userId: "system",
+    });
+    expect(result.ref).toEqual(ref);
+  });
+
   it("deleteMany delegates to grouped batch helper", async () => {
     const refs: ObjectRef[] = [
       {
@@ -88,5 +118,13 @@ describe("createAppStoragePort", () => {
 
     expect(mockPromoteLegacyUrlToRef).toHaveBeenCalledWith({ value: "https://utfs.io/f/ut_abc" });
     expect(mockDeleteFileByRef).toHaveBeenCalledWith(ref);
+  });
+
+  it("forAdapter exposes the targeted adapter surface before concrete adapters land", () => {
+    const port = createAppStoragePort();
+    const target = port.forAdapter("vercel-blob");
+
+    expect(target.adapter).toBe("vercel-blob");
+    expect(target.provider).toBe("s3");
   });
 });

--- a/apps/web/__tests__/api/storage/storage-write-routes.test.ts
+++ b/apps/web/__tests__/api/storage/storage-write-routes.test.ts
@@ -1,0 +1,208 @@
+import { POST as uploadPost } from "~/app/api/storage/upload/route";
+import { POST as presignPost } from "~/app/api/storage/presign/route";
+import { POST as presignCompletePost } from "~/app/api/storage/presign/complete/route";
+
+import { auth } from "@clerk/nextjs/server";
+import { isS3Storage } from "~/lib/storage";
+import { validateRequestBody } from "~/lib/validation";
+import { resolveStorageLocationId } from "~/lib/storage-location-id";
+import { resolveActiveCompanyForUser } from "~/lib/active-workspace";
+import { createStorageWritePort } from "~/server/storage/write-port";
+import { registerUploadArtifact } from "~/server/services/storage-manifest";
+import { db } from "~/server/db";
+
+jest.mock("@clerk/nextjs/server", () => ({
+  auth: jest.fn(),
+}));
+
+jest.mock("~/lib/storage", () => ({
+  isS3Storage: jest.fn(),
+}));
+
+jest.mock("~/lib/validation", () => ({
+  validateRequestBody: jest.fn(),
+  PresignUploadSchema: {},
+  PresignCompleteSchema: {},
+}));
+
+jest.mock("~/lib/storage-location-id", () => ({
+  resolveStorageLocationId: jest.fn(),
+}));
+
+jest.mock("~/lib/active-workspace", () => ({
+  resolveActiveCompanyForUser: jest.fn(),
+}));
+
+jest.mock("~/server/storage/write-port", () => ({
+  createStorageWritePort: jest.fn(),
+}));
+
+jest.mock("~/server/services/storage-manifest", () => ({
+  registerUploadArtifact: jest.fn(),
+}));
+
+jest.mock("~/server/db", () => ({
+  db: {
+    select: jest.fn(),
+    transaction: jest.fn(),
+  },
+}));
+
+describe("storage write routes migration", () => {
+  const mockPut = jest.fn();
+  const mockMintRef = jest.fn();
+  const mockGetSignedUrl = jest.fn();
+  const mockGetBucketName = jest.fn();
+
+  const txInsertReturning = jest.fn();
+  const txInsertValues = jest.fn(() => ({ returning: txInsertReturning }));
+  const txInsert = jest.fn(() => ({ values: txInsertValues }));
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (auth as unknown as jest.Mock).mockResolvedValue({ userId: "user-123" });
+    (isS3Storage as jest.Mock).mockReturnValue(true);
+    (resolveStorageLocationId as jest.Mock).mockReturnValue("s3:http://localhost:8333@pdr-documents");
+    (resolveActiveCompanyForUser as jest.Mock).mockResolvedValue(42n);
+
+    (createStorageWritePort as jest.Mock).mockReturnValue({
+      put: mockPut,
+      mintRef: mockMintRef,
+      getSignedUrl: mockGetSignedUrl,
+      getBucketName: mockGetBucketName,
+    });
+
+    (registerUploadArtifact as jest.Mock).mockResolvedValue({ id: 9001 });
+
+    (db.select as jest.Mock).mockReturnValue({
+      from: jest.fn().mockReturnValue({
+        where: jest.fn().mockResolvedValue([{ id: 7, companyId: 42 }]),
+      }),
+    });
+
+    (db.transaction as jest.Mock).mockImplementation(async (cb: (tx: { insert: typeof txInsert }) => Promise<unknown>) => {
+      return cb({
+        insert: txInsert,
+      });
+    });
+
+    txInsertReturning.mockResolvedValue([{ id: 314 }]);
+    mockGetBucketName.mockReturnValue("pdr-documents");
+    mockMintRef.mockImplementation((key: string) => ({
+      adapter: "s3",
+      storageLocationId: "s3:http://localhost:8333@pdr-documents",
+      key,
+    }));
+    mockGetSignedUrl.mockImplementation(({ ref }: { ref: { key: string } }) => `http://localhost:8333/pdr-documents/${ref.key}?sig=abc`);
+    mockPut.mockImplementation(({ key }: { key: string }) => ({
+      ref: {
+        adapter: "s3",
+        storageLocationId: "s3:http://localhost:8333@pdr-documents",
+        key,
+      },
+      url: `http://localhost:8333/pdr-documents/${key}`,
+      pathname: key,
+      provider: "s3",
+    }));
+  });
+
+  it("/api/storage/upload delegates writes through storage port put()", async () => {
+    const formData = new FormData();
+    formData.set("file", new File([Buffer.from("hello")], "hello.pdf", { type: "application/pdf" }));
+
+    const req = new Request("http://localhost/api/storage/upload", {
+      method: "POST",
+      body: formData,
+    });
+
+    const response = await uploadPost(req);
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(createStorageWritePort).toHaveBeenCalledTimes(1);
+    expect(mockPut).toHaveBeenCalledTimes(1);
+    expect(mockPut.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        contentType: "application/pdf",
+      }),
+    );
+
+    expect(registerUploadArtifact).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        ref: expect.objectContaining({ adapter: "s3" }),
+        fileUploadId: 314,
+        sourceOperation: "storage-upload",
+      }),
+    );
+
+    expect(json.ref.adapter).toBe("s3");
+    expect(json.bucket).toBe("pdr-documents");
+  });
+
+  it("presign -> complete flow keeps ref identity consistent", async () => {
+    (validateRequestBody as jest.Mock)
+      .mockResolvedValueOnce({
+        success: true,
+        data: {
+          filename: "demo.pdf",
+          contentType: "application/pdf",
+        },
+      });
+
+    const presignReq = new Request("http://localhost/api/storage/presign", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ filename: "demo.pdf", contentType: "application/pdf" }),
+    });
+
+    const presignResponse = await presignPost(presignReq);
+    const presignJson = await presignResponse.json();
+
+    expect(presignResponse.status).toBe(200);
+    expect(mockMintRef).toHaveBeenCalledTimes(1);
+    expect(mockGetSignedUrl).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ref: presignJson.ref,
+        operation: "put",
+        contentType: "application/pdf",
+      }),
+    );
+
+    (validateRequestBody as jest.Mock)
+      .mockResolvedValueOnce({
+        success: true,
+        data: {
+          ref: presignJson.ref,
+          filename: "demo.pdf",
+          contentType: "application/pdf",
+          sizeBytes: 123,
+        },
+      });
+
+    const completeReq = new Request("http://localhost/api/storage/presign/complete", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        ref: presignJson.ref,
+        filename: "demo.pdf",
+        contentType: "application/pdf",
+        sizeBytes: 123,
+      }),
+    });
+
+    const completeResponse = await presignCompletePost(completeReq);
+    const completeJson = await completeResponse.json();
+
+    expect(completeResponse.status).toBe(200);
+    expect(registerUploadArtifact).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        ref: presignJson.ref,
+        sourceOperation: "presign-complete",
+      }),
+    );
+    expect(completeJson.success).toBe(true);
+  });
+});

--- a/apps/web/src/app/api/documents/[id]/content/route.ts
+++ b/apps/web/src/app/api/documents/[id]/content/route.ts
@@ -3,9 +3,10 @@ import { eq } from "drizzle-orm";
 import { auth } from "@clerk/nextjs/server";
 import { db } from "~/server/db";
 import { document } from "@launchstack/core/db/schema";
-import { isPrivateBlobUrl } from "~/server/storage/vercel-blob";
 import { fetchFile, isS3Storage } from "~/lib/storage";
 import { checkDocumentServable } from "~/server/services/document-servable";
+import { getEngine } from "~/server/engine";
+import { promoteLegacyUrlToRef } from "~/server/storage/legacy-promote";
 
 const EXTENSION_TO_MIME: Record<string, string> = {
   ".pdf": "application/pdf",
@@ -64,11 +65,33 @@ export async function GET(_request: Request, { params }: RouteParams) {
       return NextResponse.json({ error: gate.message }, { status: gate.status });
     }
 
-    if (!isS3Storage() && !isPrivateBlobUrl(doc.url)) {
-      return NextResponse.redirect(doc.url, { status: 307 });
+    let promoted: ReturnType<typeof promoteLegacyUrlToRef> | undefined;
+    try {
+      promoted = promoteLegacyUrlToRef({ value: doc.url });
+    } catch {
+      // Missing provider configuration is treated like any other legacy
+      // promotion miss; fetchFile provides the compatibility fallback.
+      promoted = undefined;
+    }
+    let blobRes: Response;
+
+    if (
+      promoted?.ok &&
+      (promoted.ref.adapter === "vercel-blob" ||
+        promoted.ref.adapter === "uploadthing")
+    ) {
+      // Private vendor objects must be read by the adapter so provider auth
+      // and URL construction stay behind the storage port.
+      blobRes = await getEngine().storage.get(promoted.ref);
+    } else {
+      // Preserve the existing S3/database redirect-vs-proxy behaviour. An
+      // unpromotable legacy URL takes the string shim once as a last resort.
+      if (promoted?.ok && !isS3Storage()) {
+        return NextResponse.redirect(doc.url, { status: 307 });
+      }
+      blobRes = await fetchFile(doc.url);
     }
 
-    const blobRes = await fetchFile(doc.url);
     if (!blobRes.ok) {
       return NextResponse.json(
         { error: "Failed to retrieve document from storage" },

--- a/apps/web/src/app/api/documents/[id]/versions/[versionId]/content/route.ts
+++ b/apps/web/src/app/api/documents/[id]/versions/[versionId]/content/route.ts
@@ -17,10 +17,11 @@ import { and, eq } from "drizzle-orm";
 
 import { db } from "~/server/db";
 import { document, documentVersions, users } from "@launchstack/core/db/schema";
-import { isPrivateBlobUrl } from "~/server/storage/vercel-blob";
 import { fetchFile, isLocalStorage } from "~/lib/storage";
 import { resolveActiveCompanyForUser } from "~/lib/active-workspace";
 import { checkVersionServable } from "~/server/services/document-servable";
+import { getEngine } from "~/server/engine";
+import { promoteLegacyUrlToRef } from "~/server/storage/legacy-promote";
 
 const EXTENSION_TO_MIME: Record<string, string> = {
   ".pdf": "application/pdf",
@@ -128,14 +129,34 @@ export async function GET(
       return NextResponse.json({ error: gate.message }, { status: gate.status });
     }
 
-    // Public cloud URL — redirect the browser directly and let the CDN serve.
-    // Private Vercel Blob URLs and local SeaweedFS URLs must be proxied so
-    // we can attach the private-blob auth header / reach the private network.
-    if (!isLocalStorage() && !isPrivateBlobUrl(version.url)) {
-      return NextResponse.redirect(version.url, { status: 307 });
+    let promoted: ReturnType<typeof promoteLegacyUrlToRef> | undefined;
+    try {
+      promoted = promoteLegacyUrlToRef({ value: version.url });
+    } catch {
+      // Missing provider configuration is treated like any other legacy
+      // promotion miss; fetchFile provides the compatibility fallback.
+      promoted = undefined;
+    }
+    let blobRes: Response;
+
+    if (
+      promoted?.ok &&
+      (promoted.ref.adapter === "vercel-blob" ||
+        promoted.ref.adapter === "uploadthing")
+    ) {
+      // Vendor-backed objects are always proxied through the targeted
+      // adapter; it owns provider authentication and URL generation.
+      blobRes = await getEngine().storage.get(promoted.ref);
+    } else {
+      // Keep the existing public-cloud redirect and local-storage proxy
+      // behaviour for refs that are not vendor-private. If promotion fails,
+      // use the legacy URL shim once.
+      if (promoted?.ok && !isLocalStorage()) {
+        return NextResponse.redirect(version.url, { status: 307 });
+      }
+      blobRes = await fetchFile(version.url);
     }
 
-    const blobRes = await fetchFile(version.url);
     if (!blobRes.ok) {
       return NextResponse.json(
         { error: "Failed to retrieve version file from storage" },

--- a/apps/web/src/app/api/fetchDocument/route.ts
+++ b/apps/web/src/app/api/fetchDocument/route.ts
@@ -4,10 +4,10 @@ import { document, users, fileUploads } from "@launchstack/core/db/schema";
 import { eq, inArray } from "drizzle-orm";
 import { validateRequestBody, UserIdSchema } from "~/lib/validation";
 import { auth } from '@clerk/nextjs/server';
-import { isPrivateBlobUrl } from "~/server/storage/vercel-blob";
 import { isS3Storage } from "~/lib/storage";
 import { resolveActiveCompanyForUser } from "~/lib/active-workspace";
 import { checkDocumentServable } from "~/server/services/document-servable";
+import { promoteLegacyUrlToRef } from "~/server/storage/legacy-promote";
 
 /** Extract file id from /api/files/{id} URL so we can look up mimeType from file_uploads */
 const FILE_API_ID_REGEX = /\/api\/files\/(\d+)/;
@@ -153,8 +153,18 @@ export async function POST(request: Request) {
                 ?? mimeFromFile
                 ?? inferMimeFromName(doc.title)
                 ?? inferMimeFromName(doc.url);
-            const needsProxy = isPrivateBlobUrl(doc.url)
-                || (isS3Storage() && doc.url.startsWith("http"));
+            let promoted: ReturnType<typeof promoteLegacyUrlToRef> | undefined;
+            try {
+                promoted = promoteLegacyUrlToRef({ value: doc.url });
+            } catch {
+                promoted = undefined;
+            }
+            const needsProxy = promoted?.ok
+                && (
+                    promoted.ref.adapter === "vercel-blob"
+                    || promoted.ref.adapter === "uploadthing"
+                    || (promoted.ref.adapter === "s3" && isS3Storage())
+                );
             const url = needsProxy
                 ? `/api/documents/${Number(doc.id)}/content`
                 : doc.url;

--- a/apps/web/src/app/api/files/[id]/route.ts
+++ b/apps/web/src/app/api/files/[id]/route.ts
@@ -8,10 +8,10 @@ import { auth } from "@clerk/nextjs/server";
 import { eq } from "drizzle-orm";
 import { db } from "~/server/db";
 import { fileUploads, users } from "@launchstack/core/db/schema";
-import { isPrivateBlobUrl } from "~/server/storage/vercel-blob";
 import { fetchFile } from "~/lib/storage";
 import { checkRefServable } from "~/server/services/document-servable";
 import { promoteLegacyUrlToRef } from "~/server/storage/legacy-promote";
+import { getEngine } from "~/server/engine";
 import {
   checkFileUploadTenantAccess,
   logFileTenantDecision,
@@ -150,9 +150,13 @@ export async function GET(
       { adapter: "database", key: String(fileId) },
     ];
     if (file.storageUrl) {
-      const promoted = promoteLegacyUrlToRef({ value: file.storageUrl });
-      if (promoted.ok) {
-        candidateRefs.push({ adapter: promoted.ref.adapter, key: promoted.ref.key });
+      try {
+        const promoted = promoteLegacyUrlToRef({ value: file.storageUrl });
+        if (promoted.ok) {
+          candidateRefs.push({ adapter: promoted.ref.adapter, key: promoted.ref.key });
+        }
+      } catch {
+        // The external read below will use fetchFile's legacy fallback.
       }
     }
     const gate = await checkRefServable(candidateRefs);
@@ -160,42 +164,65 @@ export async function GET(
       return NextResponse.json({ error: gate.message }, { status: gate.status });
     }
 
-    // External storage (S3 or legacy Vercel Blob): proxy or redirect.
-    // Database-backed files (storageProvider === "database") fall through to
-    // the base64 branch below.
+    // External storage (S3, Vercel Blob, UploadThing, or SeaweedFS): proxy or
+    // redirect. Database-backed files (storageProvider === "database") fall
+    // through to the base64 branch below.
     if (file.storageProvider !== "database" && file.storageUrl) {
-      const needsProxy =
-        file.storageProvider === "s3" ||
-        file.storageProvider === "seaweedfs" ||
-        isPrivateBlobUrl(file.storageUrl);
+      let promoted: ReturnType<typeof promoteLegacyUrlToRef> | undefined;
+      try {
+        promoted = promoteLegacyUrlToRef({ value: file.storageUrl });
+      } catch {
+        // Missing provider configuration is treated like any other legacy
+        // promotion miss; fetchFile provides the compatibility fallback.
+        promoted = undefined;
+      }
+      let blobRes: Response;
 
-      if (needsProxy) {
-        const blobRes = await fetchFile(file.storageUrl);
-        if (!blobRes.ok) {
-          return NextResponse.json(
-            { error: "Failed to retrieve file from storage" },
-            { status: 502 }
-          );
-        }
-        const mimeType =
-          blobRes.headers.get("content-type") ??
-          file.mimeType?.trim() ??
-          inferMimeTypeFromFilename(file.filename);
-        return new NextResponse(blobRes.body, {
-          status: 200,
-          headers: {
-            "Content-Type": mimeType,
-            ...(blobRes.headers.get("content-length")
-              ? { "Content-Length": blobRes.headers.get("content-length")! }
-              : {}),
-            "Content-Disposition": `inline; filename="${encodeURIComponent(file.filename)}"; filename*=UTF-8''${encodeURIComponent(file.filename)}`,
-            "Cache-Control": "private, max-age=31536000",
-          },
+      if (
+        promoted?.ok &&
+        (promoted.ref.adapter === "vercel-blob" ||
+          promoted.ref.adapter === "uploadthing")
+      ) {
+        // Vendor-backed objects are always read through their targeted
+        // adapter, which owns provider authentication.
+        blobRes = await getEngine().storage.get(promoted.ref);
+      } else if (
+        !promoted?.ok ||
+        promoted.ref.adapter === "s3" ||
+        file.storageProvider === "s3" ||
+        file.storageProvider === "seaweedfs"
+      ) {
+        // Keep the existing S3/SeaweedFS proxy path and use the URL shim once
+        // when a legacy value cannot be promoted.
+        blobRes = await fetchFile(file.storageUrl);
+      } else {
+        // A public, promoted non-vendor URL can still be served directly.
+        return NextResponse.redirect(file.storageUrl, {
+          status: 307,
         });
       }
-      // Public external URL: redirect directly
-      return NextResponse.redirect(file.storageUrl, {
-        status: 307,
+
+      if (!blobRes.ok) {
+        return NextResponse.json(
+          { error: "Failed to retrieve file from storage" },
+          { status: 502 }
+        );
+      }
+
+      const mimeType =
+        blobRes.headers.get("content-type") ??
+        file.mimeType?.trim() ??
+        inferMimeTypeFromFilename(file.filename);
+      return new NextResponse(blobRes.body, {
+        status: 200,
+        headers: {
+          "Content-Type": mimeType,
+          ...(blobRes.headers.get("content-length")
+            ? { "Content-Length": blobRes.headers.get("content-length")! }
+            : {}),
+          "Content-Disposition": `inline; filename="${encodeURIComponent(file.filename)}"; filename*=UTF-8''${encodeURIComponent(file.filename)}`,
+          "Cache-Control": "private, max-age=31536000",
+        },
       });
     }
 

--- a/apps/web/src/app/api/storage/presign/route.ts
+++ b/apps/web/src/app/api/storage/presign/route.ts
@@ -2,10 +2,9 @@ import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { randomUUID } from "node:crypto";
 
-import { getPresignedUploadUrl, getS3BucketName, ensureBucketExists } from "~/server/storage/s3-client";
 import { isS3Storage } from "~/lib/storage";
-import { resolveStorageLocationId } from "~/lib/storage-location-id";
 import { validateRequestBody, PresignUploadSchema } from "~/lib/validation";
+import { createStorageWritePort } from "~/server/storage/write-port";
 
 export async function POST(request: Request) {
     try {
@@ -34,24 +33,22 @@ export async function POST(request: Request) {
 
         const safeName = resolvedFilename.replace(/\s+/g, "-").replace(/[^a-zA-Z0-9.\-_]/g, "");
         const objectKey = `documents/${randomUUID()}-${safeName || "upload"}`;
-        const bucket = getS3BucketName();
+        const storage = createStorageWritePort();
+        const bucket = storage.getBucketName();
+        const ref = storage.mintRef(objectKey);
 
-        await ensureBucketExists();
-        const presignedUrl = await getPresignedUploadUrl(
-            objectKey,
-            body.contentType,
-            300,
-        );
+        const presignedUrl = await storage.getSignedUrl({
+            ref,
+            operation: "put",
+            contentType: body.contentType,
+            expiresIn: 300,
+        });
 
         return NextResponse.json({
             presignedUrl,
             objectKey,
             bucket,
-            ref: {
-                adapter: "s3",
-                storageLocationId: resolveStorageLocationId("s3"),
-                key: objectKey,
-            },
+            ref,
         });
     } catch (error) {
         console.error("[Presign] Failed to generate presigned URL:", error);

--- a/apps/web/src/app/api/storage/upload/route.ts
+++ b/apps/web/src/app/api/storage/upload/route.ts
@@ -2,15 +2,13 @@ import { NextResponse } from "next/server";
 import { auth } from "@clerk/nextjs/server";
 import { randomUUID } from "node:crypto";
 import { eq } from "drizzle-orm";
-import type { ObjectRef } from "@launchstack/core/storage";
 
-import { putObject, getS3BucketName, ensureBucketExists, getObjectUrl } from "~/server/storage/s3-client";
 import { isS3Storage } from "~/lib/storage";
-import { resolveStorageLocationId } from "~/lib/storage-location-id";
 import { db } from "~/server/db";
 import { fileUploads, users } from "@launchstack/core/db/schema";
 import { resolveActiveCompanyForUser } from "~/lib/active-workspace";
 import { registerUploadArtifact } from "~/server/services/storage-manifest";
+import { createStorageWritePort } from "~/server/storage/write-port";
 
 function sanitizeFilename(filename: string): string {
     return filename.replace(/\s+/g, "-").replace(/[^a-zA-Z0-9.\-_]/g, "");
@@ -56,19 +54,18 @@ export async function POST(request: Request) {
 
         const safeName = sanitizeFilename(file.name);
         const objectKey = `documents/${randomUUID()}-${safeName || "upload"}`;
-        const bucket = getS3BucketName();
-
-        await ensureBucketExists();
+        const storage = createStorageWritePort();
+        const bucket = storage.getBucketName();
 
         const buffer = Buffer.from(await file.arrayBuffer());
-        await putObject(objectKey, buffer, file.type || "application/octet-stream");
-
-        const url = getObjectUrl(objectKey);
-        const ref: ObjectRef = {
-            adapter: "s3",
-            storageLocationId: resolveStorageLocationId("s3"),
+        const stored = await storage.put({
             key: objectKey,
-        };
+            body: buffer,
+            contentType: file.type || "application/octet-stream",
+        });
+
+        const url = stored.url;
+        const ref = stored.ref;
 
         const fileId = await db.transaction(async (tx) => {
             const [row] = await tx

--- a/apps/web/src/app/api/upload/github-repo/route.ts
+++ b/apps/web/src/app/api/upload/github-repo/route.ts
@@ -19,7 +19,7 @@ import {
     GitHubAuthError,
     GitHubRateLimitError,
 } from "~/server/services/github-repo";
-import { putFile } from "~/server/storage/vercel-blob";
+import { getEngine } from "~/server/engine";
 import { validateRequestBody } from "~/lib/validation";
 import { withRateLimit } from "~/lib/rate-limit-middleware";
 import { RateLimitPresets } from "~/lib/rate-limiter";
@@ -95,11 +95,13 @@ export async function POST(request: Request) {
             );
 
             // Store the ZIP in blob storage
-            const blob = await putFile({
-                filename,
-                data: zipBuffer,
-                contentType: "application/zip",
-            });
+            const blob = await getEngine().storage
+                .forAdapter("vercel-blob")
+                .put({
+                    filename,
+                    data: zipBuffer,
+                    contentType: "application/zip",
+                });
 
             // Trigger the document processing pipeline
             const uploadResult = await processDocumentUpload({

--- a/apps/web/src/env.ts
+++ b/apps/web/src/env.ts
@@ -366,12 +366,23 @@ function parseServerEnv() {
       | "s3"
       | "database"
       | undefined,
-    NEXT_PUBLIC_S3_ENDPOINT: process.env.NEXT_PUBLIC_S3_ENDPOINT,
-    S3_PUBLIC_ENDPOINT: process.env.S3_PUBLIC_ENDPOINT,
-    S3_REGION: process.env.S3_REGION,
-    S3_ACCESS_KEY: process.env.S3_ACCESS_KEY,
-    S3_SECRET_KEY: process.env.S3_SECRET_KEY,
-    S3_BUCKET_NAME: process.env.S3_BUCKET_NAME,
+    NEXT_PUBLIC_S3_ENDPOINT:
+      process.env.STORAGE_S3_ENDPOINT ?? process.env.NEXT_PUBLIC_S3_ENDPOINT,
+    S3_PUBLIC_ENDPOINT:
+      process.env.STORAGE_S3_PUBLIC_ENDPOINT ?? process.env.S3_PUBLIC_ENDPOINT,
+    S3_REGION: process.env.STORAGE_S3_REGION ?? process.env.S3_REGION,
+    S3_ACCESS_KEY:
+      process.env.STORAGE_S3_ACCESS_KEY ??
+      process.env.STORAGE_S3_ACCESS_KEY_ID ??
+      process.env.S3_ACCESS_KEY,
+    S3_SECRET_KEY:
+      process.env.STORAGE_S3_SECRET_KEY ??
+      process.env.STORAGE_S3_SECRET_ACCESS_KEY ??
+      process.env.S3_SECRET_KEY,
+    S3_BUCKET_NAME:
+      process.env.STORAGE_S3_BUCKET_NAME ??
+      process.env.STORAGE_S3_BUCKET ??
+      process.env.S3_BUCKET_NAME,
     STORAGE_DELETION_LIFECYCLE_ENABLED: process.env.STORAGE_DELETION_LIFECYCLE_ENABLED,
     STORAGE_DELETION_WORKER_ENABLED: process.env.STORAGE_DELETION_WORKER_ENABLED,
     STORAGE_FILE_TENANT_AUTH_MODE: process.env.STORAGE_FILE_TENANT_AUTH_MODE as
@@ -410,6 +421,7 @@ export const env = {
       | "s3"
       | "database"
       | undefined,
-    NEXT_PUBLIC_S3_ENDPOINT: process.env.NEXT_PUBLIC_S3_ENDPOINT,
+    NEXT_PUBLIC_S3_ENDPOINT:
+      process.env.NEXT_PUBLIC_S3_ENDPOINT ?? process.env.STORAGE_S3_ENDPOINT,
   }),
 };

--- a/apps/web/src/lib/storage.ts
+++ b/apps/web/src/lib/storage.ts
@@ -133,6 +133,13 @@ function s3VarsConfigured(): boolean {
   );
 }
 
+async function getTargetedStoragePort(adapter: ObjectRef["adapter"]) {
+  const { createStoragePortTargetFactory } = await import(
+    "~/server/storage/create-storage-port"
+  );
+  return createStoragePortTargetFactory(resolveStorageBackend()).forAdapter(adapter);
+}
+
 /**
  * Resolves the active storage backend. Honors an explicit
  * NEXT_PUBLIC_STORAGE_PROVIDER setting; otherwise infers from whether the full
@@ -196,7 +203,25 @@ export async function uploadFile(input: UploadInput): Promise<UploadResult> {
   if (backend === "s3") {
     return uploadToS3(input);
   }
-  return uploadToDatabase(input);
+
+  try {
+    const target = await getTargetedStoragePort("database");
+    const result = await target.put(input);
+    return {
+      url: result.url,
+      pathname: result.pathname,
+      ref: result.ref,
+      contentType: result.contentType,
+      provider: "database",
+    };
+  } catch (err) {
+    if (err instanceof StorageError) throw err;
+    throw new StorageError(
+      err instanceof Error ? err.message : String(err),
+      "database",
+      err instanceof Error ? err : undefined,
+    );
+  }
 }
 
 async function uploadToS3(input: UploadInput): Promise<UploadResult> {
@@ -228,54 +253,6 @@ async function uploadToS3(input: UploadInput): Promise<UploadResult> {
     throw new StorageError(
       err instanceof Error ? err.message : String(err),
       "s3",
-      err instanceof Error ? err : undefined,
-    );
-  }
-}
-
-async function uploadToDatabase(input: UploadInput): Promise<UploadResult> {
-  try {
-    const { db } = await import("~/server/db");
-    const { fileUploads } = await import("@launchstack/core/db/schema");
-
-    const body = toBuffer(input.data);
-    const safeName = sanitizeFilename(input.filename);
-    const pathname = `documents/${randomUUID()}-${safeName || "upload"}`;
-
-    const [row] = await db
-      .insert(fileUploads)
-      .values({
-        userId: input.userId,
-        filename: input.filename,
-        mimeType: input.contentType ?? "application/octet-stream",
-        fileData: body.toString("base64"),
-        fileSize: body.length,
-        storageProvider: "database",
-        storageUrl: null,
-        storagePathname: pathname,
-      })
-      .returning({ id: fileUploads.id });
-
-    if (!row) {
-      throw new Error("Insert into fileUploads returned no row");
-    }
-
-    return {
-      url: `/api/files/${row.id}`,
-      pathname,
-      ref: {
-        adapter: "database",
-        storageLocationId: resolveStorageLocationId("database"),
-        key: String(row.id),
-      },
-      contentType: input.contentType,
-      provider: "database",
-    };
-  } catch (err) {
-    if (err instanceof StorageError) throw err;
-    throw new StorageError(
-      err instanceof Error ? err.message : String(err),
-      "database",
       err instanceof Error ? err : undefined,
     );
   }
@@ -351,7 +328,8 @@ export async function deleteFile(
     return;
   }
 
-  // database: remove the fileUploads row matching this /api/files/<id> URL
+  // Database legacy calls remain a void-returning shim around the canonical
+  // target. NOT_FOUND is still successful for this compatibility surface.
   try {
     const idFromApiUrl = /^(?:https?:\/\/[^/]+)?\/api\/files\/(\d+)$/.exec(keyOrUrl)?.[1];
     const idFromOpaqueKey = /^(\d+)$/.exec(keyOrUrl)?.[1];
@@ -364,18 +342,22 @@ export async function deleteFile(
       );
     }
 
-    const id = parseInt(rawId, 10);
-    if (isNaN(id)) {
+    const target = await getTargetedStoragePort("database");
+    const result = await target.delete({
+      adapter: "database",
+      storageLocationId: resolveStorageLocationId("database"),
+      key: rawId,
+    });
+    if (
+      result.outcome === "retryable" ||
+      result.outcome === "blocked" ||
+      result.outcome === "rejected"
+    ) {
       throw new StorageError(
-        `Invalid database file id: ${rawId}`,
+        result.message ?? `Database delete failed with outcome=${result.outcome}`,
         "database",
       );
     }
-
-    const { db } = await import("~/server/db");
-    const { fileUploads } = await import("@launchstack/core/db/schema");
-    const { eq } = await import("drizzle-orm");
-    await db.delete(fileUploads).where(eq(fileUploads.id, id));
   } catch (err) {
     if (err instanceof StorageError) throw err;
     throw new StorageError(
@@ -493,18 +475,8 @@ export async function deleteFileByRef(ref: ObjectRef): Promise<DeleteResult> {
   }
 
   try {
-    if (adapter === "database") {
-      await deleteFile(ref.key, adapter);
-    } else {
-      const { createStoragePortTargetFactory } = await import(
-        "~/server/storage/create-storage-port"
-      );
-      return await createStoragePortTargetFactory(resolveStorageBackend())
-        .forAdapter(adapter)
-        .delete(ref);
-    }
-
-    return { ref, outcome: "deleted" };
+    const target = await getTargetedStoragePort(adapter);
+    return await target.delete(ref);
   } catch (err) {
     return mapDeleteError(ref, err);
   }
@@ -537,46 +509,8 @@ export async function deleteManyByRef(refs: readonly ObjectRef[]): Promise<Delet
     const first = groupRefs[0];
     if (!first) continue;
 
-    if (first.adapter === "database") {
-      let expectedLocationId: string;
-      try {
-        expectedLocationId = resolveStorageLocationId("database");
-      } catch (err) {
-        for (const ref of groupRefs) {
-          results.push({
-            ref,
-            outcome: "blocked",
-            errorCode: "location_resolution_failed",
-            message: err instanceof Error ? err.message : String(err),
-          });
-        }
-        continue;
-      }
-
-      if (first.storageLocationId !== expectedLocationId) {
-        for (const ref of groupRefs) {
-          results.push({
-            ref,
-            outcome: "blocked",
-            errorCode: "storage_location_mismatch",
-            message: `Ref storageLocationId (${ref.storageLocationId}) does not match active adapter location (${expectedLocationId}).`,
-          });
-        }
-        continue;
-      }
-
-      for (const ref of groupRefs) {
-        results.push(await deleteFileByRef(ref));
-      }
-      continue;
-    }
-
-    const { createStoragePortTargetFactory } = await import(
-      "~/server/storage/create-storage-port"
-    );
-    const groupResults = await createStoragePortTargetFactory(resolveStorageBackend())
-      .forAdapter(first.adapter)
-      .deleteMany(groupRefs);
+    const target = await getTargetedStoragePort(first.adapter);
+    const groupResults = await target.deleteMany(groupRefs);
     results.push(...groupResults);
   }
 
@@ -681,16 +615,29 @@ export async function fetchFile(
     }
   }
 
-  // Legacy private Vercel Blob URLs — delegate to fetchBlob for auth
+  // Legacy vendor URLs — promote once and let the targeted adapter own auth.
+  // Promotion is best-effort here because this function remains a string-based
+  // compatibility shim for historical URLs that predate ObjectRef.
+  let promoted:
+    | { ok: true; ref: ObjectRef }
+    | { ok: false }
+    | undefined;
   try {
-    const { fetchBlob, isPrivateBlobUrl } = await import(
-      "~/server/storage/vercel-blob"
+    const { promoteLegacyUrlToRef } = await import(
+      "~/server/storage/legacy-promote"
     );
-    if (isPrivateBlobUrl(url)) {
-      return await fetchBlob(url, init);
-    }
+    promoted = promoteLegacyUrlToRef({ value: url });
   } catch {
-    // vercel-blob module unavailable — fall through to plain fetch
+    promoted = undefined;
+  }
+
+  if (
+    promoted?.ok &&
+    (promoted.ref.adapter === "vercel-blob" ||
+      promoted.ref.adapter === "uploadthing")
+  ) {
+    const target = await getTargetedStoragePort(promoted.ref.adapter);
+    return await target.get(promoted.ref, init);
   }
 
   // Public URLs (legacy Vercel Blob, etc.) — plain fetch

--- a/apps/web/src/lib/storage.ts
+++ b/apps/web/src/lib/storage.ts
@@ -317,8 +317,29 @@ export async function deleteFile(
 
   if (resolvedProvider === "s3") {
     try {
+      let key = keyOrUrl;
+      if (/^https?:\/\//i.test(keyOrUrl)) {
+        const { promoteLegacyUrlToRef } = await import(
+          "~/server/storage/legacy-promote"
+        );
+        const promoted = promoteLegacyUrlToRef({ value: keyOrUrl });
+        if (!promoted.ok) {
+          throw new StorageError(
+            `Invalid S3 object reference: ${promoted.reason}`,
+            "s3",
+          );
+        }
+        if (promoted.ref.adapter !== "s3") {
+          throw new StorageError(
+            `S3 delete received a ${promoted.ref.adapter} reference`,
+            "s3",
+          );
+        }
+        key = promoted.ref.key;
+      }
+
       const { deleteObject } = await import("~/server/storage/s3-client");
-      await deleteObject(keyOrUrl);
+      await deleteObject(key);
     } catch (err) {
       if (err instanceof StorageError) throw err;
       throw new StorageError(
@@ -472,40 +493,15 @@ export async function deleteFileByRef(ref: ObjectRef): Promise<DeleteResult> {
   }
 
   try {
-    if (adapter === "s3" || adapter === "database") {
+    if (adapter === "database") {
       await deleteFile(ref.key, adapter);
-    } else if (adapter === "vercel-blob") {
-      const { deleteFile: deleteBlobFile } = await import("~/server/storage/vercel-blob");
-      await deleteBlobFile(ref.key);
-    } else if (adapter === "uploadthing") {
-      const { deleteUploadThingFileByKey } = await import("~/server/storage/uploadthing");
-      const outcome = await deleteUploadThingFileByKey(ref.key);
-      if (outcome.outcome === "retryable") {
-        return {
-          ref,
-          outcome: "retryable",
-          errorCode: outcome.errorCode,
-          message: outcome.message,
-        };
-      }
-      if (outcome.outcome === "blocked") {
-        return {
-          ref,
-          outcome: "blocked",
-          errorCode: outcome.errorCode,
-          message: outcome.message,
-        };
-      }
-      if (outcome.outcome === "not_found") {
-        return { ref, outcome: "not_found" };
-      }
     } else {
-      return {
-        ref,
-        outcome: "rejected",
-        errorCode: "unsupported_adapter",
-        message: `Unsupported storage adapter: ${adapter}`,
-      };
+      const { createStoragePortTargetFactory } = await import(
+        "~/server/storage/create-storage-port"
+      );
+      return await createStoragePortTargetFactory(resolveStorageBackend())
+        .forAdapter(adapter)
+        .delete(ref);
     }
 
     return { ref, outcome: "deleted" };
@@ -541,10 +537,10 @@ export async function deleteManyByRef(refs: readonly ObjectRef[]): Promise<Delet
     const first = groupRefs[0];
     if (!first) continue;
 
-    if (first.adapter === "s3") {
+    if (first.adapter === "database") {
       let expectedLocationId: string;
       try {
-        expectedLocationId = resolveStorageLocationId("s3");
+        expectedLocationId = resolveStorageLocationId("database");
       } catch (err) {
         for (const ref of groupRefs) {
           results.push({
@@ -569,35 +565,19 @@ export async function deleteManyByRef(refs: readonly ObjectRef[]): Promise<Delet
         continue;
       }
 
-      const { deleteObjects: deleteObjectsInS3 } = await import("~/server/storage/s3-client");
-      const outcomes = await deleteObjectsInS3(groupRefs.map((ref) => ref.key));
-      const outcomeByKey = new Map(outcomes.map((outcome) => [outcome.key, outcome] as const));
-
       for (const ref of groupRefs) {
-        const outcome = outcomeByKey.get(ref.key);
-        if (!outcome) {
-          results.push({
-            ref,
-            outcome: "retryable",
-            errorCode: "missing_delete_outcome",
-            message: `No delete outcome returned for key "${ref.key}".`,
-          });
-          continue;
-        }
-
-        results.push({
-          ref,
-          outcome: outcome.outcome,
-          errorCode: outcome.errorCode,
-          message: outcome.message,
-        });
+        results.push(await deleteFileByRef(ref));
       }
       continue;
     }
 
-    for (const ref of groupRefs) {
-      results.push(await deleteFileByRef(ref));
-    }
+    const { createStoragePortTargetFactory } = await import(
+      "~/server/storage/create-storage-port"
+    );
+    const groupResults = await createStoragePortTargetFactory(resolveStorageBackend())
+      .forAdapter(first.adapter)
+      .deleteMany(groupRefs);
+    results.push(...groupResults);
   }
 
   return results;

--- a/apps/web/src/server/inngest/functions/modifyDocument.ts
+++ b/apps/web/src/server/inngest/functions/modifyDocument.ts
@@ -2,7 +2,7 @@
  * Inngest Document Modification Function
  * Background job handler for Adeu-powered DOCX redlining.
  *
- * Fetches a DOCX from Vercel Blob, sends it through the Adeu service
+ * Fetches a DOCX through the storage port, sends it through the Adeu service
  * for batch edits/review actions, stores the modified DOCX back to Blob,
  * and updates the document record in the database.
  *
@@ -24,7 +24,7 @@ import { document } from "@launchstack/core/db/schema";
 import { findObjectByRef, registerArtifactEdge, registerObject } from "~/server/services/storage-manifest";
 import { isStorageDeletionLifecycleEnabled } from "~/server/storage/deletion-flags";
 import { getEngine } from "~/server/engine";
-import { fetchBlob } from "~/server/storage/vercel-blob";
+import { promoteLegacyUrlToRef } from "~/server/storage/legacy-promote";
 import { processDocumentBatch, AdeuServiceError } from "@launchstack/features/adeu";
 
 export const modifyDocument = inngest.createFunction(
@@ -62,9 +62,16 @@ export const modifyDocument = inngest.createFunction(
   async ({ event, step }) => {
     const { documentId, documentUrl, authorName, edits, actions, userId } = event.data;
 
-    // Step 1: Fetch the DOCX from Vercel Blob
+    // Step 1: Promote the legacy URL, then fetch through the storage port
     const docBuffer = await step.run("fetch-document", async () => {
-      const res = await fetchBlob(documentUrl);
+      const promoted = promoteLegacyUrlToRef({ value: documentUrl });
+      if (!promoted.ok) {
+        throw new Error(
+          `Failed to resolve document storage reference: ${promoted.reason}`,
+        );
+      }
+
+      const res = await getEngine().storage.get(promoted.ref);
       if (!res.ok) {
         throw new Error(`Failed to fetch document: HTTP ${res.status}`);
       }

--- a/apps/web/src/server/inngest/functions/modifyDocument.ts
+++ b/apps/web/src/server/inngest/functions/modifyDocument.ts
@@ -23,7 +23,8 @@ import { db } from "~/server/db";
 import { document } from "@launchstack/core/db/schema";
 import { findObjectByRef, registerArtifactEdge, registerObject } from "~/server/services/storage-manifest";
 import { isStorageDeletionLifecycleEnabled } from "~/server/storage/deletion-flags";
-import { putFile, fetchBlob } from "~/server/storage/vercel-blob";
+import { getEngine } from "~/server/engine";
+import { fetchBlob } from "~/server/storage/vercel-blob";
 import { processDocumentBatch, AdeuServiceError } from "@launchstack/features/adeu";
 
 export const modifyDocument = inngest.createFunction(
@@ -86,12 +87,14 @@ export const modifyDocument = inngest.createFunction(
 
         // Fix 1.1: store modified DOCX in blob storage instead of returning
         // raw base64, keeping step output well under Inngest's 4 MB limit
-        const stored = await putFile({
-          filename: `adeu-modified-${documentId}.docx`,
-          data: modifiedBuffer,
-          contentType:
-            "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-        });
+        const stored = await getEngine().storage
+          .forAdapter("vercel-blob")
+          .put({
+            filename: `adeu-modified-${documentId}.docx`,
+            data: modifiedBuffer,
+            contentType:
+              "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+          });
 
         return {
           summary,

--- a/apps/web/src/server/inngest/functions/processDocument.ts
+++ b/apps/web/src/server/inngest/functions/processDocument.ts
@@ -14,7 +14,7 @@ import { document, ocrJobs } from "@launchstack/core/db/schema";
 import { findObjectByRef, registerArtifactEdge, registerObject } from "~/server/services/storage-manifest";
 import { requestDocumentDeletionAndDispatch } from "~/server/services/storage-deletion-coordinator";
 import { isStorageDeletionLifecycleEnabled } from "~/server/services/storage-deletion-flags";
-import { putFile } from "~/server/storage/vercel-blob";
+import { getEngine } from "~/server/engine";
 import { fetchFile } from "~/lib/storage";
 
 import type {
@@ -434,11 +434,13 @@ export const uploadDocument = inngest.createFunction(
                 `[ProcessDocument] Storing extracted file: ${entryPath} (${(fileBuffer.length / 1024).toFixed(1)}KB, mime=${fileMime ?? "unknown"})`,
               );
 
-              const blob = await putFile({
-                filename: baseName,
-                data: fileBuffer,
-                contentType: fileMime,
-              });
+              const blob = await getEngine().storage
+                .forAdapter("vercel-blob")
+                .put({
+                  filename: baseName,
+                  data: fileBuffer,
+                  contentType: fileMime,
+                });
               const child = await db.transaction(async (tx) => {
                 const [newDoc] = await tx
                   .insert(document)
@@ -552,11 +554,13 @@ export const uploadDocument = inngest.createFunction(
               : []),
           ].join("\n");
 
-          const summaryBlob = await putFile({
-            filename: `_summary_${archiveName}.md`,
-            data: Buffer.from(summaryText, "utf-8"),
-            contentType: "text/markdown",
-          });
+          const summaryBlob = await getEngine().storage
+            .forAdapter("vercel-blob")
+            .put({
+              filename: `_summary_${archiveName}.md`,
+              data: Buffer.from(summaryText, "utf-8"),
+              contentType: "text/markdown",
+            });
 
           const summaryJobId = `ocr-${Date.now().toString(36)}-summary`;
           const summary = await db.transaction(async (tx) => {

--- a/apps/web/src/server/services/document-upload.ts
+++ b/apps/web/src/server/services/document-upload.ts
@@ -12,7 +12,6 @@ import {
 } from "@launchstack/features/voice";
 import { getEngine } from "~/server/engine";
 import { uploadFile } from "~/lib/storage";
-import { putFile } from "~/server/storage/vercel-blob";
 import {
   detectStorageType,
   toAbsoluteUrl,
@@ -520,11 +519,13 @@ export async function processVideoUrlUpload({
   const documentName = title || transcriptionResult.title || "Video Transcription";
 
   // 2. Store the transcript as a text file in blob storage
-  const textBlob = await putFile({
-    filename: `${documentName}-transcription.txt`,
-    data: Buffer.from(transcriptionResult.text, "utf-8"),
-    contentType: "text/plain",
-  });
+  const textBlob = await getEngine().storage
+    .forAdapter("vercel-blob")
+    .put({
+      filename: `${documentName}-transcription.txt`,
+      data: Buffer.from(transcriptionResult.text, "utf-8"),
+      contentType: "text/plain",
+    });
 
   const transcriptionMetadata = {
     source: "whisper-ytdlp",

--- a/apps/web/src/server/storage/adapters/database-adapter.ts
+++ b/apps/web/src/server/storage/adapters/database-adapter.ts
@@ -1,0 +1,308 @@
+/**
+ * Database adapter (C3).
+ *
+ * The backend where the bytes never leave Postgres: a file's contents live
+ * base64-encoded in a file_uploads row, and the ref's key is that row's id.
+ * Reached through `getStoragePort().forAdapter("database")`.
+ *
+ * COPIED, NOT MOVED
+ * -----------------
+ * put and delete are the logic from lib/storage.ts's database branches,
+ * reproduced here. That file is Dev A's this sprint (A3/A4 thin it down to
+ * shims), and two people editing one 726-line file produces a merge conflict
+ * neither can resolve with confidence. So this is a copy; A3 deletes the
+ * original once the port is wired.
+ *
+ * get(ref) — WHY IT MAKES AN HTTP CALL TO OUR OWN APP
+ * ---------------------------------------------------
+ * There are two defensible ways to read a database-backed file: query the row
+ * directly, or fetch /api/files/{id} over HTTP with internal credentials.
+ * Dev A chose the authenticated internal call, and that is what this
+ * implements. Two consequences follow, and both are deliberate:
+ *
+ *  - APP_PUBLIC_URL becomes a hard requirement for this adapter. There is no
+ *    silent fallback to a direct row read: quietly switching mechanism when
+ *    config is missing is how two code paths drift apart until only one of
+ *    them is ever tested. It fails loudly instead.
+ *
+ *  - Reads pass through the route's serve-gating (B6). A file whose document
+ *    has an open deletion request answers 410 even to an internal caller.
+ *    That is the correct behaviour — bytes on their way out should not be
+ *    readable — but it is a real difference from a raw row read, so it is
+ *    stated rather than discovered.
+ *
+ * The internal service token identifies the caller as *this app*, not as any
+ * company, so it bypasses the route's tenant check rather than satisfying it.
+ * Without it the ingestion path could not read its own uploads once tenant
+ * auth is enforcing.
+ */
+
+import { randomUUID } from "node:crypto";
+import { eq, inArray } from "drizzle-orm";
+import { fileUploads } from "@launchstack/core/db/schema";
+
+import type {
+  DeleteResult,
+  GetSignedUrlOptions,
+  ObjectRef,
+  TargetedStoragePort,
+  UploadInput,
+  UploadResult,
+} from "@launchstack/core/storage";
+
+import { db } from "~/server/db";
+import { env } from "~/env";
+import { resolveStorageLocationId } from "~/lib/storage-location-id";
+import { internalServiceHeaders } from "~/server/storage/internal-service-auth";
+
+const ADAPTER = "database" as const;
+
+function sanitizeFilename(filename: string): string {
+  return filename.replace(/\s+/g, "-").replace(/[^a-zA-Z0-9.\-_]/g, "");
+}
+
+function toBuffer(data: Buffer | ArrayBuffer | Uint8Array): Buffer {
+  return Buffer.from(data instanceof ArrayBuffer ? new Uint8Array(data) : data);
+}
+
+function assertOwnAdapter(ref: ObjectRef): void {
+  if (ref.adapter !== ADAPTER) {
+    throw new Error(
+      `[database-adapter] received a ref for adapter "${ref.adapter}". ` +
+        "Use getStoragePort().forAdapter(ref.adapter) to reach the right one.",
+    );
+  }
+}
+
+/**
+ * Decision 4 applies here too, even though "the location" is a fixed constant
+ * for this adapter — a ref carrying some other location came from a different
+ * store and must not be resolved against this one.
+ */
+function locationMismatch(ref: ObjectRef): string | null {
+  const current = resolveStorageLocationId(ADAPTER);
+  return ref.storageLocationId === current
+    ? null
+    : `Ref location ${ref.storageLocationId} does not match the configured database store (${current}).`;
+}
+
+/** The ref's key is a file_uploads row id. Anything else is not ours. */
+function parseRowId(ref: ObjectRef): number | null {
+  if (!/^\d+$/.test(ref.key)) return null;
+  const id = Number.parseInt(ref.key, 10);
+  return Number.isSafeInteger(id) && id > 0 ? id : null;
+}
+
+function requireAppUrl(): string {
+  const base = env.server.APP_PUBLIC_URL;
+  if (!base) {
+    throw new Error(
+      "[database-adapter] APP_PUBLIC_URL is required to read database-backed files. " +
+        "Reads go through an authenticated internal call to /api/files/{id}, which " +
+        "needs an absolute URL.",
+    );
+  }
+  return base.replace(/\/+$/, "");
+}
+
+export function createDatabaseAdapter(): TargetedStoragePort {
+  const deleteImpl = async (ref: ObjectRef): Promise<DeleteResult> => {
+    assertOwnAdapter(ref);
+
+    const mismatch = locationMismatch(ref);
+    if (mismatch) {
+      return { ref, outcome: "blocked", errorCode: "storage_location_mismatch", message: mismatch };
+    }
+
+    const id = parseRowId(ref);
+    if (id === null) {
+      // Not transient and not the database's fault — a malformed ref needs a
+      // human, so BLOCKED rather than an endless retry.
+      return {
+        ref,
+        outcome: "blocked",
+        errorCode: "invalid_database_file_reference",
+        message: `Database ref key "${ref.key}" is not a file_uploads row id.`,
+      };
+    }
+
+    try {
+      const removed = await db
+        .delete(fileUploads)
+        .where(eq(fileUploads.id, id))
+        .returning({ id: fileUploads.id });
+
+      // The row count is checked, so "it was already gone" is reported as
+      // not_found rather than as a successful delete. lib/storage.ts's
+      // database branch does not do this today — it returns success either
+      // way, which makes an already-absent object indistinguishable from one
+      // this call actually removed (design doc A7 asks for an explicit
+      // NOT_FOUND contract). Raised separately for that file; this adapter
+      // does not inherit the gap.
+      return removed.length === 0
+        ? { ref, outcome: "not_found" }
+        : { ref, outcome: "deleted" };
+    } catch (err) {
+      return {
+        ref,
+        outcome: "retryable",
+        errorCode: "database_delete_failed",
+        message: err instanceof Error ? err.message : String(err),
+      };
+    }
+  };
+
+  return {
+    adapter: ADAPTER,
+    provider: ADAPTER,
+
+    async put(input: UploadInput): Promise<UploadResult> {
+      const body = toBuffer(input.data);
+      const safeName = sanitizeFilename(input.filename);
+      const pathname = `documents/${randomUUID()}-${safeName || "upload"}`;
+
+      const [row] = await db
+        .insert(fileUploads)
+        .values({
+          // The port's userId is optional; engine-initiated writes carry no
+          // end user. "system" matches what the existing port already passes.
+          userId: input.userId ?? "system",
+          filename: input.filename,
+          mimeType: input.contentType ?? "application/octet-stream",
+          fileData: body.toString("base64"),
+          fileSize: body.length,
+          storageProvider: ADAPTER,
+          storageUrl: null,
+          storagePathname: pathname,
+        })
+        .returning({ id: fileUploads.id });
+
+      if (!row) throw new Error("[database-adapter] insert into file_uploads returned no row");
+
+      return {
+        url: `/api/files/${row.id}`,
+        pathname,
+        ref: {
+          adapter: ADAPTER,
+          storageLocationId: resolveStorageLocationId(ADAPTER),
+          // The row id is the provider-native key for this backend.
+          key: String(row.id),
+        },
+        contentType: input.contentType,
+        provider: ADAPTER,
+      };
+    },
+
+    async get(ref: ObjectRef, init?: RequestInit): Promise<Response> {
+      assertOwnAdapter(ref);
+
+      const mismatch = locationMismatch(ref);
+      if (mismatch) throw new Error(`[database-adapter] ${mismatch}`);
+
+      const id = parseRowId(ref);
+      if (id === null) {
+        throw new Error(
+          `[database-adapter] ref key "${ref.key}" is not a file_uploads row id.`,
+        );
+      }
+
+      // Internal service credentials, not a user session. The route reads this
+      // as "the app is asking" and skips its tenant check; serve-gating still
+      // applies. Merged after the caller's headers so a caller cannot
+      // accidentally overwrite them.
+      const headers = {
+        ...(init?.headers as Record<string, string> | undefined),
+        ...internalServiceHeaders(),
+      };
+
+      // Returned as-is, fetch-style: callers check response.ok. A gated or
+      // missing file surfaces as a non-ok response, not a thrown error.
+      return fetch(`${requireAppUrl()}/api/files/${id}`, { ...init, headers });
+    },
+
+    delete: deleteImpl,
+
+    async deleteMany(refs: readonly ObjectRef[]): Promise<DeleteResult[]> {
+      if (refs.length === 0) return [];
+      for (const ref of refs) assertOwnAdapter(ref);
+
+      const results: DeleteResult[] = [];
+      const byId = new Map<number, ObjectRef>();
+
+      for (const ref of refs) {
+        const mismatch = locationMismatch(ref);
+        if (mismatch) {
+          results.push({
+            ref,
+            outcome: "blocked",
+            errorCode: "storage_location_mismatch",
+            message: mismatch,
+          });
+          continue;
+        }
+
+        const id = parseRowId(ref);
+        if (id === null) {
+          results.push({
+            ref,
+            outcome: "blocked",
+            errorCode: "invalid_database_file_reference",
+            message: `Database ref key "${ref.key}" is not a file_uploads row id.`,
+          });
+          continue;
+        }
+
+        byId.set(id, ref);
+      }
+
+      if (byId.size === 0) return results;
+
+      try {
+        // Unlike the provider APIs, a SQL delete can report exactly which rows
+        // it removed — so every ref gets its true outcome from one statement,
+        // with no per-item fallback needed and no guessing.
+        const removed = await db
+          .delete(fileUploads)
+          .where(inArray(fileUploads.id, [...byId.keys()]))
+          .returning({ id: fileUploads.id });
+
+        const removedIds = new Set(removed.map((row) => row.id));
+        for (const [id, ref] of byId) {
+          results.push({ ref, outcome: removedIds.has(id) ? "deleted" : "not_found" });
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        for (const ref of byId.values()) {
+          results.push({
+            ref,
+            outcome: "retryable",
+            errorCode: "database_delete_failed",
+            message,
+          });
+        }
+      }
+
+      return results;
+    },
+
+    async getSignedUrl(ref: ObjectRef, _opts?: GetSignedUrlOptions): Promise<string> {
+      assertOwnAdapter(ref);
+
+      const mismatch = locationMismatch(ref);
+      if (mismatch) throw new Error(`[database-adapter] ${mismatch}`);
+
+      const id = parseRowId(ref);
+      if (id === null) {
+        throw new Error(`[database-adapter] ref key "${ref.key}" is not a file_uploads row id.`);
+      }
+
+      // NOT a signed URL, and deliberately not pretending to be one. Database
+      // files have no signature scheme; /api/files/{id} is their canonical
+      // serve path, and access is decided by the requester's session through
+      // the route's tenant check and serve gate — not by anything embedded in
+      // the URL. So this is safe to hand to a logged-in browser and useless to
+      // hand to a stranger. expiresIn is ignored because nothing here expires.
+      return `${requireAppUrl()}/api/files/${id}`;
+    },
+  };
+}

--- a/apps/web/src/server/storage/adapters/database-adapter.ts
+++ b/apps/web/src/server/storage/adapters/database-adapter.ts
@@ -5,13 +5,11 @@
  * base64-encoded in a file_uploads row, and the ref's key is that row's id.
  * Reached through `getStoragePort().forAdapter("database")`.
  *
- * COPIED, NOT MOVED
- * -----------------
- * put and delete are the logic from lib/storage.ts's database branches,
- * reproduced here. That file is Dev A's this sprint (A3/A4 thin it down to
- * shims), and two people editing one 726-line file produces a merge conflict
- * neither can resolve with confidence. So this is a copy; A3 deletes the
- * original once the port is wired.
+ * EXTRACTED FROM THE LEGACY HELPER
+ * ---------------------------------
+ * put and delete started as the logic from lib/storage.ts's database branches.
+ * The legacy entry points now delegate through the factory, so this adapter is
+ * the single implementation rather than a second copy of the database path.
  *
  * get(ref) — WHY IT MAKES AN HTTP CALL TO OUR OWN APP
  * ---------------------------------------------------

--- a/apps/web/src/server/storage/adapters/database-adapter.ts
+++ b/apps/web/src/server/storage/adapters/database-adapter.ts
@@ -39,7 +39,6 @@
 
 import { randomUUID } from "node:crypto";
 import { eq, inArray } from "drizzle-orm";
-import { fileUploads } from "@launchstack/core/db/schema";
 
 import type {
   DeleteResult,
@@ -50,12 +49,29 @@ import type {
   UploadResult,
 } from "@launchstack/core/storage";
 
-import { db } from "~/server/db";
 import { env } from "~/env";
 import { resolveStorageLocationId } from "~/lib/storage-location-id";
 import { internalServiceHeaders } from "~/server/storage/internal-service-auth";
 
 const ADAPTER = "database" as const;
+
+/**
+ * Loaded on demand, not at module scope.
+ *
+ * ~/server/db pulls in the engine, which pulls in ~/env — so a static import
+ * here would mean that merely *importing* this adapter drags the whole
+ * application graph along with it. lib/storage.ts's database branch used
+ * dynamic imports for exactly this reason; copying the logic without copying
+ * that property was a regression, and it immediately broke an unrelated test
+ * that imports the adapter factory.
+ */
+async function getDb() {
+  const [{ db }, { fileUploads }] = await Promise.all([
+    import("~/server/db"),
+    import("@launchstack/core/db/schema"),
+  ]);
+  return { db, fileUploads };
+}
 
 function sanitizeFilename(filename: string): string {
   return filename.replace(/\s+/g, "-").replace(/[^a-zA-Z0-9.\-_]/g, "");
@@ -127,6 +143,7 @@ export function createDatabaseAdapter(): TargetedStoragePort {
     }
 
     try {
+      const { db, fileUploads } = await getDb();
       const removed = await db
         .delete(fileUploads)
         .where(eq(fileUploads.id, id))
@@ -161,6 +178,7 @@ export function createDatabaseAdapter(): TargetedStoragePort {
       const safeName = sanitizeFilename(input.filename);
       const pathname = `documents/${randomUUID()}-${safeName || "upload"}`;
 
+      const { db, fileUploads } = await getDb();
       const [row] = await db
         .insert(fileUploads)
         .values({
@@ -261,6 +279,7 @@ export function createDatabaseAdapter(): TargetedStoragePort {
         // Unlike the provider APIs, a SQL delete can report exactly which rows
         // it removed — so every ref gets its true outcome from one statement,
         // with no per-item fallback needed and no guessing.
+        const { db, fileUploads } = await getDb();
         const removed = await db
           .delete(fileUploads)
           .where(inArray(fileUploads.id, [...byId.keys()]))

--- a/apps/web/src/server/storage/adapters/s3-adapter.ts
+++ b/apps/web/src/server/storage/adapters/s3-adapter.ts
@@ -1,0 +1,448 @@
+import {
+  CreateBucketCommand,
+  DeleteObjectCommand,
+  DeleteObjectsCommand,
+  GetObjectCommand,
+  HeadBucketCommand,
+  ListObjectsV2Command,
+  PutObjectCommand,
+  S3Client,
+} from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+import type { ObjectRef } from "@launchstack/core/storage";
+
+import { env } from "~/env";
+import { resolveStorageLocationId } from "~/lib/storage-location-id";
+
+export interface DeleteObjectOutcome {
+  key: string;
+  outcome: "deleted" | "not_found" | "retryable" | "blocked";
+  errorCode?: string;
+  message?: string;
+}
+
+export interface PutResult {
+  ref: ObjectRef;
+  url: string;
+  pathname: string;
+  provider: "s3";
+}
+
+export interface SignedUrlInput {
+  ref: ObjectRef;
+  operation: "put" | "get";
+  contentType?: string;
+  expiresIn?: number;
+}
+
+export interface S3ListedObject {
+  key: string;
+  size?: number;
+  lastModified?: string;
+  etag?: string;
+}
+
+export interface S3PrivilegedListInput {
+  prefix?: string;
+  cursor?: string;
+  limit: number;
+}
+
+export interface S3PrivilegedListResult {
+  objects: S3ListedObject[];
+  nextCursor?: string;
+}
+
+interface ResolvedS3Config {
+  endpoint: string;
+  publicEndpoint: string;
+  region: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  bucket: string;
+  forcePathStyle: boolean;
+  ensureBucketExists: boolean;
+}
+
+function readStringEnv(...names: string[]): string | undefined {
+  for (const name of names) {
+    const value = process.env[name];
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value.trim();
+    }
+  }
+  return undefined;
+}
+
+function readBooleanEnv(name: string): boolean | undefined {
+  const value = process.env[name]?.trim().toLowerCase();
+  if (!value) return undefined;
+  if (value === "1" || value === "true" || value === "yes" || value === "on") return true;
+  if (value === "0" || value === "false" || value === "no" || value === "off") return false;
+  return undefined;
+}
+
+function normalizeEndpoint(endpoint: string): string {
+  return endpoint.replace(/\/+$/, "");
+}
+
+function resolveS3Config(): ResolvedS3Config {
+  const endpoint =
+    readStringEnv("STORAGE_S3_ENDPOINT", "NEXT_PUBLIC_S3_ENDPOINT") ??
+    env.server.NEXT_PUBLIC_S3_ENDPOINT ??
+    env.client.NEXT_PUBLIC_S3_ENDPOINT;
+
+  const publicEndpoint =
+    readStringEnv("STORAGE_S3_PUBLIC_ENDPOINT", "S3_PUBLIC_ENDPOINT") ??
+    env.server.S3_PUBLIC_ENDPOINT ??
+    endpoint;
+
+  const region = readStringEnv("STORAGE_S3_REGION", "S3_REGION") ?? env.server.S3_REGION ?? "us-east-1";
+
+  const accessKeyId =
+    readStringEnv("STORAGE_S3_ACCESS_KEY", "STORAGE_S3_ACCESS_KEY_ID", "S3_ACCESS_KEY") ??
+    env.server.S3_ACCESS_KEY;
+
+  const secretAccessKey =
+    readStringEnv("STORAGE_S3_SECRET_KEY", "STORAGE_S3_SECRET_ACCESS_KEY", "S3_SECRET_KEY") ??
+    env.server.S3_SECRET_KEY;
+
+  const bucket =
+    readStringEnv("STORAGE_S3_BUCKET_NAME", "STORAGE_S3_BUCKET", "S3_BUCKET_NAME") ??
+    env.server.S3_BUCKET_NAME;
+
+  if (!endpoint || !bucket || !accessKeyId || !secretAccessKey) {
+    throw new Error(
+      "S3 configuration is incomplete. Configure STORAGE_S3_ENDPOINT/STORAGE_S3_BUCKET_NAME/STORAGE_S3_ACCESS_KEY/STORAGE_S3_SECRET_KEY (or legacy NEXT_PUBLIC_S3_ENDPOINT/S3_BUCKET_NAME/S3_ACCESS_KEY/S3_SECRET_KEY).",
+    );
+  }
+
+  return {
+    endpoint: normalizeEndpoint(endpoint),
+    publicEndpoint: normalizeEndpoint(publicEndpoint ?? endpoint),
+    region,
+    accessKeyId,
+    secretAccessKey,
+    bucket,
+    // Preserve today's behavior unless explicitly overridden.
+    forcePathStyle: readBooleanEnv("STORAGE_S3_FORCE_PATH_STYLE") ?? true,
+    // Bucket creation is now opt-in because many managed S3 providers forbid it.
+    ensureBucketExists: readBooleanEnv("STORAGE_S3_ENSURE_BUCKET_EXISTS") ?? false,
+  };
+}
+
+function isS3BlockedDeleteError(code: string, message?: string): boolean {
+  const haystack = `${code} ${message ?? ""}`;
+  return /AccessDenied|Unauthorized|Forbidden|InvalidAccessKeyId|SignatureDoesNotMatch|InvalidToken|ExpiredToken|Credentials|Credential|permission|AuthFailed/i.test(
+    haystack,
+  );
+}
+
+export class S3StorageAdapter {
+  private client: S3Client | null = null;
+  private bucketEnsured = false;
+  private warnedVirtualHostedUrlLimitation = false;
+
+  private config(): ResolvedS3Config {
+    return resolveS3Config();
+  }
+
+  getClient(): S3Client {
+    if (!this.client) {
+      const config = this.config();
+      this.client = new S3Client({
+        endpoint: config.endpoint,
+        region: config.region,
+        credentials: {
+          accessKeyId: config.accessKeyId,
+          secretAccessKey: config.secretAccessKey,
+        },
+        forcePathStyle: config.forcePathStyle,
+      });
+    }
+
+    return this.client;
+  }
+
+  getBucketName(): string {
+    return this.config().bucket;
+  }
+
+  getEndpoint(): string {
+    return this.config().endpoint;
+  }
+
+  mintRef(key: string): ObjectRef {
+    return {
+      adapter: "s3",
+      storageLocationId: resolveStorageLocationId("s3"),
+      key,
+    };
+  }
+
+  private assertActiveRef(ref: ObjectRef): void {
+    if (ref.adapter !== "s3") {
+      throw new Error(`S3 adapter cannot handle ref adapter=${ref.adapter}`);
+    }
+
+    const expectedLocationId = resolveStorageLocationId("s3");
+    if (ref.storageLocationId !== expectedLocationId) {
+      throw new Error(
+        `Ref storageLocationId (${ref.storageLocationId}) does not match active S3 location (${expectedLocationId}).`,
+      );
+    }
+  }
+
+  async ensureBucketExists(): Promise<void> {
+    const config = this.config();
+    if (!config.ensureBucketExists || this.bucketEnsured) {
+      return;
+    }
+
+    const client = this.getClient();
+    try {
+      await client.send(new HeadBucketCommand({ Bucket: config.bucket }));
+    } catch {
+      try {
+        await client.send(new CreateBucketCommand({ Bucket: config.bucket }));
+        console.log(`[S3] Created bucket "${config.bucket}" at ${config.endpoint}`);
+      } catch (createErr) {
+        throw new Error(
+          `Failed to create S3 bucket "${config.bucket}" at ${config.endpoint}: ${createErr instanceof Error ? createErr.message : String(createErr)}`,
+        );
+      }
+    }
+
+    this.bucketEnsured = true;
+  }
+
+  async putObject(key: string, body: Buffer, contentType?: string): Promise<void> {
+    const client = this.getClient();
+    const config = this.config();
+    try {
+      await client.send(
+        new PutObjectCommand({
+          Bucket: config.bucket,
+          Key: key,
+          Body: body,
+          ContentType: contentType,
+        }),
+      );
+    } catch (err) {
+      throw new Error(
+        `Failed to upload object "${key}" to S3 at ${config.endpoint}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  async listObjectsPrivileged(input: S3PrivilegedListInput): Promise<S3PrivilegedListResult> {
+    const client = this.getClient();
+    const config = this.config();
+    const response = await client.send(
+      new ListObjectsV2Command({
+        Bucket: config.bucket,
+        Prefix: input.prefix,
+        ContinuationToken: input.cursor,
+        MaxKeys: input.limit,
+      }),
+    );
+
+    const objects: S3ListedObject[] = [];
+    for (const entry of response.Contents ?? []) {
+      if (!entry.Key) continue;
+      objects.push({
+        key: entry.Key,
+        size: typeof entry.Size === "number" ? entry.Size : undefined,
+        lastModified: entry.LastModified?.toISOString(),
+        etag: entry.ETag,
+      });
+    }
+
+    return {
+      objects,
+      nextCursor: response.IsTruncated ? response.NextContinuationToken : undefined,
+    };
+  }
+
+  async put(input: { key: string; body: Buffer; contentType?: string }): Promise<PutResult> {
+    const { key, body, contentType } = input;
+    const ref = this.mintRef(key);
+
+    await this.ensureBucketExists();
+    await this.putObject(key, body, contentType);
+
+    return {
+      ref,
+      url: this.getObjectUrl(key),
+      pathname: key,
+      provider: "s3",
+    };
+  }
+
+  getObjectUrl(key: string): string {
+    const config = this.config();
+
+    // Note: URL generation is currently path-style only. If forcePathStyle is
+    // false (virtual-hosted requests), promotion/read still work, but the
+    // minted write URL may not match the provider's canonical host style.
+    if (!config.forcePathStyle && !this.warnedVirtualHostedUrlLimitation) {
+      this.warnedVirtualHostedUrlLimitation = true;
+      console.warn(
+        "[S3] STORAGE_S3_FORCE_PATH_STYLE=false is set, but getObjectUrl() still emits path-style URLs. Virtual-hosted URL minting is not implemented yet.",
+      );
+    }
+
+    return `${config.publicEndpoint}/${config.bucket}/${key}`;
+  }
+
+  async deleteObject(key: string): Promise<void> {
+    const client = this.getClient();
+    const config = this.config();
+    try {
+      await client.send(
+        new DeleteObjectCommand({
+          Bucket: config.bucket,
+          Key: key,
+        }),
+      );
+    } catch (err) {
+      throw new Error(
+        `Failed to delete object "${key}" from S3 at ${config.endpoint}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  async deleteObjects(keys: string[]): Promise<DeleteObjectOutcome[]> {
+    if (keys.length === 0) {
+      return [];
+    }
+
+    const client = this.getClient();
+    const config = this.config();
+
+    try {
+      const response = await client.send(
+        new DeleteObjectsCommand({
+          Bucket: config.bucket,
+          Delete: {
+            Objects: keys.map((key) => ({ Key: key })),
+            Quiet: false,
+          },
+        }),
+      );
+
+      const outcomeByKey = new Map<string, DeleteObjectOutcome>();
+
+      for (const deleted of response.Deleted ?? []) {
+        if (!deleted.Key) continue;
+        outcomeByKey.set(deleted.Key, {
+          key: deleted.Key,
+          outcome: "deleted",
+        });
+      }
+
+      for (const error of response.Errors ?? []) {
+        if (!error.Key) continue;
+        const code = error.Code ?? "DeleteError";
+        const isNotFound = /NoSuchKey|NotFound|404/i.test(code);
+        const isBlocked = !isNotFound && isS3BlockedDeleteError(code, error.Message);
+        outcomeByKey.set(error.Key, {
+          key: error.Key,
+          outcome: isNotFound ? "not_found" : isBlocked ? "blocked" : "retryable",
+          errorCode: code,
+          message: error.Message,
+        });
+      }
+
+      return keys.map((key) => {
+        return outcomeByKey.get(key) ?? {
+          key,
+          outcome: "deleted",
+        };
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const name =
+        typeof err === "object" &&
+        err &&
+        "name" in err &&
+        typeof (err as { name?: unknown }).name === "string"
+          ? (err as { name: string }).name
+          : "DeleteObjectsFailed";
+      const blocked = isS3BlockedDeleteError(name, message);
+      return keys.map((key) => ({
+        key,
+        outcome: blocked ? "blocked" : "retryable",
+        errorCode: blocked ? name : "DeleteObjectsFailed",
+        message: `Failed to batch delete object "${key}" from S3 at ${config.endpoint}: ${message}`,
+      }));
+    }
+  }
+
+  async getPresignedUploadUrl(
+    key: string,
+    contentType: string,
+    expiresIn = 300,
+  ): Promise<string> {
+    const client = this.getClient();
+    const config = this.config();
+    try {
+      return await getSignedUrl(
+        client,
+        new PutObjectCommand({
+          Bucket: config.bucket,
+          Key: key,
+          ContentType: contentType,
+        }),
+        { expiresIn },
+      );
+    } catch (err) {
+      throw new Error(
+        `Failed to generate presigned upload URL for "${key}" at ${config.endpoint}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  async getSignedUrl(input: SignedUrlInput): Promise<string> {
+    const { ref, operation, contentType, expiresIn = 300 } = input;
+    this.assertActiveRef(ref);
+
+    await this.ensureBucketExists();
+    if (operation === "put") {
+      if (!contentType) {
+        throw new Error("contentType is required when generating a PUT signed URL");
+      }
+      return this.getPresignedUploadUrl(ref.key, contentType, expiresIn);
+    }
+
+    return this.getPresignedDownloadUrl(ref.key, expiresIn);
+  }
+
+  async getPresignedDownloadUrl(key: string, expiresIn = 300): Promise<string> {
+    const client = this.getClient();
+    const config = this.config();
+    try {
+      return await getSignedUrl(
+        client,
+        new GetObjectCommand({
+          Bucket: config.bucket,
+          Key: key,
+        }),
+        { expiresIn },
+      );
+    } catch (err) {
+      throw new Error(
+        `Failed to generate presigned download URL for "${key}" at ${config.endpoint}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+}
+
+let singletonAdapter: S3StorageAdapter | null = null;
+
+export function getS3StorageAdapter(): S3StorageAdapter {
+  if (!singletonAdapter) {
+    singletonAdapter = new S3StorageAdapter();
+  }
+  return singletonAdapter;
+}

--- a/apps/web/src/server/storage/adapters/s3-targeted-port.ts
+++ b/apps/web/src/server/storage/adapters/s3-targeted-port.ts
@@ -1,0 +1,194 @@
+import { randomUUID } from "node:crypto";
+
+import type {
+  DeleteResult,
+  GetSignedUrlOptions,
+  ObjectRef,
+  TargetedStoragePort,
+  UploadInput,
+  UploadResult,
+} from "@launchstack/core/storage";
+
+import { resolveStorageLocationId } from "~/lib/storage-location-id";
+import { getS3StorageAdapter, type DeleteObjectOutcome } from "./s3-adapter";
+
+const ADAPTER = "s3" as const;
+
+function sanitizeFilename(filename: string): string {
+  return filename.replace(/\s+/g, "-").replace(/[^a-zA-Z0-9.\-_]/g, "");
+}
+
+function toBuffer(data: UploadInput["data"]): Buffer {
+  return Buffer.from(data instanceof ArrayBuffer ? new Uint8Array(data) : data);
+}
+
+function assertOwnAdapter(ref: ObjectRef): void {
+  if (ref.adapter !== ADAPTER) {
+    throw new Error(
+      `[s3-targeted-port] received a ref for adapter "${ref.adapter}". ` +
+        "Use getStoragePort().forAdapter(ref.adapter) to reach the right one.",
+    );
+  }
+}
+
+function getLocationMismatch(ref: ObjectRef): string | null {
+  const expectedLocationId = resolveStorageLocationId(ADAPTER);
+  return ref.storageLocationId === expectedLocationId
+    ? null
+    : `Ref storageLocationId (${ref.storageLocationId}) does not match active S3 location (${expectedLocationId}).`;
+}
+
+function assertReadableRef(ref: ObjectRef): void {
+  assertOwnAdapter(ref);
+  const mismatch = getLocationMismatch(ref);
+  if (mismatch) throw new Error(`[s3-targeted-port] ${mismatch}`);
+}
+
+function errorDetails(error: unknown): { code: string; message: string } {
+  const message = error instanceof Error ? error.message : String(error);
+  const code =
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    typeof error.name === "string"
+      ? error.name
+      : typeof error === "object" &&
+          error !== null &&
+          "code" in error &&
+          typeof error.code === "string"
+        ? error.code
+        : "s3_delete_failed";
+
+  return { code, message };
+}
+
+function isBlockedError(code: string, message: string): boolean {
+  return /AccessDenied|Unauthorized|Forbidden|InvalidAccessKeyId|SignatureDoesNotMatch|InvalidToken|ExpiredToken|Credentials|Credential|permission|AuthFailed/i.test(
+    `${code} ${message}`,
+  );
+}
+
+function mapDeleteError(ref: ObjectRef, error: unknown): DeleteResult {
+  const { code, message } = errorDetails(error);
+  return {
+    ref,
+    outcome: isBlockedError(code, message) ? "blocked" : "retryable",
+    errorCode: code,
+    message,
+  };
+}
+
+function mapBatchOutcome(ref: ObjectRef, outcome: DeleteObjectOutcome | undefined): DeleteResult {
+  if (!outcome) {
+    return {
+      ref,
+      outcome: "retryable",
+      errorCode: "missing_delete_outcome",
+      message: `No delete outcome returned for key "${ref.key}".`,
+    };
+  }
+
+  return {
+    ref,
+    outcome: outcome.outcome,
+    errorCode: outcome.errorCode,
+    message: outcome.message,
+  };
+}
+
+export function createS3TargetedPort(): TargetedStoragePort {
+  const s3 = getS3StorageAdapter();
+
+  return {
+    adapter: ADAPTER,
+    provider: ADAPTER,
+
+    async put(input: UploadInput): Promise<UploadResult> {
+      const safeName = sanitizeFilename(input.filename);
+      const key = `documents/${randomUUID()}-${safeName || "upload"}`;
+      const result = await s3.put({
+        key,
+        body: toBuffer(input.data),
+        contentType: input.contentType,
+      });
+
+      return {
+        ...result,
+        contentType: input.contentType,
+      };
+    },
+
+    async get(ref: ObjectRef, init?: RequestInit): Promise<Response> {
+      assertReadableRef(ref);
+      return fetch(s3.getObjectUrl(ref.key), init);
+    },
+
+    async delete(ref: ObjectRef): Promise<DeleteResult> {
+      assertOwnAdapter(ref);
+      const mismatch = getLocationMismatch(ref);
+      if (mismatch) {
+        return {
+          ref,
+          outcome: "blocked",
+          errorCode: "storage_location_mismatch",
+          message: mismatch,
+        };
+      }
+
+      try {
+        await s3.deleteObject(ref.key);
+        return { ref, outcome: "deleted" };
+      } catch (error) {
+        return mapDeleteError(ref, error);
+      }
+    },
+
+    async deleteMany(refs: readonly ObjectRef[]): Promise<DeleteResult[]> {
+      if (refs.length === 0) return [];
+
+      const results: Array<DeleteResult | undefined> = new Array(refs.length);
+      const deletable: Array<{ index: number; ref: ObjectRef }> = [];
+
+      refs.forEach((ref, index) => {
+        assertOwnAdapter(ref);
+        const mismatch = getLocationMismatch(ref);
+        if (mismatch) {
+          results[index] = {
+            ref,
+            outcome: "blocked",
+            errorCode: "storage_location_mismatch",
+            message: mismatch,
+          };
+        } else {
+          deletable.push({ index, ref });
+        }
+      });
+
+      if (deletable.length > 0) {
+        try {
+          const outcomes = await s3.deleteObjects(deletable.map(({ ref }) => ref.key));
+          const outcomeByKey = new Map(outcomes.map((outcome) => [outcome.key, outcome]));
+
+          for (const { index, ref } of deletable) {
+            results[index] = mapBatchOutcome(ref, outcomeByKey.get(ref.key));
+          }
+        } catch (error) {
+          for (const { index, ref } of deletable) {
+            results[index] = mapDeleteError(ref, error);
+          }
+        }
+      }
+
+      return results as DeleteResult[];
+    },
+
+    async getSignedUrl(ref: ObjectRef, opts?: GetSignedUrlOptions): Promise<string> {
+      assertReadableRef(ref);
+      return s3.getSignedUrl({
+        ref,
+        operation: "get",
+        ...(opts?.expiresIn !== undefined ? { expiresIn: opts.expiresIn } : {}),
+      });
+    },
+  };
+}

--- a/apps/web/src/server/storage/adapters/uploadthing-adapter.ts
+++ b/apps/web/src/server/storage/adapters/uploadthing-adapter.ts
@@ -1,0 +1,259 @@
+/**
+ * UploadThing adapter (C2).
+ *
+ * Reached through `getStoragePort().forAdapter("uploadthing")`. Like the
+ * Vercel Blob adapter, this is a fixed single-vendor backend: UploadThing has
+ * no open protocol, so unlike S3 there is nothing here to point at a
+ * different endpoint via config.
+ *
+ * SCOPE — READ THIS BEFORE EXTENDING IT
+ * -------------------------------------
+ * In scope (C2): server-side ref minting, get, delete, deleteMany,
+ * getSignedUrl.
+ *
+ * Explicitly OUT of scope: the browser upload flow. api/uploadthing/core.ts
+ * and its route keep using UploadThing's own client SDK, because that upload
+ * happens in the user's browser and never passes through this server-side
+ * port at all. Routing it through here is not a smaller version of the same
+ * thing — it is a different mechanism wearing a similar name.
+ *
+ * server/storage/uploadthing.ts is left untouched: lib/storage.ts and the
+ * upload callback both still import it, and those call sites belong to Dev A.
+ * The delete logic below is therefore a copy, not a move.
+ *
+ * WHY get() NEEDED NEW CODE
+ * -------------------------
+ * There was no server-side read path for UploadThing anywhere in the codebase
+ * — the old module could mint refs and delete, nothing more. The temptation is
+ * to build "https://{appId}.ufs.sh/f/{key}" by hand, which is URL-guessing of
+ * exactly the kind that produced the original P0 bug, and it silently fails
+ * for private files.
+ *
+ * Instead get() asks the SDK for a presigned URL (generateSignedURL) and
+ * fetches that. It works for public and private files alike, and the SDK
+ * generates it locally without a round trip to UploadThing's API.
+ */
+
+import type {
+  DeleteResult,
+  GetSignedUrlOptions,
+  ObjectRef,
+  TargetedStoragePort,
+  UploadInput,
+  UploadResult,
+} from "@launchstack/core/storage";
+
+import { env } from "~/env";
+import {
+  parseUploadThingIdentityFromToken,
+  storageLocationIdForUploadThing,
+} from "~/lib/storage-location-id";
+
+const ADAPTER = "uploadthing" as const;
+
+function getUploadThingToken(): string {
+  const token = env.server.UPLOADTHING_TOKEN ?? process.env.UPLOADTHING_TOKEN;
+  if (!token) throw new Error("UPLOADTHING_TOKEN is not configured.");
+  return token;
+}
+
+/** The location a ref minted under the *current* token would carry. */
+function currentStorageLocationId(): string {
+  const identity = parseUploadThingIdentityFromToken(getUploadThingToken());
+  if (!identity) throw new Error("UPLOADTHING_TOKEN is unparseable.");
+  return storageLocationIdForUploadThing(identity.appId, identity.region);
+}
+
+async function getUTApi() {
+  const { UTApi } = await import("uploadthing/server");
+  return new UTApi({ token: getUploadThingToken() });
+}
+
+/**
+ * Same classifier the previous module used: an auth/config problem is
+ * permanent and needs a human (BLOCKED), anything else is worth retrying.
+ */
+function isAuthOrConfigError(text: string): boolean {
+  return /Unauthorized|Forbidden|AccessDenied|InvalidToken|Credentials|Credential|permission|not configured|unparseable|misconfigured/i.test(
+    text,
+  );
+}
+
+function assertOwnAdapter(ref: ObjectRef): void {
+  if (ref.adapter !== ADAPTER) {
+    throw new Error(
+      `[uploadthing-adapter] received a ref for adapter "${ref.adapter}". ` +
+        "Use getStoragePort().forAdapter(ref.adapter) to reach the right one.",
+    );
+  }
+}
+
+/**
+ * Decision 4: a ref names the app (and region) it was minted against. If the
+ * configured token now points somewhere else, the key would address a
+ * different file that happens to share an id. Refuse rather than guess.
+ */
+function locationMismatch(ref: ObjectRef): string | null {
+  let current: string;
+  try {
+    current = currentStorageLocationId();
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+  return ref.storageLocationId === current
+    ? null
+    : `Ref location ${ref.storageLocationId} does not match the configured UploadThing app (${current}).`;
+}
+
+export function createUploadThingAdapter(): TargetedStoragePort {
+  const deleteImpl = async (ref: ObjectRef): Promise<DeleteResult> => {
+    assertOwnAdapter(ref);
+
+    const mismatch = locationMismatch(ref);
+    if (mismatch) {
+      return {
+        ref,
+        outcome: "blocked",
+        errorCode: "storage_location_mismatch",
+        message: mismatch,
+      };
+    }
+
+    try {
+      const utapi = await getUTApi();
+      const response = await utapi.deleteFiles(ref.key);
+
+      if (!response.success) {
+        return {
+          ref,
+          outcome: "retryable",
+          errorCode: "uploadthing_delete_failed",
+          message: "UploadThing delete returned success=false.",
+        };
+      }
+
+      // Unlike Vercel Blob, UploadThing tells us how many files it actually
+      // removed — so "it was already gone" is observable here and reported
+      // honestly rather than collapsed into "deleted".
+      return response.deletedCount === 0
+        ? { ref, outcome: "not_found" }
+        : { ref, outcome: "deleted" };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      const code =
+        err instanceof Error && err.name ? err.name : "uploadthing_delete_failed";
+
+      return {
+        ref,
+        outcome: isAuthOrConfigError(`${code} ${message}`) ? "blocked" : "retryable",
+        errorCode: code,
+        message,
+      };
+    }
+  };
+
+  const signedUrlImpl = async (
+    ref: ObjectRef,
+    opts?: GetSignedUrlOptions,
+  ): Promise<string> => {
+    assertOwnAdapter(ref);
+
+    const mismatch = locationMismatch(ref);
+    if (mismatch) throw new Error(`[uploadthing-adapter] ${mismatch}`);
+
+    const utapi = await getUTApi();
+    const { ufsUrl } = await utapi.generateSignedURL(
+      ref.key,
+      opts?.expiresIn !== undefined ? { expiresIn: opts.expiresIn } : undefined,
+    );
+    return ufsUrl;
+  };
+
+  return {
+    adapter: ADAPTER,
+    provider: ADAPTER,
+
+    async put(_input: UploadInput): Promise<UploadResult> {
+      // Deliberately unsupported, and loudly so. UploadThing uploads happen in
+      // the browser through its client SDK; there is no server-side write path
+      // in this app, and C2 scopes the browser flow out.
+      //
+      // The dangerous alternative would be quietly forwarding to the default
+      // backend — a caller asking for UploadThing would get their bytes in S3
+      // or Postgres, compile clean, pass tests, and only surface when someone
+      // went looking for a file that was never there. That is precisely the
+      // silent-misrouting failure forAdapter() exists to prevent.
+      throw new Error(
+        "[uploadthing-adapter] put() is not supported: UploadThing uploads are " +
+          "client-side. Use the UploadThing SDK route (api/uploadthing), or target " +
+          "a different adapter explicitly if these bytes should live elsewhere.",
+      );
+    },
+
+    async get(ref: ObjectRef, init?: RequestInit): Promise<Response> {
+      assertOwnAdapter(ref);
+
+      const mismatch = locationMismatch(ref);
+      if (mismatch) throw new Error(`[uploadthing-adapter] ${mismatch}`);
+
+      // A presigned URL works for both public and private files, so there is
+      // no access mode to detect the way there is for Vercel Blob.
+      const url = await signedUrlImpl(ref);
+
+      // Returned as-is, fetch-style: callers check response.ok, exactly as
+      // they do today with fetchFile. A missing file surfaces as a non-ok
+      // response rather than a thrown error.
+      return fetch(url, init);
+    },
+
+    delete: deleteImpl,
+
+    async deleteMany(refs: readonly ObjectRef[]): Promise<DeleteResult[]> {
+      if (refs.length === 0) return [];
+      for (const ref of refs) assertOwnAdapter(ref);
+
+      const results: DeleteResult[] = [];
+      const deletable: ObjectRef[] = [];
+
+      for (const ref of refs) {
+        const mismatch = locationMismatch(ref);
+        if (mismatch) {
+          results.push({
+            ref,
+            outcome: "blocked",
+            errorCode: "storage_location_mismatch",
+            message: mismatch,
+          });
+        } else {
+          deletable.push(ref);
+        }
+      }
+
+      if (deletable.length === 0) return results;
+
+      try {
+        const utapi = await getUTApi();
+        const response = await utapi.deleteFiles(deletable.map((ref) => ref.key));
+
+        // The bulk call reports a count, not which keys it removed. A full
+        // count is unambiguous; anything less means some were already gone —
+        // but we cannot tell which, and guessing would attribute a not_found
+        // to the wrong ref. Fall back to per-key deletes so every outcome is
+        // one we actually observed (design doc A7: no all-or-nothing lie).
+        if (response.success && response.deletedCount === deletable.length) {
+          for (const ref of deletable) results.push({ ref, outcome: "deleted" });
+          return results;
+        }
+      } catch {
+        // Fall through to the per-ref path, which classifies properly.
+      }
+
+      for (const ref of deletable) {
+        results.push(await deleteImpl(ref));
+      }
+      return results;
+    },
+
+    getSignedUrl: signedUrlImpl,
+  };
+}

--- a/apps/web/src/server/storage/adapters/vercel-blob-adapter.ts
+++ b/apps/web/src/server/storage/adapters/vercel-blob-adapter.ts
@@ -1,0 +1,406 @@
+/**
+ * Vercel Blob adapter (C1).
+ *
+ * One of the concrete implementations behind TargetedStoragePort. Callers
+ * reach it through `getStoragePort().forAdapter("vercel-blob")` and never
+ * import this file — that indirection is the entire point of the sprint.
+ *
+ * WHAT MOVED, AND WHAT IS NEW
+ * ---------------------------
+ * put / delete / deleteMany are the existing logic from
+ * ~/server/storage/vercel-blob.ts, unchanged in behaviour. That file stays in
+ * place for now: several call sites still import it directly, and removing
+ * those imports is Dev A's A5/A6, not this task. Extract first, delete later.
+ *
+ * get(ref) is genuinely new, and it is the interesting part of C1.
+ *
+ * WHY get(ref) NEEDED NEW CODE
+ * ----------------------------
+ * An ObjectRef carries `key`, which for this adapter is the blob's *pathname*
+ * ("documents/uuid-name.pdf"). Reading a blob needs its full URL, and the old
+ * code decided whether to attach an Authorization header by string-matching
+ * ".private.blob." inside that URL. Neither of those is available from a ref.
+ *
+ * The wrong fix is to rebuild the URL from the store id. That is exactly the
+ * URL-guessing that caused the original P0 deletion bug, and it cannot work
+ * anyway: public and private stores use different hostnames, and a ref does
+ * not say which kind it came from.
+ *
+ * The right fix is to ask the provider. @vercel/blob exposes
+ * `get(pathname, { access, token })`, which resolves the pathname itself and —
+ * per its own docs — sets the authorization header automatically for private
+ * blobs. So the private/public handling that used to leak out through
+ * isPrivateBlobUrl now lives entirely inside this file, which is what lets
+ * A6 drop its direct vercel-blob.ts imports.
+ *
+ * ACCESS DETECTION
+ * ----------------
+ * A store is either public or private, and nothing in the ref or the env says
+ * which. The existing put() already solves this by trying "public", catching
+ * the "private store" error, and caching the answer in module state. get()
+ * uses the same cache and the same fallback rather than inventing a second
+ * mechanism. First read in a fresh process may cost one extra call; after that
+ * it is free.
+ */
+
+import { randomUUID } from "node:crypto";
+
+import type {
+  DeleteResult,
+  GetSignedUrlOptions,
+  ObjectRef,
+  TargetedStoragePort,
+  UploadInput,
+  UploadResult,
+} from "@launchstack/core/storage";
+
+const ADAPTER = "vercel-blob" as const;
+
+type BlobAccess = "public" | "private";
+
+/**
+ * Cached per process. Shared by put and get on purpose — they are asking the
+ * same question about the same store.
+ */
+let detectedAccess: BlobAccess | null = null;
+
+class MissingBlobTokenError extends Error {
+  constructor() {
+    super("BLOB_READ_WRITE_TOKEN is not configured. Set it in your Vercel project settings.");
+    this.name = "MissingBlobTokenError";
+  }
+}
+
+class UnparseableBlobTokenError extends Error {
+  constructor() {
+    super('BLOB_READ_WRITE_TOKEN is unparseable (expected token.split("_")[3]).');
+    this.name = "UnparseableBlobTokenError";
+  }
+}
+
+function getBlobToken(): string {
+  const token = process.env.BLOB_READ_WRITE_TOKEN;
+  if (!token) throw new MissingBlobTokenError();
+  return token;
+}
+
+/**
+ * The store id is parsed the same way the SDK does it. Frozen at upload time
+ * into storageLocationId, so a token rotation within one store keeps old refs
+ * valid while a token for a *different* store correctly invalidates them.
+ */
+function getBlobStoreId(token: string): string {
+  const storeId = token.split("_")[3];
+  if (!storeId) throw new UnparseableBlobTokenError();
+  return storeId;
+}
+
+function storageLocationIdForVercelBlob(storeId: string): string {
+  return `vercel-blob:${storeId}`;
+}
+
+function sanitizeFilename(filename: string): string {
+  return filename.replace(/\s+/g, "-").replace(/[^a-zA-Z0-9.\-_]/g, "");
+}
+
+function isAuthOrConfigError(text: string): boolean {
+  return /Unauthorized|Forbidden|AccessDenied|InvalidToken|token|Credentials|permission|not configured|unparseable|suspended|not found store/i.test(
+    text,
+  );
+}
+
+/**
+ * Copy provider response headers into a plain [key, value][].
+ *
+ * @vercel/blob returns undici's Headers, which is a *different declared type*
+ * from the global Headers this project's Response constructor expects, even
+ * though at runtime they are the same thing. TypeScript compares them
+ * structurally, finds their iterators disagree, and refuses — so passing one
+ * straight through fails to compile.
+ *
+ * The parameter is typed by the single method we actually use rather than by
+ * either Headers type, so this keeps working whichever one the caller hands
+ * us, and needs no cast.
+ */
+function toHeaderEntries(headers: {
+  forEach(cb: (value: string, key: string) => void): void;
+}): [string, string][] {
+  const entries: [string, string][] = [];
+  headers.forEach((value, key) => entries.push([key, value]));
+  return entries;
+}
+
+/** A ref from another adapter reaching this file is a programming error. */
+function assertOwnAdapter(ref: ObjectRef): void {
+  if (ref.adapter !== ADAPTER) {
+    throw new Error(
+      `[vercel-blob-adapter] received a ref for adapter "${ref.adapter}". ` +
+        "Use getStoragePort().forAdapter(ref.adapter) to reach the right one.",
+    );
+  }
+}
+
+/**
+ * Decision 4: a ref names the store it was minted against. If that no longer
+ * matches the configured store, the object we would touch is a *different*
+ * object that happens to share a pathname. Refuse rather than guess.
+ */
+function locationMatches(ref: ObjectRef, storeId: string): boolean {
+  return ref.storageLocationId === storageLocationIdForVercelBlob(storeId);
+}
+
+export function createVercelBlobAdapter(): TargetedStoragePort {
+  /**
+   * Hoisted rather than written as a method so deleteMany can call it without
+   * `this`. A port handle gets passed around and destructured; a method that
+   * silently depends on its receiver is a trap waiting for the first caller
+   * who writes `const { deleteMany } = port`.
+   */
+  const deleteImpl = async (ref: ObjectRef): Promise<DeleteResult> => {
+    assertOwnAdapter(ref);
+
+    let storeId: string;
+    try {
+      storeId = getBlobStoreId(getBlobToken());
+    } catch (err) {
+      return {
+        ref,
+        outcome: "blocked",
+        errorCode: "vercel_blob_token_unavailable",
+        message: err instanceof Error ? err.message : String(err),
+      };
+    }
+
+    if (!locationMatches(ref, storeId)) {
+      return {
+        ref,
+        outcome: "blocked",
+        errorCode: "storage_location_mismatch",
+        message:
+          `Ref location ${ref.storageLocationId} does not match the configured store ` +
+          `(${storageLocationIdForVercelBlob(storeId)}).`,
+      };
+    }
+
+    try {
+      const { del } = await import("@vercel/blob");
+      await del(ref.key, { token: getBlobToken() });
+
+      // NOTE: "not_found" is unreachable for this adapter. Vercel Blob's del
+      // is idempotent and returns void — deleting something that was already
+      // gone is indistinguishable from deleting something that was there.
+      // Both are terminal and both mean "the bytes are not in the store", so
+      // the lifecycle converges either way. Reporting a "not_found" we did
+      // not actually observe would be a lie.
+      return { ref, outcome: "deleted" };
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return {
+        ref,
+        outcome: isAuthOrConfigError(message) ? "blocked" : "retryable",
+        errorCode: "vercel_blob_delete_failed",
+        message,
+      };
+    }
+  };
+
+  return {
+    adapter: ADAPTER,
+    provider: ADAPTER,
+
+    async put(input: UploadInput): Promise<UploadResult> {
+      const { put } = await import("@vercel/blob");
+      const token = getBlobToken();
+      const storeId = getBlobStoreId(token);
+
+      const safeName = sanitizeFilename(input.filename);
+      const key = `documents/${randomUUID()}-${safeName.length > 0 ? safeName : "upload"}`;
+      const body = Buffer.from(
+        input.data instanceof ArrayBuffer ? new Uint8Array(input.data) : input.data,
+      );
+
+      const tryPut = (access: BlobAccess) =>
+        put(key, body, { access, contentType: input.contentType, token });
+
+      let blob;
+      if (detectedAccess) {
+        blob = await tryPut(detectedAccess);
+      } else {
+        try {
+          blob = await tryPut("public");
+          detectedAccess = "public";
+        } catch (err) {
+          // The only failure we translate: a private store rejects a public
+          // write with a specific message. Anything else is a real error.
+          if (err instanceof Error && err.message.includes("private store")) {
+            blob = await tryPut("private");
+            detectedAccess = "private";
+          } else {
+            throw err;
+          }
+        }
+      }
+
+      return {
+        url: blob.url,
+        pathname: blob.pathname,
+        ref: {
+          adapter: ADAPTER,
+          storageLocationId: storageLocationIdForVercelBlob(storeId),
+          // The provider's own name for the object. Never derived from a URL.
+          key: blob.pathname,
+        },
+        contentType: blob.contentType,
+        provider: ADAPTER,
+      };
+    },
+
+    async get(ref: ObjectRef, init?: RequestInit): Promise<Response> {
+      assertOwnAdapter(ref);
+
+      const { get, BlobNotFoundError } = await import("@vercel/blob");
+      const token = getBlobToken();
+      const storeId = getBlobStoreId(token);
+
+      if (!locationMatches(ref, storeId)) {
+        throw new Error(
+          `[vercel-blob-adapter] ref location ${ref.storageLocationId} does not match the ` +
+            `configured store (${storageLocationIdForVercelBlob(storeId)}). Refusing to read ` +
+            "a same-pathname object from a different store.",
+        );
+      }
+
+      // Only headers are forwarded. The SDK owns the request otherwise — it
+      // sets authorization for private blobs itself, which is the reason this
+      // goes through the SDK rather than a raw fetch.
+      const headers = init?.headers;
+
+      const attempt = async (access: BlobAccess) =>
+        get(ref.key, { access, token, ...(headers ? { headers } : {}) });
+
+      const order: BlobAccess[] = detectedAccess
+        ? [detectedAccess, detectedAccess === "public" ? "private" : "public"]
+        : ["public", "private"];
+
+      let lastError: unknown;
+      for (const access of order) {
+        try {
+          const result = await attempt(access);
+
+          // null means the store answered "no such blob" without throwing.
+          if (!result) {
+            return new Response(null, { status: 404, statusText: "Blob not found" });
+          }
+
+          detectedAccess = access;
+
+          // 304: the caller sent ifNoneMatch and the blob is unchanged.
+          if (result.statusCode !== 200) {
+            return new Response(null, {
+              status: result.statusCode,
+              headers: toHeaderEntries(result.headers),
+            });
+          }
+
+          return new Response(result.stream as unknown as BodyInit, {
+            status: 200,
+            headers: toHeaderEntries(result.headers),
+          });
+        } catch (err) {
+          if (err instanceof BlobNotFoundError) {
+            return new Response(null, { status: 404, statusText: "Blob not found" });
+          }
+          lastError = err;
+          // Fall through and try the other access mode once — this is the
+          // "wrong guess about the store" case, not a real failure.
+        }
+      }
+
+      throw lastError instanceof Error
+        ? lastError
+        : new Error(`[vercel-blob-adapter] could not read ${ref.key}`);
+    },
+
+    delete: deleteImpl,
+
+    async deleteMany(refs: readonly ObjectRef[]): Promise<DeleteResult[]> {
+      if (refs.length === 0) return [];
+      for (const ref of refs) assertOwnAdapter(ref);
+
+      // Split first: a stale-location ref must not ride along in a bulk call
+      // that would delete a same-pathname object out of the current store.
+      let storeId: string | null = null;
+      try {
+        storeId = getBlobStoreId(getBlobToken());
+      } catch {
+        storeId = null;
+      }
+
+      const deletable = storeId ? refs.filter((ref) => locationMatches(ref, storeId)) : [];
+      const deletableSet = new Set(deletable);
+      const refused = refs.filter((ref) => !deletableSet.has(ref));
+
+      const results: DeleteResult[] = refused.map((ref) => ({
+        ref,
+        outcome: "blocked" as const,
+        errorCode: storeId ? "storage_location_mismatch" : "vercel_blob_token_unavailable",
+        message: storeId
+          ? `Ref location ${ref.storageLocationId} does not match the configured store.`
+          : "BLOB_READ_WRITE_TOKEN is not configured or unparseable.",
+      }));
+
+      if (deletable.length === 0) return results;
+
+      try {
+        const { del } = await import("@vercel/blob");
+        await del(
+          deletable.map((ref) => ref.key),
+          { token: getBlobToken() },
+        );
+        for (const ref of deletable) results.push({ ref, outcome: "deleted" });
+      } catch {
+        // The bulk call gives no per-item detail, so a partial failure would
+        // otherwise be reported as total failure — the "all-or-nothing lie"
+        // the design doc's A7 warns about. Retry individually so each ref
+        // gets the outcome that is actually true for it.
+        for (const ref of deletable) {
+          results.push(await deleteImpl(ref));
+        }
+      }
+
+      return results;
+    },
+
+    async getSignedUrl(ref: ObjectRef, _opts?: GetSignedUrlOptions): Promise<string> {
+      assertOwnAdapter(ref);
+
+      const { head } = await import("@vercel/blob");
+      const token = getBlobToken();
+      const storeId = getBlobStoreId(token);
+
+      if (!locationMatches(ref, storeId)) {
+        throw new Error(
+          `[vercel-blob-adapter] ref location ${ref.storageLocationId} does not match the ` +
+            "configured store.",
+        );
+      }
+
+      // Vercel Blob has no signing API. A public blob's URL is already
+      // shareable and needs no signature, so returning it is honest. A private
+      // blob's URL is NOT shareable — it only works with an Authorization
+      // header — so handing one back as a "signed URL" would be a URL that
+      // silently 401s for whoever receives it. Fail loudly instead and let the
+      // caller stream the bytes through get(ref).
+      const meta = await head(ref.key, { token });
+
+      if (detectedAccess === "private") {
+        throw new Error(
+          "[vercel-blob-adapter] private Vercel Blob stores do not support signed URLs. " +
+            "Use get(ref) to stream the bytes through the app instead.",
+        );
+      }
+
+      return meta.url;
+    },
+  };
+}

--- a/apps/web/src/server/storage/create-storage-port.ts
+++ b/apps/web/src/server/storage/create-storage-port.ts
@@ -1,0 +1,55 @@
+import type {
+  DeleteResult,
+  GetSignedUrlOptions,
+  ObjectRef,
+  StorageAdapter,
+  TargetedStoragePort,
+  UploadInput,
+  UploadResult,
+} from "@launchstack/core/storage";
+
+function createUnwiredAdapterTarget(
+  adapter: StorageAdapter,
+  provider: string,
+): TargetedStoragePort {
+  const error = (method: string): Error =>
+    new Error(
+      `[storage] Adapter target "${adapter}" is not wired for ${method} yet. ` +
+        "A2 only locks the contract surface; concrete adapter extraction lands later.",
+    );
+
+  return {
+    adapter,
+    provider,
+    async put(_input: UploadInput): Promise<UploadResult> {
+      throw error("put()");
+    },
+    async get(_ref: ObjectRef, _init?: RequestInit): Promise<Response> {
+      throw error("get()");
+    },
+    async delete(_ref: ObjectRef): Promise<DeleteResult> {
+      throw error("delete()");
+    },
+    async deleteMany(_refs: readonly ObjectRef[]): Promise<DeleteResult[]> {
+      throw error("deleteMany()");
+    },
+    async getSignedUrl(_ref: ObjectRef, _opts?: GetSignedUrlOptions): Promise<string> {
+      throw error("getSignedUrl()");
+    },
+  };
+}
+
+/**
+ * A2 factory skeleton: this locks the targeted-adapter surface before real
+ * adapter extraction lands. The default app port can keep using existing
+ * helpers for now, while future migrations call through concrete targets.
+ */
+export function createStoragePortTargetFactory(provider: string): {
+  forAdapter(adapter: StorageAdapter): TargetedStoragePort;
+} {
+  return {
+    forAdapter(adapter: StorageAdapter): TargetedStoragePort {
+      return createUnwiredAdapterTarget(adapter, provider);
+    },
+  };
+}

--- a/apps/web/src/server/storage/create-storage-port.ts
+++ b/apps/web/src/server/storage/create-storage-port.ts
@@ -8,6 +8,10 @@ import type {
   UploadResult,
 } from "@launchstack/core/storage";
 
+import { createS3TargetedPort } from "./adapters/s3-targeted-port";
+import { createUploadThingAdapter } from "./adapters/uploadthing-adapter";
+import { createVercelBlobAdapter } from "./adapters/vercel-blob-adapter";
+
 function createUnwiredAdapterTarget(
   adapter: StorageAdapter,
   provider: string,
@@ -49,7 +53,17 @@ export function createStoragePortTargetFactory(provider: string): {
 } {
   return {
     forAdapter(adapter: StorageAdapter): TargetedStoragePort {
-      return createUnwiredAdapterTarget(adapter, provider);
+      switch (adapter) {
+        case "s3":
+          return createS3TargetedPort();
+        case "vercel-blob":
+          return createVercelBlobAdapter();
+        case "uploadthing":
+          return createUploadThingAdapter();
+        case "database":
+        default:
+          return createUnwiredAdapterTarget(adapter, provider);
+      }
     },
   };
 }

--- a/apps/web/src/server/storage/create-storage-port.ts
+++ b/apps/web/src/server/storage/create-storage-port.ts
@@ -8,6 +8,7 @@ import type {
   UploadResult,
 } from "@launchstack/core/storage";
 
+import { createDatabaseAdapter } from "./adapters/database-adapter";
 import { createS3TargetedPort } from "./adapters/s3-targeted-port";
 import { createUploadThingAdapter } from "./adapters/uploadthing-adapter";
 import { createVercelBlobAdapter } from "./adapters/vercel-blob-adapter";
@@ -61,7 +62,11 @@ export function createStoragePortTargetFactory(provider: string): {
         case "uploadthing":
           return createUploadThingAdapter();
         case "database":
+          return createDatabaseAdapter();
         default:
+          // Unreachable while StorageAdapter has exactly these four members.
+          // Kept so that adding a fifth adapter fails loudly at runtime
+          // instead of silently resolving to whichever backend is primary.
           return createUnwiredAdapterTarget(adapter, provider);
       }
     },

--- a/apps/web/src/server/storage/create-storage-port.ts
+++ b/apps/web/src/server/storage/create-storage-port.ts
@@ -45,9 +45,9 @@ function createUnwiredAdapterTarget(
 }
 
 /**
- * A2 factory skeleton: this locks the targeted-adapter surface before real
- * adapter extraction lands. The default app port can keep using existing
- * helpers for now, while future migrations call through concrete targets.
+ * Target factory for canonical storage operations. The app port and legacy
+ * compatibility shims resolve each adapter through this surface so backend
+ * selection cannot silently route a request to the primary provider.
  */
 export function createStoragePortTargetFactory(provider: string): {
   forAdapter(adapter: StorageAdapter): TargetedStoragePort;

--- a/apps/web/src/server/storage/inventory.ts
+++ b/apps/web/src/server/storage/inventory.ts
@@ -1,6 +1,5 @@
 import "server-only";
 
-import { ListObjectsV2Command } from "@aws-sdk/client-s3";
 import type { ObjectRef } from "@launchstack/core/storage";
 import { and, asc, eq, gt, like } from "drizzle-orm";
 
@@ -8,7 +7,7 @@ import { fileUploads } from "@launchstack/core/db/schema";
 import { env } from "~/env";
 import { resolveStorageLocationId, parseVercelBlobStoreIdFromToken } from "~/lib/storage-location-id";
 import { db } from "~/server/db";
-import { getS3BucketName, getS3Client } from "~/server/storage/s3-client";
+import { getS3StorageAdapter } from "~/server/storage/adapters/s3-adapter";
 
 export interface PrivilegedListObjectsInput {
   adapter: ObjectRef["adapter"];
@@ -83,31 +82,28 @@ async function listS3Objects(input: Required<Pick<PrivilegedListObjectsInput, "s
   const limit = clampLimit(input.limit);
 
   try {
-    const response = await getS3Client().send(
-      new ListObjectsV2Command({
-        Bucket: getS3BucketName(),
-        Prefix: input.prefix,
-        ContinuationToken: input.cursor,
-        MaxKeys: limit,
-      }),
-    );
+    const response = await getS3StorageAdapter().listObjectsPrivileged({
+      prefix: input.prefix,
+      cursor: input.cursor,
+      limit,
+    });
 
     const objects: PrivilegedInventoryObject[] = [];
-    for (const entry of response.Contents ?? []) {
-      if (!entry.Key) continue;
+    for (const entry of response.objects) {
+      if (!entry.key) continue;
       objects.push({
-        key: entry.Key,
-        ref: makeRef("s3", input.storageLocationId, entry.Key),
-        size: typeof entry.Size === "number" ? entry.Size : undefined,
-        lastModified: entry.LastModified?.toISOString(),
-        etag: entry.ETag,
+        key: entry.key,
+        ref: makeRef("s3", input.storageLocationId, entry.key),
+        size: entry.size,
+        lastModified: entry.lastModified,
+        etag: entry.etag,
       });
     }
 
     return {
       ok: true,
       objects,
-      nextCursor: response.IsTruncated ? response.NextContinuationToken : undefined,
+      nextCursor: response.nextCursor,
     };
   } catch (err) {
     return {

--- a/apps/web/src/server/storage/inventory.ts
+++ b/apps/web/src/server/storage/inventory.ts
@@ -299,6 +299,141 @@ async function listDatabaseObjects(input: Required<Pick<PrivilegedListObjectsInp
 }
 
 /**
+ * UploadThing inventory listing (C5).
+ *
+ * This branch previously returned a hardcoded "unavailable". That was true
+ * when it was written and is not true now: UTApi exposes listFiles, so the
+ * orphan audit can see UploadThing objects like any other adapter. Reporting
+ * "unavailable" for a provider that can in fact list is worse than reporting
+ * nothing — C3's audit is told to treat unavailable as *unknown*, so a whole
+ * adapter's objects would sit permanently unclassified for no reason.
+ *
+ * Pagination is offset-based rather than cursor-based, because that is what
+ * the provider offers. The cursor is the offset, kept opaque to callers.
+ */
+async function listUploadThingObjects(
+  input: Required<Pick<PrivilegedListObjectsInput, "storageLocationId">> &
+    Omit<PrivilegedListObjectsInput, "storageLocationId">,
+): Promise<PrivilegedListObjectsResult> {
+  const token = env.server.UPLOADTHING_TOKEN ?? process.env.UPLOADTHING_TOKEN;
+  if (!token) {
+    return {
+      ok: false,
+      error: {
+        kind: "unavailable",
+        code: "uploadthing_token_missing",
+        message: "UPLOADTHING_TOKEN is not configured.",
+      },
+    };
+  }
+
+  // UploadThing's list API has no prefix filter. Ignoring the prefix would
+  // return objects the caller did not ask for and let an audit believe it had
+  // scanned a narrower set than it actually did, so this refuses instead of
+  // quietly doing something different from what was requested.
+  if (input.prefix && input.prefix.length > 0) {
+    return {
+      ok: false,
+      error: {
+        kind: "invalid_request",
+        code: "uploadthing_prefix_unsupported",
+        message:
+          "UploadThing listing does not support prefix filtering. Omit prefix, or filter the returned keys.",
+      },
+    };
+  }
+
+  // Order matters. The location guard runs *after* the token check, because
+  // resolveStorageLocationId throws when the token is missing or unparseable —
+  // and a deployment that simply does not use UploadThing should read as
+  // "unavailable" (nothing to see), not "blocked" (a config error a human must
+  // fix). Blocked is reserved for a token that exists but points somewhere
+  // other than the refs being asked about.
+  let expectedLocationId: string;
+  try {
+    expectedLocationId = resolveStorageLocationId("uploadthing");
+  } catch (err) {
+    return {
+      ok: false,
+      error: {
+        kind: "unavailable",
+        code: "uploadthing_token_unparseable",
+        message: err instanceof Error ? err.message : String(err),
+      },
+    };
+  }
+
+  if (input.storageLocationId !== expectedLocationId) {
+    return locationMismatch(input.storageLocationId, expectedLocationId);
+  }
+
+  const limit = clampLimit(input.limit);
+  const cursor = input.cursor?.trim();
+  const offset = cursor && cursor.length > 0 ? Number.parseInt(cursor, 10) : 0;
+
+  if (!Number.isSafeInteger(offset) || offset < 0) {
+    return {
+      ok: false,
+      error: {
+        kind: "invalid_request",
+        code: "invalid_cursor",
+        message: "Cursor must be a non-negative integer offset for UploadThing inventory scans.",
+      },
+    };
+  }
+
+  try {
+    const { UTApi } = await import("uploadthing/server");
+    const utapi = new UTApi({ token });
+    const listed = await utapi.listFiles({ limit, offset });
+
+    const objects: PrivilegedInventoryObject[] = [];
+    for (const file of listed.files) {
+      if (!file.key) continue;
+      objects.push({
+        key: file.key,
+        ref: makeRef("uploadthing", input.storageLocationId, file.key),
+        size: typeof file.size === "number" ? file.size : undefined,
+        // uploadedAt is epoch milliseconds on this API, not a Date.
+        lastModified:
+          typeof file.uploadedAt === "number"
+            ? new Date(file.uploadedAt).toISOString()
+            : undefined,
+      });
+    }
+
+    return {
+      ok: true,
+      objects,
+      // Advance by what the provider returned, not by what survived the
+      // keyless filter above — otherwise a single keyless entry rewinds the
+      // offset by one and the next page repeats an object forever.
+      nextCursor: listed.hasMore ? String(offset + listed.files.length) : undefined,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+
+    // An auth/config failure is permanent and needs a human; everything else
+    // is worth retrying. Same split the adapters use.
+    if (
+      /Unauthorized|Forbidden|AccessDenied|InvalidToken|Credentials|permission|not configured|unparseable/i.test(
+        message,
+      )
+    ) {
+      return {
+        ok: false,
+        error: { kind: "blocked", code: "uploadthing_auth_or_config_error", message },
+      };
+    }
+
+    return {
+      ok: false,
+      error: { kind: "retryable", code: "uploadthing_list_failed", message },
+    };
+  }
+}
+
+/**
  * Privileged object inventory listing for storage-audit tooling.
  *
  * Server-only and intentionally not part of StoragePort.
@@ -306,15 +441,11 @@ async function listDatabaseObjects(input: Required<Pick<PrivilegedListObjectsInp
 export async function listObjectsPrivileged(
   input: PrivilegedListObjectsInput,
 ): Promise<PrivilegedListObjectsResult> {
+  // Handled before the shared location resolution below, which throws for an
+  // unconfigured UploadThing token. The branch does its own guard in the right
+  // order — see listUploadThingObjects.
   if (input.adapter === "uploadthing") {
-    return {
-      ok: false,
-      error: {
-        kind: "unavailable",
-        code: "uploadthing_list_unavailable",
-        message: "UploadThing object listing is unavailable in this runtime.",
-      },
-    };
+    return listUploadThingObjects({ ...input, storageLocationId: input.storageLocationId });
   }
 
   let expectedLocationId: string;

--- a/apps/web/src/server/storage/port.ts
+++ b/apps/web/src/server/storage/port.ts
@@ -12,6 +12,7 @@
 import type {
   DeleteResult,
   ObjectRef,
+  StorageAdapter,
   StoragePort,
   UploadInput,
   UploadResult,
@@ -32,6 +33,10 @@ export function createAppStoragePort(): StoragePort {
   const targets = createStoragePortTargetFactory(provider);
 
   const putImpl = async (input: UploadInput): Promise<UploadResult> => {
+    if (provider === "s3") {
+      return targets.forAdapter("s3").put(input);
+    }
+
     // The app's uploadFile requires a userId; default to "system" for
     // engine-initiated writes that do not carry an end-user context.
     const result = await uploadFile({
@@ -50,27 +55,88 @@ export function createAppStoragePort(): StoragePort {
   };
 
   const getImpl = (input: ObjectRef | string, init?: RequestInit): Promise<Response> => {
-    const urlOrKey = typeof input === "string" ? input : input.key;
-    return fetchFile(urlOrKey, init);
+    if (typeof input === "string") {
+      return fetchFile(input, init);
+    }
+
+    if (input.adapter === "database") {
+      return fetchFile(`/api/files/${input.key}`, init);
+    }
+
+    return targets.forAdapter(input.adapter).get(input, init);
+  };
+
+  const deleteRefImpl = (ref: ObjectRef): Promise<DeleteResult> => {
+    if (ref.adapter === "database") {
+      return deleteFileByRef(ref);
+    }
+
+    return targets.forAdapter(ref.adapter).delete(ref);
+  };
+
+  const deleteManyImpl = async (refs: readonly ObjectRef[]): Promise<DeleteResult[]> => {
+    if (refs.length === 0) return [];
+
+    const groups = new Map<
+      string,
+      { adapter: StorageAdapter; refs: ObjectRef[]; indexes: number[] }
+    >();
+
+    refs.forEach((ref, index) => {
+      const groupKey = `${ref.adapter}::${ref.storageLocationId}`;
+      const group = groups.get(groupKey);
+      if (group) {
+        group.refs.push(ref);
+        group.indexes.push(index);
+      } else {
+        groups.set(groupKey, {
+          adapter: ref.adapter,
+          refs: [ref],
+          indexes: [index],
+        });
+      }
+    });
+
+    const results: Array<DeleteResult | undefined> = new Array(refs.length);
+    for (const group of groups.values()) {
+      const groupResults =
+        group.adapter === "database"
+          ? await deleteManyByRef(group.refs)
+          : await targets.forAdapter(group.adapter).deleteMany(group.refs);
+
+      groupResults.forEach((result, index) => {
+        const originalIndex = group.indexes[index];
+        if (originalIndex !== undefined) {
+          results[originalIndex] = result;
+        }
+      });
+    }
+
+    return results as DeleteResult[];
   };
 
   async function deleteImpl(ref: ObjectRef): Promise<DeleteResult>;
   async function deleteImpl(urlOrKey: string): Promise<void>;
   async function deleteImpl(input: ObjectRef | string): Promise<DeleteResult | void> {
-    if (typeof input !== "string") {
-      return deleteFileByRef(input);
+    if (typeof input === "string") {
+      if (!input) return;
+      const promoted = promoteLegacyUrlToRef({ value: input });
+      if (!promoted.ok) {
+        throw new Error(`Ref promotion failed (${promoted.reason})`);
+      }
+
+      const result = await deleteRefImpl(promoted.ref);
+      if (
+        result.outcome === "retryable" ||
+        result.outcome === "blocked" ||
+        result.outcome === "rejected"
+      ) {
+        throw new Error(result.message ?? `Delete failed with outcome=${result.outcome}`);
+      }
+      return;
     }
 
-    if (!input) return;
-    const promoted = promoteLegacyUrlToRef({ value: input });
-    if (!promoted.ok) {
-      throw new Error(`Ref promotion failed (${promoted.reason})`);
-    }
-
-    const result = await deleteFileByRef(promoted.ref);
-    if (result.outcome === "retryable" || result.outcome === "blocked" || result.outcome === "rejected") {
-      throw new Error(result.message ?? `Delete failed with outcome=${result.outcome}`);
-    }
+    return deleteRefImpl(input);
   }
 
   return {
@@ -110,12 +176,12 @@ export function createAppStoragePort(): StoragePort {
 
     /** @deprecated Use delete(ObjectRef). */
     deleteRef(ref: ObjectRef): Promise<DeleteResult> {
-      return deleteFileByRef(ref);
+      return deleteRefImpl(ref);
     },
 
     /** @deprecated Use deleteMany(). */
     deleteMany(refs: readonly ObjectRef[]): Promise<DeleteResult[]> {
-      return deleteManyByRef(refs);
+      return deleteManyImpl(refs);
     },
   };
 }

--- a/apps/web/src/server/storage/port.ts
+++ b/apps/web/src/server/storage/port.ts
@@ -24,57 +24,98 @@ import {
   fetchFile,
   resolveStorageBackend,
 } from "~/lib/storage";
+import { createStoragePortTargetFactory } from "./create-storage-port";
 import { promoteLegacyUrlToRef } from "~/server/storage/legacy-promote";
 
 export function createAppStoragePort(): StoragePort {
   const provider = resolveStorageBackend();
+  const targets = createStoragePortTargetFactory(provider);
+
+  const putImpl = async (input: UploadInput): Promise<UploadResult> => {
+    // The app's uploadFile requires a userId; default to "system" for
+    // engine-initiated writes that do not carry an end-user context.
+    const result = await uploadFile({
+      filename: input.filename,
+      data: input.data,
+      contentType: input.contentType,
+      userId: input.userId ?? "system",
+    });
+    return {
+      url: result.url,
+      pathname: result.pathname,
+      ref: result.ref,
+      contentType: result.contentType,
+      provider: result.provider,
+    };
+  };
+
+  const getImpl = (input: ObjectRef | string, init?: RequestInit): Promise<Response> => {
+    const urlOrKey = typeof input === "string" ? input : input.key;
+    return fetchFile(urlOrKey, init);
+  };
+
+  async function deleteImpl(ref: ObjectRef): Promise<DeleteResult>;
+  async function deleteImpl(urlOrKey: string): Promise<void>;
+  async function deleteImpl(input: ObjectRef | string): Promise<DeleteResult | void> {
+    if (typeof input !== "string") {
+      return deleteFileByRef(input);
+    }
+
+    if (!input) return;
+    const promoted = promoteLegacyUrlToRef({ value: input });
+    if (!promoted.ok) {
+      throw new Error(`Ref promotion failed (${promoted.reason})`);
+    }
+
+    const result = await deleteFileByRef(promoted.ref);
+    if (result.outcome === "retryable" || result.outcome === "blocked" || result.outcome === "rejected") {
+      throw new Error(result.message ?? `Delete failed with outcome=${result.outcome}`);
+    }
+  }
 
   return {
     provider,
 
-    async upload(input: UploadInput): Promise<UploadResult> {
-      // The app's uploadFile requires a userId; default to "system" for
-      // engine-initiated writes that do not carry an end-user context.
-      const result = await uploadFile({
-        filename: input.filename,
-        data: input.data,
-        contentType: input.contentType,
-        userId: input.userId ?? "system",
-      });
-      return {
-        url: result.url,
-        pathname: result.pathname,
-        ref: result.ref,
-        contentType: result.contentType,
-        provider: result.provider,
-      };
+    put(input: UploadInput): Promise<UploadResult> {
+      return putImpl(input);
     },
 
+    get(input: ObjectRef | string, init?: RequestInit): Promise<Response> {
+      return getImpl(input, init);
+    },
+
+    /**
+     * Canonical delete accepts ObjectRef; the legacy string overload remains
+     * available for migration and promotes through legacy-promote.
+     */
+    delete: deleteImpl,
+
+    getSignedUrl(ref, opts) {
+      return targets.forAdapter(ref.adapter).getSignedUrl(ref, opts);
+    },
+
+    forAdapter(adapter) {
+      return targets.forAdapter(adapter);
+    },
+
+    /** @deprecated Use put(). */
+    async upload(input: UploadInput): Promise<UploadResult> {
+      return putImpl(input);
+    },
+
+    /** @deprecated Use get(). */
+    download(urlOrKey, init) {
+      return getImpl(urlOrKey, init);
+    },
+
+    /** @deprecated Use delete(ObjectRef). */
     deleteRef(ref: ObjectRef): Promise<DeleteResult> {
       return deleteFileByRef(ref);
     },
 
+    /** @deprecated Use deleteMany(). */
     deleteMany(refs: readonly ObjectRef[]): Promise<DeleteResult[]> {
       return deleteManyByRef(refs);
-    },
-
-    download(urlOrKey, init) {
-      return fetchFile(urlOrKey, init);
-    },
-
-    /** @deprecated Use deleteRef/deleteMany. Kept as URL-based migration shim. */
-    async delete(urlOrKey) {
-      if (!urlOrKey) return;
-
-      const promoted = promoteLegacyUrlToRef({ value: urlOrKey });
-      if (!promoted.ok) {
-        throw new Error(`Ref promotion failed (${promoted.reason})`);
-      }
-
-      const result = await deleteFileByRef(promoted.ref);
-      if (result.outcome === "retryable" || result.outcome === "blocked" || result.outcome === "rejected") {
-        throw new Error(result.message ?? `Delete failed with outcome=${result.outcome}`);
-      }
     },
   };
 }

--- a/apps/web/src/server/storage/port.ts
+++ b/apps/web/src/server/storage/port.ts
@@ -1,12 +1,11 @@
 /**
- * Concrete StoragePort implementation that wraps the app's existing
- * storage helpers (~/lib/storage). This is what apps/web hands to
+ * Concrete StoragePort implementation that routes canonical operations through
+ * the targeted adapter factory. This is what apps/web hands to
  * createEngine so core can read and write objects without knowing
  * about S3, Vercel Blob, or the database-base64 fallback.
  *
- * The underlying storage helpers already auto-detect the active backend
- * from env; the port just adapts their shape to the StoragePort
- * interface exported by @launchstack/core.
+ * The legacy string overload still delegates to fetchFile in ~/lib/storage;
+ * canonical ObjectRef operations never bypass their targeted adapter.
  */
 
 import type {
@@ -18,13 +17,7 @@ import type {
   UploadResult,
 } from "@launchstack/core/storage";
 
-import {
-  deleteFileByRef,
-  deleteManyByRef,
-  uploadFile,
-  fetchFile,
-  resolveStorageBackend,
-} from "~/lib/storage";
+import { fetchFile, resolveStorageBackend } from "~/lib/storage";
 import { createStoragePortTargetFactory } from "./create-storage-port";
 import { promoteLegacyUrlToRef } from "~/server/storage/legacy-promote";
 
@@ -33,25 +26,7 @@ export function createAppStoragePort(): StoragePort {
   const targets = createStoragePortTargetFactory(provider);
 
   const putImpl = async (input: UploadInput): Promise<UploadResult> => {
-    if (provider === "s3") {
-      return targets.forAdapter("s3").put(input);
-    }
-
-    // The app's uploadFile requires a userId; default to "system" for
-    // engine-initiated writes that do not carry an end-user context.
-    const result = await uploadFile({
-      filename: input.filename,
-      data: input.data,
-      contentType: input.contentType,
-      userId: input.userId ?? "system",
-    });
-    return {
-      url: result.url,
-      pathname: result.pathname,
-      ref: result.ref,
-      contentType: result.contentType,
-      provider: result.provider,
-    };
+    return targets.forAdapter(provider).put(input);
   };
 
   const getImpl = (input: ObjectRef | string, init?: RequestInit): Promise<Response> => {
@@ -59,18 +34,10 @@ export function createAppStoragePort(): StoragePort {
       return fetchFile(input, init);
     }
 
-    if (input.adapter === "database") {
-      return fetchFile(`/api/files/${input.key}`, init);
-    }
-
     return targets.forAdapter(input.adapter).get(input, init);
   };
 
   const deleteRefImpl = (ref: ObjectRef): Promise<DeleteResult> => {
-    if (ref.adapter === "database") {
-      return deleteFileByRef(ref);
-    }
-
     return targets.forAdapter(ref.adapter).delete(ref);
   };
 
@@ -99,10 +66,7 @@ export function createAppStoragePort(): StoragePort {
 
     const results: Array<DeleteResult | undefined> = new Array(refs.length);
     for (const group of groups.values()) {
-      const groupResults =
-        group.adapter === "database"
-          ? await deleteManyByRef(group.refs)
-          : await targets.forAdapter(group.adapter).deleteMany(group.refs);
+      const groupResults = await targets.forAdapter(group.adapter).deleteMany(group.refs);
 
       groupResults.forEach((result, index) => {
         const originalIndex = group.indexes[index];

--- a/apps/web/src/server/storage/write-port.ts
+++ b/apps/web/src/server/storage/write-port.ts
@@ -1,0 +1,46 @@
+import type { ObjectRef } from "@launchstack/core/storage";
+
+import { getS3StorageAdapter } from "~/server/storage/adapters/s3-adapter";
+
+export interface StorageWritePort {
+  put(input: {
+    key: string;
+    body: Buffer;
+    contentType?: string;
+  }): Promise<{
+    ref: ObjectRef;
+    url: string;
+    pathname: string;
+    provider: "s3";
+  }>;
+  mintRef(key: string): ObjectRef;
+  getSignedUrl(input: {
+    ref: ObjectRef;
+    operation: "put" | "get";
+    contentType?: string;
+    expiresIn?: number;
+  }): Promise<string>;
+  getBucketName(): string;
+}
+
+export function createStorageWritePort(): StorageWritePort {
+  const s3 = getS3StorageAdapter();
+
+  return {
+    put(input) {
+      return s3.put(input);
+    },
+
+    mintRef(key: string): ObjectRef {
+      return s3.mintRef(key);
+    },
+
+    getSignedUrl(input) {
+      return s3.getSignedUrl(input);
+    },
+
+    getBucketName(): string {
+      return s3.getBucketName();
+    },
+  };
+}

--- a/docs/storage-ref-contract.md
+++ b/docs/storage-ref-contract.md
@@ -26,6 +26,26 @@ This document captures the frozen storage contract used by server-side upload/de
 - Database: `database:pdr_file_uploads_v1`
 - UploadThing: `uploadthing:{appId}[@region]`
 
+## S3-compatible env var reference (B5)
+
+S3 adapter configuration accepts the `STORAGE_S3_*` names below (legacy names remain supported; precedence rules are defined in A1):
+
+- `STORAGE_S3_ENDPOINT` — provider/API endpoint used for SDK calls.
+- `STORAGE_S3_PUBLIC_ENDPOINT` — optional public/base URL for minted object URLs.
+- `STORAGE_S3_REGION` — region value for request signing.
+- `STORAGE_S3_ACCESS_KEY` — access key id credential.
+- `STORAGE_S3_SECRET_KEY` — secret access key credential.
+- `STORAGE_S3_BUCKET_NAME` — bucket/container name.
+- `STORAGE_S3_FORCE_PATH_STYLE` — optional boolean, defaults to path-style (`true`).
+- `STORAGE_S3_ENSURE_BUCKET_EXISTS` — optional boolean, default `false` (opt-in bucket bootstrap).
+
+Legacy aliases still recognized by runtime and env parsing:
+
+- `NEXT_PUBLIC_S3_ENDPOINT`, `S3_PUBLIC_ENDPOINT`
+- `S3_REGION`, `S3_ACCESS_KEY`, `S3_SECRET_KEY`, `S3_BUCKET_NAME`
+
+Current limitation note: URL minting is path-style today. With `STORAGE_S3_FORCE_PATH_STYLE=false`, signed requests can be virtual-hosted-style, but minted object URLs remain path-style until `getObjectUrl` gains virtual-host formatting.
+
 ## Delete outcomes
 
 Deletion uses per-ref outcome reporting (`DeleteResult.outcome`):

--- a/docs/storage-ref-contract.md
+++ b/docs/storage-ref-contract.md
@@ -46,6 +46,27 @@ Legacy aliases still recognized by runtime and env parsing:
 
 Current limitation note: URL minting is path-style today. With `STORAGE_S3_FORCE_PATH_STYLE=false`, signed requests can be virtual-hosted-style, but minted object URLs remain path-style until `getObjectUrl` gains virtual-host formatting.
 
+## Non-S3 adapter env
+
+The non-S3 adapters use the following environment variables and location
+identities:
+
+- **Vercel Blob:** `BLOB_READ_WRITE_TOKEN`. The store id is
+  `token.split("_")[3]`, so the location identity is
+  `vercel-blob:{storeId}`.
+- **UploadThing:** `UPLOADTHING_TOKEN`. Its app id and optional region form the
+  location identity `uploadthing:{appId}[@region]`. The browser upload SDK is
+  outside the storage port.
+- **Database:** select it with `NEXT_PUBLIC_STORAGE_PROVIDER=database`, or use
+  the automatic database fallback when no S3 configuration is present. Its
+  location identity is `database:pdr_file_uploads_v1`.
+  `forAdapter("database")` remains unwired until C3; reads use `get(ref)`,
+  which resolves through `/api/files/{id}`.
+
+Fixed-intent writes such as GitHub repository uploads, video transcripts, and
+`processDocument` artifacts must use
+`forAdapter("vercel-blob")`, not the default `put()`.
+
 ## Delete outcomes
 
 Deletion uses per-ref outcome reporting (`DeleteResult.outcome`):

--- a/docs/storage-ref-contract.md
+++ b/docs/storage-ref-contract.md
@@ -60,8 +60,9 @@ identities:
 - **Database:** select it with `NEXT_PUBLIC_STORAGE_PROVIDER=database`, or use
   the automatic database fallback when no S3 configuration is present. Its
   location identity is `database:pdr_file_uploads_v1`.
-  `forAdapter("database")` remains unwired until C3; reads use `get(ref)`,
-  which resolves through `/api/files/{id}`.
+  `forAdapter("database")` is wired through `createDatabaseAdapter`; reads use
+  `get(ref)`, which resolves through `/api/files/{id}` with internal service
+  authentication.
 
 Fixed-intent writes such as GitHub repository uploads, video transcripts, and
 `processDocument` artifacts must use
@@ -112,19 +113,18 @@ Canonical write/read/delete flows should move toward `ObjectRef`-based calls.
 Deprecated aliases remain so existing callers can migrate incrementally without
 changing lifecycle behavior.
 
-## Database adapter read path during C3 transition
+## Database adapter read path
 
 For database-backed refs, `ObjectRef.key` is the numeric `fileUploads.id`
-encoded as a string. Until the database adapter is extracted, `get(ref)` on the
-app port resolves that key to `/api/files/{id}` and calls `fetchFile`, which
-adds internal service headers for a self-origin request. The `/api/files/[id]`
-route remains the single place for tenant authorization and serve-gating before
-reading the Postgres row.
+encoded as a string. The database adapter resolves that key to
+`${APP_PUBLIC_URL}/api/files/{id}` and sends an internal service request. The
+`/api/files/[id]` route remains the single place for tenant authorization and
+serve-gating before reading the Postgres row.
 
-`forAdapter("database")` remains unwired until C3. Callers reading a database
-ref should use `getStoragePort().get(ref)` during this transition rather than
-targeting the unwired database handle or duplicating the route's authorization
-logic in another adapter.
+`forAdapter("database")` is wired through the adapter factory. Callers reading
+a database ref should use `getStoragePort().get(ref)` or
+`getStoragePort().forAdapter("database").get(ref)` rather than duplicating the
+route's authorization logic in another adapter.
 
 ## Lifecycle feature flags (exactly two)
 

--- a/docs/storage-ref-contract.md
+++ b/docs/storage-ref-contract.md
@@ -91,6 +91,20 @@ Canonical write/read/delete flows should move toward `ObjectRef`-based calls.
 Deprecated aliases remain so existing callers can migrate incrementally without
 changing lifecycle behavior.
 
+## Database adapter read path during C3 transition
+
+For database-backed refs, `ObjectRef.key` is the numeric `fileUploads.id`
+encoded as a string. Until the database adapter is extracted, `get(ref)` on the
+app port resolves that key to `/api/files/{id}` and calls `fetchFile`, which
+adds internal service headers for a self-origin request. The `/api/files/[id]`
+route remains the single place for tenant authorization and serve-gating before
+reading the Postgres row.
+
+`forAdapter("database")` remains unwired until C3. Callers reading a database
+ref should use `getStoragePort().get(ref)` during this transition rather than
+targeting the unwired database handle or duplicating the route's authorization
+logic in another adapter.
+
 ## Lifecycle feature flags (exactly two)
 
 - `STORAGE_DELETION_LIFECYCLE_ENABLED` (intake gate, default off)

--- a/docs/storage-ref-contract.md
+++ b/docs/storage-ref-contract.md
@@ -9,6 +9,7 @@ This document captures the frozen storage contract used by server-side upload/de
 - `storageLocationId` is server-resolved from configured adapter environment.
 - Clients do not guess, derive, or mint `storageLocationId`.
 - `ObjectRef` is opaque and immutable once minted.
+- New `STORAGE_S3_*` env vars take precedence over legacy S3 env names; legacy names remain supported for compatibility.
 
 ## ObjectRef
 
@@ -48,6 +49,28 @@ Worker/state mapping (frozen):
 Blocked/rejected outcomes are terminal for that adapter attempt and must not fall
 through to another adapter.
 
+## Port surface
+
+The storage contract now distinguishes canonical methods from compatibility
+aliases:
+
+- Canonical methods:
+  - `put`
+  - `get`
+  - `delete`
+  - `deleteMany`
+  - `getSignedUrl`
+- Explicit adapter targeting:
+  - `getStoragePort().forAdapter(adapter)`
+- Deprecated compatibility aliases:
+  - `upload`
+  - `download`
+  - `deleteRef`
+
+Canonical write/read/delete flows should move toward `ObjectRef`-based calls.
+Deprecated aliases remain so existing callers can migrate incrementally without
+changing lifecycle behavior.
+
 ## Lifecycle feature flags (exactly two)
 
 - `STORAGE_DELETION_LIFECYCLE_ENABLED` (intake gate, default off)
@@ -72,4 +95,9 @@ Dominance rules:
 
 ## Deferred port scope
 
-The frozen lifecycle contract covers provider-owned identity and deletion. Full naming parity for `put`, `get`, and `getSignedUrl` is intentionally deferred; the current `StoragePort` continues to expose `upload` and `download` until existing ingestion callers can migrate without a compatibility break. New deletion and manifest code must use `ObjectRef`, `deleteRef`, and `deleteMany`; the legacy URL `delete` method remains only as a promotion shim for historical rows.
+The frozen lifecycle contract still covers provider-owned identity and deletion.
+This contract update only locks the canonical method names and adapter-targeting
+shape; it does not by itself rewire existing app call sites. New deletion and
+manifest code must continue to use `ObjectRef` and `deleteMany`, while the
+legacy URL `delete` overload remains a promotion shim for historical rows until
+downstream migration work lands.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,9 +23,11 @@ export * from "./errors";
 export type {
   DeleteOutcome,
   DeleteResult,
+  GetSignedUrlOptions,
   ObjectRef,
   StorageAdapter,
   StoragePort,
+  TargetedStoragePort,
   UploadInput,
   UploadResult,
 } from "./storage/types";

--- a/packages/core/src/storage/in-memory.ts
+++ b/packages/core/src/storage/in-memory.ts
@@ -1,6 +1,15 @@
 import { randomUUID } from "node:crypto";
 
-import type { DeleteResult, ObjectRef, StoragePort, UploadInput, UploadResult } from "./types";
+import type {
+  DeleteResult,
+  GetSignedUrlOptions,
+  ObjectRef,
+  StorageAdapter,
+  StoragePort,
+  TargetedStoragePort,
+  UploadInput,
+  UploadResult,
+} from "./types";
 
 export interface InMemoryStoredObject {
   ref: ObjectRef;
@@ -29,6 +38,8 @@ export interface CreateInMemoryStoragePortOptions {
   urlBase?: string;
 }
 
+type InMemoryGetInput = ObjectRef | string;
+
 function makeRefKey(ref: ObjectRef): string {
   return `${ref.adapter}::${ref.storageLocationId}::${ref.key}`;
 }
@@ -41,6 +52,10 @@ function toUrl(base: string, pathname: string): string {
   return `${base.replace(/\/+$/, "")}/${pathname.replace(/^\/+/, "")}`;
 }
 
+function coerceKey(input: string): string {
+  return input.replace(/\s+/g, "-");
+}
+
 /**
  * Test-only in-memory StoragePort implementation.
  *
@@ -50,9 +65,9 @@ function toUrl(base: string, pathname: string): string {
 export function createInMemoryStoragePort(
   options: CreateInMemoryStoragePortOptions = {},
 ): InMemoryStoragePort {
-  const adapter = options.adapter ?? "database";
-  const storageLocationId = options.storageLocationId ?? "memory:default";
-  const provider = options.provider ?? `memory:${adapter}`;
+  const defaultAdapter = options.adapter ?? "database";
+  const defaultStorageLocationId = options.storageLocationId ?? `memory:${defaultAdapter}`;
+  const provider = options.provider ?? `memory:${defaultAdapter}`;
   const urlBase = options.urlBase ?? "memory://storage";
 
   const objects = new Map<string, InMemoryStoredObject>();
@@ -73,6 +88,43 @@ export function createInMemoryStoragePort(
     objects.set(refKey, stored);
     urlToRefKey.set(url, refKey);
     return stored;
+  };
+
+  const resolveStorageLocationId = (targetAdapter: StorageAdapter): string => {
+    if (targetAdapter === defaultAdapter) {
+      return defaultStorageLocationId;
+    }
+    return `memory:${targetAdapter}`;
+  };
+
+  const resolveStoredObject = (input: InMemoryGetInput): InMemoryStoredObject | undefined => {
+    if (typeof input !== "string") {
+      return objects.get(makeRefKey(input));
+    }
+
+    const refKeyByUrl = urlToRefKey.get(input);
+    if (refKeyByUrl) {
+      return objects.get(refKeyByUrl);
+    }
+
+    const syntheticRef: ObjectRef = {
+      adapter: defaultAdapter,
+      storageLocationId: resolveStorageLocationId(defaultAdapter),
+      key: input,
+    };
+    return objects.get(makeRefKey(syntheticRef));
+  };
+
+  const getImpl = async (input: InMemoryGetInput): Promise<Response> => {
+    const stored = resolveStoredObject(input);
+    if (!stored) {
+      return new Response("Not Found", { status: 404 });
+    }
+
+    return new Response(new Uint8Array(stored.data), {
+      status: 200,
+      headers: stored.contentType ? { "content-type": stored.contentType } : undefined,
+    });
   };
 
   const deleteRefImpl = async (ref: ObjectRef): Promise<DeleteResult> => {
@@ -99,77 +151,116 @@ export function createInMemoryStoragePort(
     return results;
   };
 
+  const deleteLegacyImpl = async (urlOrKey: string): Promise<void> => {
+    const stored = resolveStoredObject(urlOrKey);
+    if (!stored) {
+      return;
+    }
+    await deleteRefImpl(stored.ref);
+  };
+
+  const getSignedUrlImpl = async (
+    ref: ObjectRef,
+    opts?: GetSignedUrlOptions,
+  ): Promise<string> => {
+    const stored = resolveStoredObject(ref);
+    const url = stored?.url ?? toUrl(urlBase, ref.key);
+    const expiresIn = opts?.expiresIn;
+    return expiresIn ? `${url}?expiresIn=${expiresIn}` : url;
+  };
+
+  const putForAdapter = async (
+    targetAdapter: StorageAdapter,
+    input: UploadInput,
+  ): Promise<UploadResult> => {
+    const pathname = `documents/${randomUUID()}-${coerceKey(input.filename)}`;
+    const ref: ObjectRef = {
+      adapter: targetAdapter,
+      storageLocationId: resolveStorageLocationId(targetAdapter),
+      key: pathname,
+    };
+    const stored = seedObject({
+      ref,
+      data: input.data,
+      contentType: input.contentType,
+      pathname,
+    });
+
+    return {
+      url: stored.url,
+      pathname: stored.pathname,
+      ref,
+      contentType: stored.contentType,
+      provider,
+    };
+  };
+
+  const createTargetedPort = (targetAdapter: StorageAdapter): TargetedStoragePort => ({
+    adapter: targetAdapter,
+    provider,
+    put(input: UploadInput): Promise<UploadResult> {
+      return putForAdapter(targetAdapter, input);
+    },
+    get(ref: ObjectRef, init?: RequestInit): Promise<Response> {
+      void init;
+      return getImpl(ref);
+    },
+    delete(ref: ObjectRef): Promise<DeleteResult> {
+      return deleteRefImpl(ref);
+    },
+    deleteMany(refs: readonly ObjectRef[]): Promise<DeleteResult[]> {
+      return deleteManyImpl(refs);
+    },
+    getSignedUrl(ref: ObjectRef, opts?: GetSignedUrlOptions): Promise<string> {
+      return getSignedUrlImpl(ref, opts);
+    },
+  });
+
+  async function deleteImpl(ref: ObjectRef): Promise<DeleteResult>;
+  async function deleteImpl(urlOrKey: string): Promise<void>;
+  async function deleteImpl(input: ObjectRef | string): Promise<DeleteResult | void> {
+    if (typeof input === "string") {
+      await deleteLegacyImpl(input);
+      return;
+    }
+
+    return deleteRefImpl(input);
+  }
+
   return {
     provider,
 
-    async upload(input: UploadInput): Promise<UploadResult> {
-      const pathname = `documents/${randomUUID()}-${input.filename.replace(/\s+/g, "-")}`;
-      const ref: ObjectRef = {
-        adapter,
-        storageLocationId,
-        key: pathname,
-      };
-      const stored = seedObject({
-        ref,
-        data: input.data,
-        contentType: input.contentType,
-        pathname,
-      });
-
-      return {
-        url: stored.url,
-        pathname: stored.pathname,
-        ref,
-        contentType: stored.contentType,
-        provider,
-      };
+    put(input: UploadInput): Promise<UploadResult> {
+      return putForAdapter(defaultAdapter, input);
     },
 
-    async download(urlOrKey: string): Promise<Response> {
-      const refKeyByUrl = urlToRefKey.get(urlOrKey);
-      let stored: InMemoryStoredObject | undefined;
+    get(input: InMemoryGetInput, init?: RequestInit): Promise<Response> {
+      void init;
+      return getImpl(input);
+    },
 
-      if (refKeyByUrl) {
-        stored = objects.get(refKeyByUrl);
-      } else {
-        const syntheticRef: ObjectRef = {
-          adapter,
-          storageLocationId,
-          key: urlOrKey,
-        };
-        stored = objects.get(makeRefKey(syntheticRef));
-      }
+    delete: deleteImpl,
 
-      if (!stored) {
-        return new Response("Not Found", { status: 404 });
-      }
+    getSignedUrl(ref: ObjectRef, opts?: GetSignedUrlOptions): Promise<string> {
+      return getSignedUrlImpl(ref, opts);
+    },
 
-      return new Response(new Uint8Array(stored.data), {
-        status: 200,
-        headers: stored.contentType ? { "content-type": stored.contentType } : undefined,
-      });
+    forAdapter(targetAdapter: StorageAdapter): TargetedStoragePort {
+      return createTargetedPort(targetAdapter);
+    },
+
+    async upload(input: UploadInput): Promise<UploadResult> {
+      return putForAdapter(defaultAdapter, input);
+    },
+
+    async download(urlOrKey: string, init?: RequestInit): Promise<Response> {
+      void init;
+      return getImpl(urlOrKey);
     },
 
     deleteRef: deleteRefImpl,
 
     deleteMany: deleteManyImpl,
-
-    async delete(urlOrKey: string): Promise<void> {
-      const refKeyByUrl = urlToRefKey.get(urlOrKey);
-      if (refKeyByUrl) {
-        const stored = objects.get(refKeyByUrl);
-        if (!stored) return;
-        await deleteRefImpl(stored.ref);
-        return;
-      }
-
-      const ref: ObjectRef = {
-        adapter,
-        storageLocationId,
-        key: urlOrKey,
-      };
-      await deleteRefImpl(ref);
-    },
 
     seedObject,
 

--- a/packages/core/src/storage/index.ts
+++ b/packages/core/src/storage/index.ts
@@ -1,9 +1,11 @@
 export type {
 	DeleteOutcome,
 	DeleteResult,
+	GetSignedUrlOptions,
 	ObjectRef,
 	StorageAdapter,
 	StoragePort,
+	TargetedStoragePort,
 	UploadInput,
 	UploadResult,
 } from "./types";

--- a/packages/core/src/storage/types.ts
+++ b/packages/core/src/storage/types.ts
@@ -33,27 +33,77 @@ export interface DeleteResult {
   message?: string;
 }
 
+export interface GetSignedUrlOptions {
+  expiresIn?: number;
+}
+
+export interface TargetedStoragePort {
+  /** Adapter/backend this handle is pinned to. */
+  readonly adapter: StorageAdapter;
+  /** Identifier for the active backend (e.g. "s3", "database"). */
+  readonly provider: string;
+
+  /** Store a new object using the explicitly targeted adapter. */
+  put(input: UploadInput): Promise<UploadResult>;
+
+  /** Fetch an object's bytes by canonical reference. */
+  get(ref: ObjectRef, init?: RequestInit): Promise<Response>;
+
+  /** Delete an object by canonical reference with a stable per-item outcome. */
+  delete(ref: ObjectRef): Promise<DeleteResult>;
+
+  /** Batch delete canonical refs, preserving one outcome per requested ref. */
+  deleteMany(refs: readonly ObjectRef[]): Promise<DeleteResult[]>;
+
+  /** Generate a signed or shareable URL for the adapter-owned object. */
+  getSignedUrl(ref: ObjectRef, opts?: GetSignedUrlOptions): Promise<string>;
+}
+
 export interface StoragePort {
+  /** Store a new object using the host's default storage backend. */
+  put(input: UploadInput): Promise<UploadResult>;
+
+  /** Fetch an object's bytes by canonical reference. */
+  get(ref: ObjectRef, init?: RequestInit): Promise<Response>;
+
+  /**
+   * @deprecated Legacy URL/key read shim kept for migration. New code should
+   * resolve a canonical ObjectRef and call {@link get}.
+   */
+  get(urlOrKey: string, init?: RequestInit): Promise<Response>;
+
+  /** Delete an object by canonical reference with a stable per-item outcome. */
+  delete(ref: ObjectRef): Promise<DeleteResult>;
+
+  /**
+   * @deprecated URL/key delete shim kept only for migration. New code must use
+   * canonical ObjectRefs and avoid URL parsing outside legacy promotion.
+   */
+  delete(urlOrKey: string): Promise<void>;
+
+  /** Batch delete canonical refs, preserving one outcome per requested ref. */
+  deleteMany(refs: readonly ObjectRef[]): Promise<DeleteResult[]>;
+
+  /** Generate a signed or shareable URL for the object. */
+  getSignedUrl(ref: ObjectRef, opts?: GetSignedUrlOptions): Promise<string>;
+
+  /** Pin a handle to one concrete adapter instead of the default backend. */
+  forAdapter(adapter: StorageAdapter): TargetedStoragePort;
+
   /** Store a new object. Returns the public URL (or /api/files/ id) and pathname. */
+  /** @deprecated Use {@link put}. */
   upload(input: UploadInput): Promise<UploadResult>;
 
   /**
    * Fetch an object's bytes. Accepts either a URL returned by {@link upload}
    * or a raw key. Returns a fetch-style Response so callers can stream.
    */
+  /** @deprecated Use {@link get}. */
   download(urlOrKey: string, init?: RequestInit): Promise<Response>;
 
   /** Delete an object by canonical reference with a stable per-item outcome. */
+  /** @deprecated Use {@link delete}. */
   deleteRef(ref: ObjectRef): Promise<DeleteResult>;
-
-  /** Batch delete canonical refs, preserving one outcome per requested ref. */
-  deleteMany(refs: readonly ObjectRef[]): Promise<DeleteResult[]>;
-
-  /**
-   * @deprecated URL/key delete shim kept only for migration. New code must use
-   * `deleteRef` / `deleteMany` and avoid URL parsing outside legacy promotion.
-   */
-  delete(urlOrKey: string): Promise<void>;
 
   /** Identifier for the active backend (e.g. "s3", "database"). */
   readonly provider: string;


### PR DESCRIPTION
## Summary

- Introduce a provider-neutral storage port with canonical `ObjectRef` identities and targeted adapters for S3, Vercel Blob, UploadThing, database storage, and in-memory testing.
- Add the complete storage-deletion lifecycle: manifest/lineage tracking, coordinated and batched deletion, retries, tombstones, serve-gating, tenant checks, status/inventory APIs, rollout flags, and admin UI.
- Harden adapter/location identity handling and migrate upload/read paths to the storage port while preserving legacy URL compatibility.

## Related

LAU-22 — Document storage port

## Checklist

- [ ] `pnpm check` passes (lint + typecheck)
- [ ] `pnpm --filter @launchstack/web test` passes
- [ ] Changeset added (`packages/core/` changed; changeset still needed)
- [x] New env vars documented in `.env.example` and `apps/web/src/env.ts`
- [ ] UI changes exercised in a browser
- [x] Docs updated if behavior changed

## Testing

- `pnpm --filter @launchstack/web typecheck`
- Targeted Jest verification: 8 suites, 98 tests passed
- Verified adapter routing, database behavior, deletion outcomes, Adeu storage-port reads, and legacy URL promotion.
- Confirmed no production imports of `fetchBlob` or `isPrivateBlobUrl` remain outside the legacy module.

## Notes for reviewers

- Database `get(ref)` intentionally uses authenticated internal HTTP through `/api/files/{id}` and requires `APP_PUBLIC_URL`.
- Legacy `fetchFile(url)` remains as a compatibility shim.
- A7 legacy backfill remains deferred.
- Full repository checks and browser-based UI verification still need to be run.