### PR TITLE
Unbreak main: route export from #364, Docker manifests for both new bricks

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -23,6 +23,8 @@ COPY packages/indexing/package.json ./packages/indexing/
 COPY packages/search/package.json ./packages/search/
 COPY packages/orchestration/package.json ./packages/orchestration/
 COPY packages/editing/package.json ./packages/editing/
+COPY packages/google-drive/package.json ./packages/google-drive/
+COPY packages/document-conversion-engine/package.json ./packages/document-conversion-engine/
 COPY packages/collab/package.json ./packages/collab/
 COPY packages/engine/package.json ./packages/engine/
 COPY packages/schema-generator/package.json ./packages/schema-generator/

--- a/apps/web/Dockerfile.prebuilt
+++ b/apps/web/Dockerfile.prebuilt
@@ -28,6 +28,8 @@ COPY packages/indexing/package.json ./packages/indexing/
 COPY packages/search/package.json ./packages/search/
 COPY packages/orchestration/package.json ./packages/orchestration/
 COPY packages/editing/package.json ./packages/editing/
+COPY packages/google-drive/package.json ./packages/google-drive/
+COPY packages/document-conversion-engine/package.json ./packages/document-conversion-engine/
 COPY packages/collab/package.json ./packages/collab/
 COPY packages/engine/package.json ./packages/engine/
 COPY packages/schema-generator/package.json ./packages/schema-generator/

--- a/apps/web/src/app/api/connectors/google/oauth/callback/route.ts
+++ b/apps/web/src/app/api/connectors/google/oauth/callback/route.ts
@@ -16,13 +16,12 @@ import { users } from "~/server/db/schema";
 import { isManagementRole, requireWorkspaceContext } from "~/lib/require-workspace-context";
 import {
     GOOGLE_DRIVE_SCOPES,
+    OAUTH_STATE_COOKIE,
     getGoogleOAuthApp,
     getOAuthRedirectUrl,
     isDriveLinkingEnabled,
 } from "~/server/services/google-drive/config";
 import { upsertGoogleConnection } from "~/server/services/google-drive/connections";
-
-import { OAUTH_STATE_COOKIE } from "../start/route";
 
 function redirectToWorkspace(request: Request, flag: string): NextResponse {
     const response = NextResponse.redirect(

--- a/apps/web/src/app/api/connectors/google/oauth/start/route.ts
+++ b/apps/web/src/app/api/connectors/google/oauth/start/route.ts
@@ -15,12 +15,11 @@ import { buildAuthorizationUrl } from "@launchstack/google-drive";
 import { isManagementRole, requireWorkspaceContext } from "~/lib/require-workspace-context";
 import {
     GOOGLE_DRIVE_SCOPES,
+    OAUTH_STATE_COOKIE,
     getGoogleOAuthApp,
     getOAuthRedirectUrl,
     isDriveLinkingEnabled,
 } from "~/server/services/google-drive/config";
-
-export const OAUTH_STATE_COOKIE = "gdrive_oauth_state";
 
 export async function GET(request: Request) {
     if (!isDriveLinkingEnabled()) {

--- a/apps/web/src/server/services/google-drive/config.ts
+++ b/apps/web/src/server/services/google-drive/config.ts
@@ -13,6 +13,13 @@ import { env } from "~/env";
 export const GOOGLE_DRIVE_PROVIDER = "google-drive";
 
 /**
+ * CSRF nonce cookie for the OAuth flow. Lives here, not in the route file:
+ * Next.js route modules may only export handler fields, and `next build`
+ * enforces that where plain typechecking does not.
+ */
+export const OAUTH_STATE_COOKIE = "gdrive_oauth_state";
+
+/**
  * drive.file only: the app can touch files it created, nothing else in the
  * user's Drive. openid+email identify which Google account holds the files.
  */

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -27,6 +27,8 @@ COPY packages/indexing/package.json ./packages/indexing/
 COPY packages/search/package.json ./packages/search/
 COPY packages/orchestration/package.json ./packages/orchestration/
 COPY packages/editing/package.json ./packages/editing/
+COPY packages/google-drive/package.json ./packages/google-drive/
+COPY packages/document-conversion-engine/package.json ./packages/document-conversion-engine/
 COPY packages/collab/package.json ./packages/collab/
 COPY packages/engine/package.json ./packages/engine/
 COPY packages/schema-generator/package.json ./packages/schema-generator/


### PR DESCRIPTION
## Summary

- Main's CI went red when #364 merged at its conflict-resolution commit (the branch's CI fixes hadn't landed yet), and #362 stacked a second latent failure on top. This PR carries the two remaining fixes; the third failure from that set (the package-test lint error) was already fixed on main by #362's follow-through commit.
- `next build` rejects non-handler exports from route modules — a validation plain `tsc --noEmit` never runs — so `OAUTH_STATE_COOKIE` moves from the OAuth start route into `services/google-drive/config`, and the callback no longer imports from a sibling route file. Fixes the `build` job, both Docker image builds, and the Vercel deploy.
- The worker/web Dockerfiles enumerate workspace package manifests for their install layer, and **both** newly merged bricks were missing: `packages/google-drive` (#364) is what killed compose-smoke (`Cannot find package 'zod'`), and `packages/document-conversion-engine` (#362) would have failed the web image build identically next. Both added to all three Dockerfiles.

## Related

Follow-up to #364 and #362.

## Checklist

- [x] `pnpm check` passes (lint + typecheck)
- [x] `pnpm --filter @launchstack/web test` passes (unchanged by this diff; google-drive package tests 13/13)
- [x] Changeset added — n/a
- [x] New env vars — n/a
- [x] UI changes — n/a
- [x] Docs — n/a

## Testing

- `SKIP_ENV_VALIDATION=1 pnpm --filter @launchstack/web build` compiles clean on this branch (it fails on main with the route-type error).
- Dockerfile fix mirrors the failure mechanism exactly: the manifest COPY list drives the filtered install, and the missing entries are the two packages whose imports crashed at runtime/build.

## Notes for reviewers

Six files, 15 insertions. The Dockerfile manifest list is a recurring trap — every new workspace package must be added in three places; possibly worth generating that layer from `pnpm-workspace.yaml` in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Infrastructure and module-export fixes with no change to OAuth behavior or runtime auth logic beyond where the constant is defined.
> 
> **Overview**
> Restores **main** after follow-on breakage from the Google Drive and document-conversion workspace packages.
> 
> **Next.js build:** `OAUTH_STATE_COOKIE` is no longer exported from the Google OAuth **start** route. It lives in `server/services/google-drive/config` with a short note that route modules may only export handlers—something `next build` enforces but plain typecheck does not. The **callback** route imports the cookie name from config instead of the sibling route file.
> 
> **Docker install layers:** The manifest `COPY` lists in `apps/web/Dockerfile`, `apps/web/Dockerfile.prebuilt`, and `apps/worker/Dockerfile` now include `packages/google-drive` and `packages/document-conversion-engine` so filtered `pnpm install --frozen-lockfile` resolves those workspace deps (fixing compose-smoke / image build failures from missing packages like `zod`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f25fa083df4e335a860d4f8aeb2de1dc934976d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->