### PR TITLE
Fix main's build and compose-smoke: route-file export, Docker workspace manifests

### DIFF
--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -23,6 +23,8 @@ COPY packages/indexing/package.json ./packages/indexing/
 COPY packages/search/package.json ./packages/search/
 COPY packages/orchestration/package.json ./packages/orchestration/
 COPY packages/editing/package.json ./packages/editing/
+COPY packages/document-conversion-engine/package.json ./packages/document-conversion-engine/
+COPY packages/google-drive/package.json ./packages/google-drive/
 COPY packages/collab/package.json ./packages/collab/
 COPY packages/engine/package.json ./packages/engine/
 COPY packages/schema-generator/package.json ./packages/schema-generator/

--- a/apps/web/src/app/api/connectors/google/oauth/callback/route.ts
+++ b/apps/web/src/app/api/connectors/google/oauth/callback/route.ts
@@ -22,7 +22,7 @@ import {
 } from "~/server/services/google-drive/config";
 import { upsertGoogleConnection } from "~/server/services/google-drive/connections";
 
-import { OAUTH_STATE_COOKIE } from "../start/route";
+import { OAUTH_STATE_COOKIE } from "~/server/services/google-drive/config";
 
 function redirectToWorkspace(request: Request, flag: string): NextResponse {
     const response = NextResponse.redirect(

--- a/apps/web/src/app/api/connectors/google/oauth/start/route.ts
+++ b/apps/web/src/app/api/connectors/google/oauth/start/route.ts
@@ -15,12 +15,11 @@ import { buildAuthorizationUrl } from "@launchstack/google-drive";
 import { isManagementRole, requireWorkspaceContext } from "~/lib/require-workspace-context";
 import {
     GOOGLE_DRIVE_SCOPES,
+    OAUTH_STATE_COOKIE,
     getGoogleOAuthApp,
     getOAuthRedirectUrl,
     isDriveLinkingEnabled,
 } from "~/server/services/google-drive/config";
-
-export const OAUTH_STATE_COOKIE = "gdrive_oauth_state";
 
 export async function GET(request: Request) {
     if (!isDriveLinkingEnabled()) {

--- a/apps/web/src/server/services/google-drive/config.ts
+++ b/apps/web/src/server/services/google-drive/config.ts
@@ -13,6 +13,13 @@ import { env } from "~/env";
 export const GOOGLE_DRIVE_PROVIDER = "google-drive";
 
 /**
+ * CSRF cookie for the OAuth round trip. Lives here rather than in the start
+ * route: Next.js route files may only export handlers and route config, and
+ * `next build` rejects extra exports.
+ */
+export const OAUTH_STATE_COOKIE = "gdrive_oauth_state";
+
+/**
  * drive.file only: the app can touch files it created, nothing else in the
  * user's Drive. openid+email identify which Google account holds the files.
  */

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -27,6 +27,8 @@ COPY packages/indexing/package.json ./packages/indexing/
 COPY packages/search/package.json ./packages/search/
 COPY packages/orchestration/package.json ./packages/orchestration/
 COPY packages/editing/package.json ./packages/editing/
+COPY packages/document-conversion-engine/package.json ./packages/document-conversion-engine/
+COPY packages/google-drive/package.json ./packages/google-drive/
 COPY packages/collab/package.json ./packages/collab/
 COPY packages/engine/package.json ./packages/engine/
 COPY packages/schema-generator/package.json ./packages/schema-generator/


### PR DESCRIPTION
## Summary

- Carries the one commit stranded when #362 was merged (its head was `e4dbc591`; the CI-fix commit `b019d46d` landed on the branch minutes later). Without it, main's `build` and `compose-smoke` jobs fail.
- **build**: `next build` rejects the Drive OAuth start route — Next.js route files may only export handlers and route config, and `OAUTH_STATE_COOKIE` was a bare constant export that the callback imported across routes. It now lives in `server/services/google-drive/config`, imported by both legs. (`tsc --noEmit` can't catch this; only `next build`'s route typegen does — which is why #364's `check` job was green.)
- **compose-smoke**: the worker crash-looped on `ERR_MODULE_NOT_FOUND: zod` from `packages/google-drive/src/wire.ts` — neither Dockerfile copied the two newest workspace manifests before `pnpm install`, so those packages got no dependency links. Both Dockerfiles now list `google-drive` and `document-conversion-engine` (the latter was the same latent bomb waiting for the web image).

## Related

Follow-up to #362 (merged with these fixes still on the branch); fixes fallout from #364.

## Checklist

- [x] `pnpm check` passes (lint + typecheck)
- [x] `pnpm --filter @launchstack/web test` passes
- [ ] Changeset — not needed: no publishable package source changed
- [ ] New env vars — none
- [ ] UI changes — none
- [x] Docs — no behavior change beyond CI

## Testing

- `SKIP_ENV_VALIDATION=1 pnpm --filter @launchstack/web build` exits 0 (the exact `build` gate that fails on main).
- Worker image rebuilt from the patched Dockerfile; inside it, `packages/google-drive/src/wire.ts` (the exact module in the crash loop) and `packages/document-conversion-engine/src/index.ts` both import cleanly under tsx.

## Notes for reviewers

Same content as `b019d46d` on the merged #362 branch, cherry-picked onto main. Merging this should turn main's `build` and `compose-smoke` green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/CI and import-location fixes with no intended runtime behavior change beyond restoring green builds and worker startup.
> 
> **Overview**
> Unblocks **main** CI by fixing two unrelated breakages from recent Google Drive / workspace package work.
> 
> **`next build`**: Moves **`OAUTH_STATE_COOKIE`** out of the OAuth **start** route into **`server/services/google-drive/config`**, with **start** and **callback** importing it from there. Route modules may only export handlers and route config; the extra constant export caused the build gate to fail (typecheck alone does not catch this).
> 
> **Docker `compose-smoke`**: Adds **`document-conversion-engine`** and **`google-drive`** **`package.json`** copies to the **web** and **worker** images before **`pnpm install`**, so workspace packages link correctly and runtime no longer hits missing deps (e.g. **`zod`** from **`google-drive`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fab809b6b45744f6e5ed4ef56be5d777cabe558. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->