### PR TITLE
fix: copy every workspace manifest into the image deps layers

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,6 +58,12 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
 
+      # Cheap, dependency-free, and fails fast: a workspace package missing
+      # from a Dockerfile deps layer otherwise surfaces ~2 minutes into the
+      # image build as an unresolvable dependency the package does declare.
+      - name: Dockerfile deps layers cover every workspace manifest
+        run: node scripts/ci/check-dockerfile-manifests.mjs
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -28,6 +28,8 @@ COPY packages/engine/package.json ./packages/engine/
 COPY packages/schema-generator/package.json ./packages/schema-generator/
 COPY packages/tools/package.json ./packages/tools/
 COPY packages/design-tokens/package.json ./packages/design-tokens/
+COPY packages/document-conversion-engine/package.json ./packages/document-conversion-engine/
+COPY packages/google-drive/package.json ./packages/google-drive/
 COPY pipelines/package.json ./pipelines/
 COPY apps/web/package.json ./apps/web/
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -32,6 +32,8 @@ COPY packages/engine/package.json ./packages/engine/
 COPY packages/schema-generator/package.json ./packages/schema-generator/
 COPY packages/tools/package.json ./packages/tools/
 COPY packages/design-tokens/package.json ./packages/design-tokens/
+COPY packages/document-conversion-engine/package.json ./packages/document-conversion-engine/
+COPY packages/google-drive/package.json ./packages/google-drive/
 COPY pipelines/package.json ./pipelines/
 
 RUN pnpm install --frozen-lockfile

--- a/scripts/ci/check-dockerfile-manifests.mjs
+++ b/scripts/ci/check-dockerfile-manifests.mjs
@@ -1,0 +1,85 @@
+/**
+ * Verify every workspace package manifest is copied into each Dockerfile's
+ * dependency layer.
+ *
+ * The deps stage copies manifests one explicit `COPY` line at a time so that
+ * source edits don't bust the install cache. That list is maintained by hand,
+ * and nothing has ever checked it against the actual workspace — so adding a
+ * package silently omits it. `pnpm install --frozen-lockfile` then resolves a
+ * workspace that is missing that member, its dependencies are never installed,
+ * and the failure only surfaces much later as a type error in the builder
+ * stage, pointing at a dependency the package *does* declare.
+ *
+ * That is exactly how `packages/google-drive` broke the image build with
+ * "Cannot find module 'zod'" while its package.json declared zod all along.
+ *
+ * Run:
+ *   node scripts/ci/check-dockerfile-manifests.mjs
+ *
+ * Exit codes: 0 ok · 1 a manifest is missing from a Dockerfile
+ */
+import { readFileSync, readdirSync, existsSync } from "node:fs";
+import { join, resolve as resolvePath } from "node:path";
+
+const ROOT = resolvePath(import.meta.dirname, "../..");
+const DOCKERFILES = ["apps/web/Dockerfile", "apps/worker/Dockerfile"];
+
+/** Workspace dirs that ship a package.json, as the Dockerfiles address them. */
+function workspaceManifests() {
+    const found = [];
+    for (const group of ["packages", "pipelines", "apps"]) {
+        const groupDir = join(ROOT, group);
+        if (!existsSync(groupDir)) continue;
+
+        // pipelines/ is itself a single package, not a directory of them.
+        if (existsSync(join(groupDir, "package.json"))) {
+            found.push(`${group}/package.json`);
+            continue;
+        }
+        for (const entry of readdirSync(groupDir, { withFileTypes: true })) {
+            if (!entry.isDirectory()) continue;
+            if (existsSync(join(groupDir, entry.name, "package.json"))) {
+                found.push(`${group}/${entry.name}/package.json`);
+            }
+        }
+    }
+    return found;
+}
+
+const manifests = workspaceManifests();
+const failures = [];
+
+for (const dockerfile of DOCKERFILES) {
+    const path = join(ROOT, dockerfile);
+    if (!existsSync(path)) continue;
+    const contents = readFileSync(path, "utf8");
+
+    for (const manifest of manifests) {
+        // apps/* manifests are only required in the Dockerfile that builds
+        // that app; a worker image has no reason to carry apps/web's.
+        if (manifest.startsWith("apps/") && !dockerfile.startsWith(manifest.slice(0, manifest.lastIndexOf("/")))) {
+            continue;
+        }
+        if (!contents.includes(manifest)) {
+            failures.push({ dockerfile, manifest });
+        }
+    }
+}
+
+if (failures.length > 0) {
+    console.error(
+        `[check-dockerfile-manifests] ${failures.length} workspace manifest(s) missing from a Dockerfile deps layer:`
+    );
+    for (const { dockerfile, manifest } of failures) {
+        console.error(`  ✗ ${dockerfile} — add: COPY ${manifest} ./${manifest.slice(0, manifest.lastIndexOf("/"))}/`);
+    }
+    console.error(
+        "\nWithout the COPY, pnpm installs a workspace that is missing this member and the\n" +
+            "image build fails later with an unresolvable dependency the package does declare."
+    );
+    process.exit(1);
+}
+
+console.log(
+    `[check-dockerfile-manifests] ok — ${manifests.length} manifests present across ${DOCKERFILES.length} Dockerfiles`
+);


### PR DESCRIPTION
## Problem

`main` has not produced a deployable image since 2026-08-29 — four consecutive failed runs of the Docker workflow. Because `docker.yml` only pushes `:latest` on a successful build, GHCR's `:latest` is still commit `5452aedd`, and any production `docker compose pull` today is a no-op. Three merges have landed on a branch that cannot build.

The most recent failure:

```
../../packages/google-drive/src/wire.ts:7
Type error: Cannot find module 'zod'
```

`packages/google-drive/package.json` declares `"zod": "^3.23.8"`, so the error points at the wrong thing.

## Root cause

The deps stage copies workspace manifests one explicit `COPY` line at a time, so that source edits don't bust the install cache:

```dockerfile
COPY packages/runtime/package.json ./packages/runtime/
COPY packages/evidence/package.json ./packages/evidence/
...
```

That list is maintained by hand and nothing has ever compared it to the actual workspace. The two packages added recently — `packages/google-drive` and `packages/document-conversion-engine` — were never added, in **either** Dockerfile.

So `pnpm install --frozen-lockfile` resolves a workspace that is missing those members. The install succeeds (the lockfile is consistent; the packages simply aren't part of the graph it sees), their dependencies are never installed, and the failure surfaces two minutes later in the builder stage as an unresolvable import — naming a dependency the package does declare, in a file that is not at fault.

`apps/worker/Dockerfile` had the identical omission, so the worker image would have failed the same way as soon as the web build was fixed.

## Changes

- **`apps/web/Dockerfile`, `apps/worker/Dockerfile`** — add the two missing manifests to the deps layer.
- **`scripts/ci/check-dockerfile-manifests.mjs`** — compares every workspace manifest against each Dockerfile's deps layer and fails with the exact `COPY` line to add.
- **`.github/workflows/CI.yml`** — runs that check early in the `check` job, before `pnpm install`. It needs no dependencies, so it fails in seconds rather than after a multi-minute image build.

## Why the guard

This failure mode is silent at the point of the mistake and misleading at the point of discovery: adding a package is normal work, nothing warns you, and the error that eventually appears blames a dependency that is correctly declared. Without a check, the next package added repeats it.

Verified both directions:

```
$ node scripts/ci/check-dockerfile-manifests.mjs
[check-dockerfile-manifests] ok — 20 manifests present across 2 Dockerfiles

$ # with packages/google-drive removed from the web Dockerfile
[check-dockerfile-manifests] 1 workspace manifest(s) missing from a Dockerfile deps layer:
  ✗ apps/web/Dockerfile — add: COPY packages/google-drive/package.json ./packages/google-drive/
```

## Validation

The `pull_request` trigger runs a smoke build of both images, which is the real test of this change — a green build here is proof the deps layer now resolves `zod` for `packages/google-drive`.

## Note for whoever deploys after this merges

This unblocks the image, but production is still on `5452aedd` and the intervening commits replace Clerk with better-auth. Deploying will need `BETTER_AUTH_SECRET` set (`openssl rand -base64 32`) before the app can boot — it is `requiredString()` — plus `BETTER_AUTH_URL` behind the proxy, and three new migrations will apply. That is a planned cutover, not a routine redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/CI guardrails and Dockerfile manifest COPY lines only; no runtime auth, data, or application logic changes.
> 
> **Overview**
> Fixes broken Docker image builds caused by **hand-maintained** deps-stage `COPY` lists omitting newer workspace packages (`document-conversion-engine`, `google-drive`). Without those manifests, `pnpm install --frozen-lockfile` sees an incomplete workspace, skips those packages’ dependencies, and the builder later fails with misleading errors (e.g. missing `zod`).
> 
> **`apps/web/Dockerfile` and `apps/worker/Dockerfile`** now copy both missing `package.json` files in the deps layer.
> 
> Adds **`scripts/ci/check-dockerfile-manifests.mjs`**, which enumerates workspace manifests under `packages/`, `pipelines/`, and `apps/` and asserts each required path appears in the web and worker Dockerfiles (with app-specific rules so the worker image isn’t forced to list unrelated `apps/*` manifests).
> 
> **`.github/workflows/CI.yml`** runs that script early in the `check` job—before `pnpm install`—so omissions fail in seconds instead of deep in a multi-minute image build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e79278591c125595186e52c2f9dc686f5d706f65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->