### PR TITLE
Production Compose overlay, deployment runbook, and the SeaweedFS filer password fix

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -138,6 +138,9 @@ jobs:
         env:
           SKIP_ENV_VALIDATION: "1"
           STANDALONE_BUILD: "1"
+          # better-auth throws on the default secret during `next build`, and
+          # SKIP_ENV_VALIDATION only bypasses the zod schema, not that check.
+          BETTER_AUTH_SECRET: ci-better-auth-secret-placeholder
         run: pnpm --filter @launchstack/web build
 
       - name: Set up Docker Buildx

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -20,7 +20,7 @@ COPY packages/store/package.json ./packages/store/
 COPY packages/llm/package.json ./packages/llm/
 COPY packages/conversion/package.json ./packages/conversion/
 COPY packages/indexing/package.json ./packages/indexing/
-COPY packages/search/package.json ./packages/search/
+COPY packages/retrieval/package.json ./packages/retrieval/
 COPY packages/orchestration/package.json ./packages/orchestration/
 COPY packages/editing/package.json ./packages/editing/
 COPY packages/collab/package.json ./packages/collab/

--- a/apps/web/Dockerfile.prebuilt
+++ b/apps/web/Dockerfile.prebuilt
@@ -25,7 +25,7 @@ COPY packages/store/package.json ./packages/store/
 COPY packages/llm/package.json ./packages/llm/
 COPY packages/conversion/package.json ./packages/conversion/
 COPY packages/indexing/package.json ./packages/indexing/
-COPY packages/search/package.json ./packages/search/
+COPY packages/retrieval/package.json ./packages/retrieval/
 COPY packages/orchestration/package.json ./packages/orchestration/
 COPY packages/editing/package.json ./packages/editing/
 COPY packages/collab/package.json ./packages/collab/
@@ -33,6 +33,8 @@ COPY packages/engine/package.json ./packages/engine/
 COPY packages/schema-generator/package.json ./packages/schema-generator/
 COPY packages/tools/package.json ./packages/tools/
 COPY packages/design-tokens/package.json ./packages/design-tokens/
+COPY packages/document-conversion-engine/package.json ./packages/document-conversion-engine/
+COPY packages/google-drive/package.json ./packages/google-drive/
 COPY pipelines/package.json ./pipelines/
 COPY apps/web/package.json ./apps/web/
 RUN --mount=type=cache,id=pnpm,target=/pnpm/store \

--- a/apps/web/config/chat-models.yaml
+++ b/apps/web/config/chat-models.yaml
@@ -1,64 +1,67 @@
-# Chat model configuration.
+# Chat model configuration. Mounted read-only into the app and the worker, so
+# changing a model is an edit plus a restart — never an image rebuild.
 #
-# Non-secret only. The endpoint URL lives in CHAT_BASE_URL and its credential
-# in CHAT_API_KEY; point CHAT_MODELS_CONFIG at another file to use one instead
-# of this. Every model here is served by that single OpenAI-compatible
-# endpoint — "compatible" meaning it implements the OpenAI
-# /chat/completions protocol, not that it is any HTTP API at all.
+# `id` is the id your endpoint serves. CHAT_BASE_URL points at OpenRouter,
+# which accepts both the bare id and the vendor-prefixed form; the prefixed
+# form is written here because it is unambiguous about which vendor serves it.
 #
-# A model must either reference a bundled preset or declare its behavior in
-# full. Nothing is inferred from the model id: a name that merely resembles a
-# known model gets no capabilities. Anything you write under `behavior` is
-# authoritative and overrides the preset in both directions, so
-# `nativeStructuredOutput: []` genuinely turns that off.
-#
-# See docs/chat-models.md for the full reference.
-
+# The Gemini 3.x models have no entry in packages/llm/src/presets.ts, so
+# `primary` and `fast` declare their behavior in full. A model with neither a
+# preset nor a `behavior` block is a startup error by design — an unknown model
+# is never silently classified as text-only.
 version: 1
 
 models:
-  # Default: Google Gemini. Reached at
-  # CHAT_BASE_URL=https://generativelanguage.googleapis.com/v1beta/openai,
-  # which is also where chat falls back when CHAT_BASE_URL is unset.
-  #
-  # Model ids here are the BARE ids Google's endpoint expects. The `google/`
-  # prefix belongs only to the `preset:` field, which names a bundled behavior
-  # entry — see packages/core/src/llm/presets.ts.
-  primary:
-    id: gemini-2.5-flash
-    preset: google/gemini-2.5-flash
+    # Vision route inherits this model, so it must declare image input.
+    primary:
+        id: google/gemini-3.7-flash
+        behavior:
+            input: [text, image]
+            image:
+                mimeTypes: [image/png, image/jpeg, image/webp, image/heic]
+            reasoning:
+                mode: effort
+                levels:
+                    none: { reasoning_effort: "none" }
+                    low: { reasoning_effort: "low" }
+                    medium: { reasoning_effort: "medium" }
+                    high: { reasoning_effort: "high" }
+                default: "medium"
+            nativeStructuredOutput: [json-object, json-schema, tool-calling]
+            parameters:
+                temperature: supported
+                systemMessages: supported
+                streaming: supported
+                maxOutputTokens: supported
 
-  # The cheap tier. Its preset sets reasoning `default: none`, so routine work
-  # does not pay for thinking tokens.
-  fast:
-    id: gemini-2.5-flash-lite
-    preset: google/gemini-2.5-flash-lite
+    # The cheap tier. `mode: none` is deliberate rather than asserted: the
+    # lite models' reasoning surface was not verified against this endpoint,
+    # and an over-claimed capability surfaces as a confusing runtime error.
+    # The fast route never asks for reasoning, so nothing is lost.
+    fast:
+        id: google/gemini-3.5-flash-lite
+        behavior:
+            input: [text, image]
+            image:
+                mimeTypes: [image/png, image/jpeg, image/webp, image/heic]
+            reasoning:
+                mode: none
+            nativeStructuredOutput: [json-object, json-schema, tool-calling]
+            parameters:
+                temperature: supported
+                systemMessages: supported
+                streaming: supported
+                maxOutputTokens: supported
 
-  # The reasoning tier. 2.5 Pro always reasons, so its preset omits the `none`
-  # level rather than claiming a capability the endpoint would reject.
-  deep:
-    id: gemini-2.5-pro
-    preset: google/gemini-2.5-pro
-
-  # Talking to something else instead? Any OpenAI-compatible endpoint works —
-  # set CHAT_BASE_URL and replace the models above. With OpenRouter the ids
-  # carry a vendor prefix and a bundled preset may not exist, in which case
-  # declare `behavior` in full instead of referencing one:
-  #
-  #   primary:
-  #     id: moonshotai/kimi-k3
-  #     behavior:
-  #       input: [text, image]
-  #       nativeStructuredOutput: [json-schema, tool-calling]
-  #       parameters: { temperature: supported, streaming: supported }
+    # The reasoning route. No 3.7-generation Pro model is published, so this
+    # stays on the 2.5 preset, whose reasoning contract is a verified catalog
+    # entry rather than an assertion made here.
+    deep:
+        id: google/gemini-2.5-pro
+        preset: google/gemini-2.5-pro
 
 routes:
-  # `default` is required. `fast` inherits it unless assigned.
-  #
-  # `reasoning` and `vision` inherit `default` only when that model declares
-  # the capability. gemini-2.5-flash declares both, so both would work
-  # unassigned; `reasoning` is pointed at the Pro tier deliberately.
-  default: primary
-  fast: fast
-  reasoning: deep
-  vision: primary
+    default: primary
+    fast: fast
+    reasoning: deep
+    vision: primary

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -24,7 +24,7 @@ COPY packages/store/package.json ./packages/store/
 COPY packages/llm/package.json ./packages/llm/
 COPY packages/conversion/package.json ./packages/conversion/
 COPY packages/indexing/package.json ./packages/indexing/
-COPY packages/search/package.json ./packages/search/
+COPY packages/retrieval/package.json ./packages/retrieval/
 COPY packages/orchestration/package.json ./packages/orchestration/
 COPY packages/editing/package.json ./packages/editing/
 COPY packages/collab/package.json ./packages/collab/

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,102 @@
+# Production overlay — the "lean" single-VM deployment (see
+# docs/runbooks/azure-lean-deploy.md).
+#
+#   docker compose -f docker-compose.yml -f docker-compose.prod.yml --env-file .env up -d
+#
+# What it changes relative to the local stack:
+#   - app + worker run the GHCR images published by .github/workflows/docker.yml
+#     (only `migrate` still builds locally — its target is the light deps stage).
+#   - No self-hosted Whisper and no Docling: transcription resolves to the
+#     cloud provider (packages/llm registry default) and OCR routes to the
+#     provider named by OCR_DEFAULT_PROVIDER (AZURE in the lean setup). Both
+#     containers move behind opt-in profiles.
+#   - No Inngest dev server. INNGEST_DEV is cleared; set INNGEST_EVENT_KEY /
+#     INNGEST_SIGNING_KEY to enable the background verticals via Inngest Cloud
+#     (ingestion itself runs through the outbox and needs neither).
+#   - Caddy terminates TLS for ${DOMAIN} (app, plus /api/inngest on the
+#     worker) and files.${DOMAIN} (SeaweedFS object URLs, anonymous read).
+#   - No service publishes a host port except Caddy; the NSG only admits
+#     22/80/443 anyway, but the containers shouldn't offer more than the
+#     firewall happens to block.
+
+services:
+  app:
+    image: ghcr.io/deodat-lawson/launchstack-web:latest
+    build: !reset null
+    ports: !reset []
+    depends_on: !reset
+      migrate:
+        condition: service_completed_successfully
+      seaweedfs:
+        condition: service_started
+      adeu-docs-editing:
+        condition: service_started
+      document-converter:
+        condition: service_started
+    environment:
+      INNGEST_DEV: ""
+      INNGEST_SIGNING_KEY: ${INNGEST_SIGNING_KEY:-}
+      # Public object-URL origin. Also the SDK endpoint — the app reaches its
+      # own SeaweedFS through Caddy so that stored URLs and fetch checks agree
+      # on one origin (lib/storage matches URLs by this prefix).
+      NEXT_PUBLIC_S3_ENDPOINT: https://files.${DOMAIN}
+      NEXT_PUBLIC_APP_URL: https://${DOMAIN}
+
+  worker:
+    image: ghcr.io/deodat-lawson/launchstack-web-worker:latest
+    build: !reset null
+    ports: !reset []
+    environment:
+      INNGEST_DEV: ""
+      INNGEST_SIGNING_KEY: ${INNGEST_SIGNING_KEY:-}
+      NEXT_PUBLIC_S3_ENDPOINT: https://files.${DOMAIN}
+
+  db:
+    ports: !reset []
+
+  # The base stack leaves seaweedfs with Docker's default restart policy, so a
+  # single failed start (a slow db, a host reboot) leaves object storage down
+  # until someone notices. Every other service here is unless-stopped.
+  seaweedfs:
+    restart: unless-stopped
+
+  adeu-docs-editing:
+    ports: !reset []
+
+  document-converter:
+    ports: !reset []
+
+  # Added to the base stack by ADR-009; same rule as the others.
+  gotenberg:
+    ports: !reset []
+
+  # Self-hosted Whisper — excluded from the lean stack. Re-enable with
+  # `--profile whisper` and TRANSCRIPTION_PROVIDER=sidecar.
+  transcription:
+    profiles: ["whisper"]
+    ports: !reset []
+
+  # Dev-only Inngest server; production uses Inngest Cloud (or none).
+  inngest-dev:
+    profiles: ["inngest-dev"]
+
+  caddy:
+    image: caddy:2
+    container_name: pdr_ai_v2-caddy
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./docker/Caddyfile.prod:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    environment:
+      DOMAIN: ${DOMAIN}
+      ACME_EMAIL: ${ACME_EMAIL:-}
+    depends_on:
+      - app
+
+volumes:
+  caddy_data:
+  caddy_config:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -182,6 +182,14 @@ services:
         condition: service_healthy
     environment:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-password}
+      # The filer stores its metadata in Postgres, and docker/filer.toml is a
+      # static file mounted read-only — its `password` line can only carry the
+      # local default. SeaweedFS overlays any filer.toml key from
+      # WEED_<SECTION>_<KEY>, so this is what actually authenticates the filer.
+      # Without it, every deployment that sets a real POSTGRES_PASSWORD (i.e.
+      # every production one) crash-loops on `failed SASL auth` and object
+      # storage never comes up.
+      WEED_POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-password}
       S3_ACCESS_KEY: ${S3_ACCESS_KEY:-pdr_local_key}
       S3_SECRET_KEY: ${S3_SECRET_KEY:-pdr_local_secret}
     volumes:

--- a/docker/Caddyfile.prod
+++ b/docker/Caddyfile.prod
@@ -1,0 +1,23 @@
+# Production Caddyfile (mounted by docker-compose.prod.yml).
+# Caddy provisions and renews Let's Encrypt certificates for both hosts.
+# Optional: add a global `email you@example.com` block to receive certificate
+# expiry notices from Let's Encrypt.
+
+{$DOMAIN} {
+	# Inngest Cloud syncs against the worker's serve endpoint (ADR-003:
+	# the app no longer serves /api/inngest).
+	@inngest path /api/inngest*
+	handle @inngest {
+		reverse_proxy worker:8020
+	}
+
+	handle {
+		reverse_proxy app:3000
+	}
+}
+
+# Object storage: SeaweedFS S3, anonymous read only (writes require the
+# signed credentials only the app holds). Object keys contain UUIDs.
+files.{$DOMAIN} {
+	reverse_proxy seaweedfs:8333
+}

--- a/docker/filer.toml
+++ b/docker/filer.toml
@@ -1,3 +1,8 @@
+# Mounted read-only, so every value here is a static default. SeaweedFS
+# overrides any key from WEED_<SECTION>_<KEY>; docker-compose.yml sets
+# WEED_POSTGRES_PASSWORD from POSTGRES_PASSWORD, which is what a deployment
+# with a real password actually authenticates with. The literal below only
+# applies to a stack running the local default.
 [postgres]
 enabled = true
 hostname = "db"

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -44,7 +44,10 @@ CREATE EXTENSION IF NOT EXISTS vector;
 
 ## Option 1: Docker Compose (full stack)
 
-Recommended for local and self-hosted deployments.
+Recommended for local and self-hosted deployments. For the production
+single-VM variant (GHCR images, Caddy TLS, no Whisper/Docling/Inngest-dev
+containers), layer `docker-compose.prod.yml` on top — see
+[`docs/runbooks/azure-lean-deploy.md`](./runbooks/azure-lean-deploy.md).
 
 ```bash
 docker compose --env-file .env up

--- a/docs/design/self-host-readiness.md
+++ b/docs/design/self-host-readiness.md
@@ -1,0 +1,311 @@
+# Technical Design
+
+**Feature** Self-host readiness · **Author** Deodat-Lawson · **Date** 2026-08-29 ·
+**Status** Draft · **Brief** _none — see §9_
+
+> This doc is being written without an approved brief, which the template
+> forbids. The justification is that the kill test was effectively run in
+> production: a real deployment (§7) surfaced a class of defect that makes the
+> "can someone else run this?" question answerable only by fixing it. If that
+> reasoning is not accepted, §9 row 1 kills the doc.
+
+---
+
+## 1 Summary
+
+Deploying LaunchStack outside the author's laptop currently fails in ways that
+look like success. A production bring-up on Azure hit a defect where object
+storage crash-looped for two days while every other service reported healthy,
+because a hardcoded password in a mounted config file could not see the real
+one in the environment. That is not a one-off bug; it is a category. This design
+closes the category with four changes: a preflight command that validates a
+deployment before it starts, a rule that config must never be hand-mirrored into
+a sidecar, completion of the storage provider seam so object storage is a choice
+rather than a fork, and deployment ergonomics (restart policies, a restore
+drill) that let an instance survive unattended. The target reader is someone who
+clones the repo and wants a running instance without reading the source.
+
+**Ship target** Before the first external self-hoster, or before the first
+paying user on the hosted instance — whichever comes first.
+
+---
+
+## 2 Context and constraints
+
+**Builds on**
+
+- `docker-compose.yml` — the deployment spec. Nine services; six run in the lean
+  production shape (`docker-compose.prod.yml`).
+- `apps/web/src/env.ts` — **190 declared environment variables**, validated with
+  Zod at process start, bypassable with `SKIP_ENV_VALIDATION`.
+- `packages/engine/src/config/types.ts` — `CoreConfig`, the composition root.
+  Core never reads `process.env`; the app builds one config object and hands it
+  down. This is the right shape and the design leans on it.
+- `packages/runtime/src/storage-port/` — `StoragePort`, a four-method interface
+  (`upload` / `download` / `delete` / `provider`) that core uses for document
+  bytes.
+- ADR-002 (layered engine packages), ADR-003 (outbox + worker), ADR-004 (compute
+  service consolidation).
+
+**Not changing**
+
+- The deployment model. Container images to GHCR plus Compose stays; this is not
+  a move to Kubernetes, Helm, or a PaaS.
+- The ADR-003 split. The worker remains the sole durable coordinator, and
+  nothing here tries to make the app self-sufficient.
+- `CoreConfig` and the ports. The seams are correct; the work is in what fills
+  them and what validates them.
+- The 190-variable surface itself. Reducing it is a separate, larger piece of
+  work. This design makes the existing surface *safe*, not smaller.
+
+---
+
+## 3 Architecture / Design
+
+Four workstreams. W1 and W2 are the safety work; W3 and W4 are the
+self-hostability work.
+
+### W1 — Preflight validation (`pnpm deploy:check`)
+
+Today `env.ts` validates types at process start, inside the container, per
+process. That misses three whole classes of misconfiguration, all of which have
+already occurred:
+
+1. **Paired variables.** Base URL and API key are read as a pair at every level.
+   Setting `EMBEDDING_API_KEY` without `EMBEDDING_API_BASE_URL` type-checks
+   fine, then fails at call time with "API key not configured" — hours later,
+   inside a background job.
+2. **Cross-process agreement.** `FILE_ACCESS_TOKEN_SECRET`, the S3 credential
+   triple, `NEXT_PUBLIC_S3_ENDPOINT`, and every `*_SERVICE_API_KEY` must be
+   *identical* between app and worker. Each process validates its own copy and
+   is satisfied. Nothing compares them.
+3. **Defaults that are only safe locally.** `docker-compose.yml` ships
+   `pdr_local_sidecar_key`, `pdr_local_adeu_key`, `pdr_local_converter_key`,
+   `pdr_local_file_access_secret`, and `POSTGRES_PASSWORD=password` so `make up`
+   works with no `.env`. Every one is a production compromise, and nothing stops
+   them shipping.
+
+`deploy:check` is a single command, run against a `.env` before the stack
+starts, that exits non-zero with actionable messages:
+
+| Check | Failure message names |
+|---|---|
+| Required set present | which variable, which feature dies without it |
+| Pairs complete | the missing half, not the present one |
+| Cross-process identity | which two services disagree |
+| No `pdr_local_*` / `password` when `DOMAIN` is set | the specific defaults still in place |
+| Secret entropy floor | the variable, and the length required |
+| Reachability | DB, object store, and each compute service, probed with the configured credentials |
+
+Reachability probing is what separates this from a linter — it catches the
+SeaweedFS defect directly, because the filer's Postgres credential is exercised
+rather than merely present.
+
+### W2 — Config must never be hand-mirrored
+
+The SeaweedFS defect in full: SeaweedFS stores filer metadata in Postgres.
+`docker/filer.toml` is mounted read-only and contains a literal
+`password = "password"`. In local development that matches
+`POSTGRES_PASSWORD`'s default and everything works. Any deployment that sets a
+real password gets `FATAL: password authentication failed`, SeaweedFS exits, and
+— because that service carried no restart policy — stays dead. The app, worker,
+database, and both document services remain healthy. The only visible symptom is
+a 502 from the file origin, which nothing alerts on.
+
+The fix already applied: `docker-compose.yml` now sets
+`WEED_POSTGRES_PASSWORD` from `POSTGRES_PASSWORD`, because SeaweedFS overlays
+any `filer.toml` key from `WEED_<SECTION>_<KEY>`. The filer authenticates with
+the real value; the literal in the file is now only a local-default fallback.
+
+The generalizable rule, and the actual design content:
+
+> **A sidecar's configuration is either injected from the environment or
+> generated at startup from the environment. It is never a static file that
+> restates a value the environment also holds.**
+
+The repo already has the good pattern —
+`docker/seaweedfs-entrypoint.sh` generates `s3-config.json` from
+`S3_ACCESS_KEY` / `S3_SECRET_KEY` at boot. `filer.toml` is the same file in the
+same container that did not get the same treatment. Audit for the rest:
+`docker/Caddyfile*`, `apps/web/config/chat-models.yaml`, and any future mounted
+config.
+
+Enforcement is a CI job, not a convention (see §7): boot the stack with
+randomized non-default secrets and assert an end-to-end upload. That test fails
+today against the pre-fix code, which is the only proof that it is testing
+anything.
+
+### W3 — Complete the storage provider seam
+
+`StoragePort` is a clean four-method interface, and core is correctly unaware of
+which backend fills it. But backend *selection* is hardcoded in
+`apps/web/src/lib/storage.ts`: `resolveStorageBackend()` returns the union
+`"s3" | "database"`, and `uploadFile()` branches to exactly two
+implementations. Adding a backend means editing that union and that branch.
+
+This is why "can we use Azure Blob Storage?" currently reads as a fork. It
+should not:
+
+- **Object storage** is the category — immutable blobs addressed by key over
+  HTTP, no filesystem semantics.
+- **The S3 API** is Amazon's interface to that category, and it became the de
+  facto standard. SeaweedFS, MinIO, Cloudflare R2, Backblaze B2, and
+  DigitalOcean Spaces all speak it. For all of these, switching backends is
+  **configuration**: change `NEXT_PUBLIC_S3_ENDPOINT` and the credentials.
+- **Azure Blob Storage** is the same category with a *different* API — containers
+  rather than buckets, shared-key/SAS auth, its own SDK. For this one, switching
+  is **code**.
+
+The design: make backends registered rather than enumerated. A backend supplies
+a name and a `StoragePort` implementation; `resolveStorageBackend()` picks from
+the registry by `NEXT_PUBLIC_STORAGE_PROVIDER`, with the current S3/database
+inference preserved as the default. An Azure Blob backend then becomes one file
+implementing four methods, and the same is true for GCS or a future provider.
+
+Scope note: `@vercel/blob` remains for reading legacy URLs only — `uploadFile()`
+already cannot write to it. The registry makes that status explicit instead of
+implied by a `deleteFileByUrl` comment.
+
+### W4 — Deployment ergonomics
+
+Smaller, but this is where a self-hoster actually gives up.
+
+- **Restart policies on every service.** SeaweedFS had none; six of seven did.
+  A single failed start left object storage down indefinitely. Fixed in the
+  production overlay, but it belongs in the base file.
+- **Health checks on every service.** The app currently has none, so
+  `docker compose ps` reports it `Up` before it can serve.
+- **A documented restore drill.** Backups that have never been restored are not
+  backups. The runbook has the restore command; nothing has run it.
+- **One documented bring-up path** with the overlay, rather than a Compose
+  invocation reconstructed from three docs.
+
+---
+
+## 4 Impacts
+
+**Graph changes** None. This design touches no node types, edges, or
+properties.
+
+**Provider interfaces touched** `StoragePort` — implementations added, the
+interface unchanged. This sits on the **OSS side** of the boundary: a
+self-hoster choosing MinIO or Azure Blob must not need anything proprietary.
+`LLMProvider` and `AuthProvider` are untouched.
+
+**Public surface**
+
+- New: `pnpm deploy:check` (root script, runnable in CI and against a `.env`).
+- New env var: `WEED_POSTGRES_PASSWORD` — set by Compose, not by operators.
+- Extended: `NEXT_PUBLIC_STORAGE_PROVIDER` gains registry-supplied values
+  (`azure-blob`, …) alongside `s3` / `database`.
+- No API routes, no CLI commands, no SDK exports change.
+
+**External services, and how they fail**
+
+| Service | When it is down or misconfigured | Behaviour |
+|---|---|---|
+| Object store (SeaweedFS / S3 / Blob) | Wrong credential, unreachable endpoint | **Today:** silent crash-loop, 502 on file reads, uploads fail late. **After W1:** preflight refuses to start and names the credential. |
+| Postgres | Unreachable or wrong password | App and worker fail fast and loudly; already acceptable. Preflight catches it before boot. |
+| Document converter / adeu | Key mismatch | 401 on every call, fail-closed by design. Preflight compares the app's copy to the service's. |
+| Chat / embedding provider | Missing base URL, or key without URL | Falls through to "API key not configured" at call time. Preflight catches the unpaired half. |
+| Inngest Cloud | Absent | Background verticals off; **ingestion unaffected** (outbox). Warns at boot. Correct as-is. |
+
+**Background jobs** Ingestion runs through the transactional outbox and the
+worker; nothing in this design changes that path. The CI verification job (§7)
+runs a full ingestion to completion, so it is bounded by real processing time —
+budget several minutes, and it must fail rather than hang if the worker never
+claims the event.
+
+---
+
+## 5 Alternatives considered
+
+| Option | Why it was rejected | What would change our mind |
+|---|---|---|
+| **Ship Kubernetes manifests / a Helm chart** | Solves distribution, not correctness — the same mirrored-password bug reappears as a ConfigMap that restates a Secret. Adds an operational burden no current deployment needs. | A self-hoster who already runs Kubernetes and wants to adopt this; or multi-node scale-out becoming real. |
+| **Move to managed services (Container Apps + Flexible Server + Blob)** | Does not make the project self-hostable — it makes *our* instance someone else's problem, and forecloses air-gapped deployment. Measured cost is ~2–3× current for the same functionality at present scale. | Traffic that justifies autoscaling, or a compliance requirement for managed data services. |
+| **Documentation only — write the gotchas down** | The SeaweedFS defect *was* documented behaviour (the compose file says "override all of them in production") and still shipped broken. Docs do not fail a build. | Never on its own; docs ship alongside W1–W4 regardless. |
+| **Do nothing** | The next person to deploy repeats the same two days of debugging, and the failure mode is silent rather than loud. Blocks external self-hosting entirely. | Deciding LaunchStack is a hosted-only product and self-hosting is not a goal — which contradicts the self-hosting defaults already built into `deployment.md`. |
+
+---
+
+## 6 Failure modes
+
+The four standing rows, answered as the template requires. Three are not
+applicable to this feature and one reframes cleanly — see §9 row 4.
+
+| What breaks | Blast radius | How we detect it | Fallback |
+|---|---|---|---|
+| **Venue network blocks outbound calls** | Reframed: a self-hoster deploys behind an egress-restricted firewall. Chat, embeddings, and hosted OCR all fail; ingestion of text files still works. | Preflight reachability probes fail at deploy time rather than at first upload. | Self-hosting defaults already assume this is legitimate — no telemetry, no third-party asset fetches, pdf.js served locally. Document the egress allowlist; Ollama covers fully air-gapped chat. |
+| **Event page or rules change format mid-event** | Not applicable — this feature parses no third-party page. | — | — |
+| **Repo is private, enormous, or barely committed** | Partially applicable: the GHCR images are public today. If they are made private, every `docker compose pull` fails on a fresh host. | Preflight pulls before it validates. | Document the registry-credential path; the images are reproducible from source in-tree. |
+| **Upload fails, or the video lands private** | Reframed and **live**: uploads fail, or objects land unreadable, when the object store is misconfigured. This is exactly the SeaweedFS defect. | W1 reachability probe; W2's CI boot test; a health check on SeaweedFS. | Fall back to the `database` storage backend, which needs no external service — already implemented, currently undocumented as a fallback. |
+| **A default secret reaches production** | Total: forgeable file-access tokens, a compute service anyone can call, a guessable database password. | Preflight refuses to start when `DOMAIN` is set and any `pdr_local_*` or `password` default remains. | None — this must be prevented, not recovered from. |
+| **App and worker drift on a shared secret** | Ingestion silently fails or file URLs 401; both processes report healthy. | Preflight compares the two environments. | None today; the mismatch is invisible at runtime. |
+| **Migrations applied to the wrong database** | Severe if the app and worker point at different `DATABASE_URL`s — the outbox is written to one and polled from the other. | Preflight asserts a single resolved `DATABASE_URL` across processes. | Migrations are ordered and idempotent; re-running against the correct database is safe. |
+| **Backup has never been restored** | Discovered only during an incident. | A quarterly restore drill into a scratch database. | None — an unrestored backup is a hypothesis. |
+
+**The worst thing this can do to a team** — A self-hoster runs for weeks on
+default secrets, believing the stack is healthy because every container reports
+healthy, and their documents are readable by anyone who finds the file origin.
+They find out from someone else.
+
+---
+
+## 7 Verification
+
+**Automated**
+
+- A CI job that boots the full Compose stack with **randomized, non-default**
+  secrets and asserts an end-to-end upload → outbox → worker → evidence →
+  retrieval. This is the regression test for the entire W2 category; it fails
+  against the pre-fix `filer.toml` and passes after, which is what makes it
+  meaningful rather than decorative.
+- `deploy:check` unit tests over crafted `.env` fixtures: unpaired provider
+  variables, drifted cross-process secrets, surviving defaults, weak secrets.
+- `deploy:check --ci` runs in the same job, so the checker and the stack it
+  describes cannot diverge.
+
+**End-to-end dry run** Already performed against the live Azure instance
+(`launchstack-vm`, eastus2): schema applied and `vector` extension confirmed;
+worker `/healthz` green; an object written through the app's real S3 credentials
+and read back over public HTTPS with a valid certificate. That run is what
+surfaced the SeaweedFS defect, and it is the shape the CI job automates.
+
+**The check that catches the worst failure in §6** Preflight's default-secret
+refusal, which is non-overridable when `DOMAIN` is set, plus the randomized-secret
+CI boot. The pairing matters: the first stops a human shipping defaults, the
+second stops us shipping a stack that only works *with* them.
+
+**Instrumentation**
+
+- Log the resolved storage provider, chat/embedding provider names, and metering
+  mode once at boot — enough to reconstruct a deployment's shape from its logs
+  without asking for the `.env`.
+- Emit a structured event when a compute service returns 401, distinguishing key
+  mismatch from service-down.
+- Count outbox events claimed vs. completed per interval; a claimed-not-completed
+  gap is the signature of a half-configured deployment.
+
+---
+
+## 8 Team assignment (after approval)
+
+| Workstream | Owner | Notes |
+|---|---|---|
+| W1 Preflight (`deploy:check`) | _unassigned_ | Largest piece; start here — W2's CI job depends on the checker |
+| W2 No hand-mirrored config | _unassigned_ | Fix landed; audit + CI job outstanding |
+| W3 Storage registry | _unassigned_ | Blocked on the §9 Azure Blob decision |
+| W4 Deploy ergonomics | _unassigned_ | Small, independent, parallelizable |
+
+---
+
+## 9 Open questions
+
+| Question | Who decides | By when |
+|---|---|---|
+| This doc has no approved brief. Does the production defect count as the kill test, or is a brief required first? | Repository maintainers | Before any W1 work starts |
+| Where does production Postgres live — self-hosted container, Azure Flexible Server, or a third party (Neon / Supabase / Crunchy)? All support `pgvector`; the design is indifferent, but §7's CI job needs one target. | Deodat-Lawson | Before W1 lands |
+| Is an Azure Blob `StoragePort` implementation in scope now, or does W3 ship as a registry with the two existing backends? | Deodat-Lawson | Before W3 starts |
+| The template's four standing failure modes (venue network, event page format, repo size, video upload) appear to belong to a different product surface. Should they be revised for the document-platform context, or kept as-is? | Repository maintainers | Next template revision |
+| Should `SKIP_ENV_VALIDATION` be refused outright when `DOMAIN` is set, or remain an escape hatch? | Repository maintainers | With W1 |

--- a/docs/runbooks/azure-lean-deploy.md
+++ b/docs/runbooks/azure-lean-deploy.md
@@ -16,27 +16,29 @@ pgvector, object storage, the document services — still runs on your own box.
 
 ---
 
-## Current live instance
+## Your deployment's inventory
+
+Fill this in once and the rest of the guide refers back to it. The commands
+below use these names.
 
 | | |
 |---|---|
-| **URL** | https://20.110.112.248.sslip.io |
-| **Files origin** | https://files.20.110.112.248.sslip.io |
-| Resource group | `launchstack-prod` (subscription "Azure subscription 1") |
-| VM | `launchstack-vm` — Standard_D2as_v7 (2 vCPU / 8 GB), Ubuntu 24.04, eastus2 |
-| Public IP | `20.110.112.248` (static) |
-| SSH | `ssh launchstack@20.110.112.248` |
-| Open ports | 22, 80, 443 (Azure NSG) |
-| Stack location | `/home/launchstack/LaunchStack` |
-| OCR | `launchstack-docintel` — Azure Document Intelligence, **F0 free tier (500 pages/month)** |
-| Backups | Storage account `lsbackup0fd637`, container `db-backups`, 30-day retention |
+| **URL** | `https://<DOMAIN>` |
+| **Files origin** | `https://files.<DOMAIN>` |
+| Resource group | `<RESOURCE_GROUP>` |
+| VM | `<VM_NAME>` — Standard_D2as_v7 (2 vCPU / 8 GB), Ubuntu 24.04 |
+| Public IP | `<PUBLIC_IP>` (static) |
+| SSH | `ssh <ADMIN_USER>@<PUBLIC_IP>` |
+| Stack location | `/home/<ADMIN_USER>/LaunchStack` |
+| OCR | `<DOCINTEL_NAME>` — Azure Document Intelligence, F0 free tier (500 pages/month) |
+| Secrets | Key Vault `<VAULT_NAME>` |
+| Backups | Storage account `<BACKUP_ACCOUNT>`, container `db-backups`, 30-day retention |
 
-`*.sslip.io` is wildcard DNS that resolves any `<ip>.sslip.io` name to that IP —
-it gives a real, publicly valid HTTPS hostname with no registrar. Swapping in
-your own domain is a two-minute change; see
+**On hostnames without a domain.** `*.sslip.io` is wildcard DNS that resolves
+any `<ip>.sslip.io` name to that IP, so `https://<PUBLIC_IP>.sslip.io` gives a
+publicly valid HTTPS hostname with no registrar. Certificates issue normally.
+Swapping in your own domain later is the substitution in
 [Moving to your own domain](#moving-to-your-own-domain).
-
----
 
 ## Prerequisites
 
@@ -54,17 +56,17 @@ your own domain is a two-minute change; see
 ## Step 1 — Provision the Azure resources
 
 ```bash
-az group create -n launchstack-prod -l eastus2
+az group create -n <RESOURCE_GROUP> -l eastus2
 
 az vm create \
-  -g launchstack-prod -n launchstack-vm -l eastus2 \
+  -g <RESOURCE_GROUP> -n <VM_NAME> -l eastus2 \
   --image Ubuntu2404 --size Standard_D2as_v7 \
   --os-disk-size-gb 64 --storage-sku StandardSSD_LRS \
   --public-ip-sku Standard --public-ip-address-allocation static \
   --admin-username launchstack --generate-ssh-keys \
   --custom-data cloud-init.yaml
 
-az vm open-port -g launchstack-prod -n launchstack-vm --port 80,443 --priority 900
+az vm open-port -g <RESOURCE_GROUP> -n <VM_NAME> --port 80,443 --priority 900
 ```
 
 with `cloud-init.yaml` installing Docker on first boot:
@@ -97,10 +99,10 @@ Then provision OCR (free tier) and the backup storage account:
 az provider register --namespace Microsoft.CognitiveServices   # once per subscription
 
 az cognitiveservices account create \
-  -n launchstack-docintel -g launchstack-prod \
+  -n <DOCINTEL_NAME> -g <RESOURCE_GROUP> \
   --kind FormRecognizer --sku F0 -l eastus2 --yes
 
-az storage account create -n <unique-name> -g launchstack-prod -l eastus2 \
+az storage account create -n <unique-name> -g <RESOURCE_GROUP> -l eastus2 \
   --sku Standard_LRS --kind StorageV2 --access-tier Cool --allow-blob-public-access false
 az storage container create -n db-backups --account-name <unique-name>
 ```
@@ -110,7 +112,7 @@ az storage container create -n db-backups --account-name <unique-name>
 ## Step 2 — Install the stack on the VM
 
 ```bash
-ssh launchstack@<PUBLIC_IP>
+ssh <ADMIN_USER>@<PUBLIC_IP>
 git clone --depth 1 https://github.com/Deodat-Lawson/LaunchStack.git
 ```
 
@@ -121,7 +123,7 @@ of what is committed on `main`.
 
 ## Step 3 — Configure `.env`
 
-Create `/home/launchstack/LaunchStack/.env` (mode `600`, never committed).
+Create `/home/<ADMIN_USER>/LaunchStack/.env` (mode `600`, never committed).
 
 **Generate every internal secret** — do not ship the `pdr_local_*` defaults from
 `docker-compose.yml`. They exist so `make up` works locally and are marked
@@ -246,7 +248,7 @@ Then in a browser:
 Images publish to GHCR on every push to `main`.
 
 ```bash
-ssh launchstack@<PUBLIC_IP> 'cd LaunchStack && git pull && \
+ssh <ADMIN_USER>@<PUBLIC_IP> 'cd LaunchStack && git pull && \
   docker compose -f docker-compose.yml -f docker-compose.prod.yml --env-file .env pull app worker && \
   docker compose -f docker-compose.yml -f docker-compose.prod.yml --env-file .env up -d --build'
 ```
@@ -261,7 +263,7 @@ changes on its own.
 ## Secrets: Azure Key Vault
 
 `.env` on the VM is a **derived artifact**. The source of record is Key Vault
-`launchstack-kv-a9be20`, which holds 29 secrets (empty-valued variables are not
+`<VAULT_NAME>`, which holds 29 secrets (empty-valued variables are not
 stored — Key Vault rejects empty values, and Compose treats absent and empty
 identically through its `${VAR:-}` defaults).
 
@@ -270,7 +272,7 @@ the app reads plain environment variables, so rather than touch application
 code, a script regenerates the `.env` Compose already consumes.
 
 **No credential is stored on the VM.** The VM has a system-assigned managed
-identity (`55e2e28d-7476-48db-b199-2e8c8b68a8aa`) holding exactly one role on
+identity (`<VM_PRINCIPAL_ID>`) holding exactly one role on
 the vault — `Key Vault Secrets User`, read-only. The token comes from IMDS
 (`169.254.169.254`), which only answers processes on that machine. Writes are
 refused with HTTP 403; the seeding step used a temporary
@@ -279,7 +281,7 @@ refused with HTTP 403; the seeding step used a temporary
 Regenerate `.env` before bringing the stack up:
 
 ```bash
-python3 ~/sync-env-from-keyvault.py launchstack-kv-a9be20
+python3 ~/sync-env-from-keyvault.py <VAULT_NAME>
 ```
 
 It writes atomically via a temp file, saves the previous copy as `.env.bak`,
@@ -304,7 +306,7 @@ dashes, so the reverse mapping is unambiguous.
 
 ## Backups and restore
 
-`/home/launchstack/backup-db.sh` runs nightly at **03:10 UTC** via cron: it
+`/home/<ADMIN_USER>/backup-db.sh` runs nightly at **03:10 UTC** via cron: it
 pipes `pg_dump` of `pdr_ai_v2` through gzip into the `db-backups` container
 using a **write-only SAS token** (valid ~2 years — rotate before mid-2028). A
 storage lifecycle policy deletes blobs after 30 days. Check `~/backup.log`.
@@ -331,7 +333,7 @@ early on; revisit when originals become irreplaceable.
 
    ```bash
    cd ~/LaunchStack
-   sed -i "s/20.110.112.248.sslip.io/app.example.com/g" .env
+   sed -i "s/<PUBLIC_IP>.sslip.io/app.example.com/g" .env
    docker compose -f docker-compose.yml -f docker-compose.prod.yml --env-file .env up -d \
      --force-recreate app worker caddy
    ```
@@ -352,10 +354,10 @@ alive, or rewrite `document_versions.url` if you migrate before real traffic.
   `TRANSCRIPTION_PROVIDER=sidecar`. Budget ~1.5 GB.
 - **Docling back on-box:** `--profile ocr` plus `OCR_DEFAULT_PROVIDER=DOCLING`.
   Budget ~1.2 GB.
-- Either one needs a bigger VM first: stop it, `az vm resize -g launchstack-prod
-  -n launchstack-vm --size Standard_D4as_v7` (16 GB), start it.
+- Either one needs a bigger VM first: stop it, `az vm resize -g <RESOURCE_GROUP>
+  -n <VM_NAME> --size Standard_D4as_v7` (16 GB), start it.
 - **Document Intelligence** F0 caps at 500 pages/month. Upgrade in place:
-  `az cognitiveservices account update -n launchstack-docintel -g launchstack-prod --sku S0`.
+  `az cognitiveservices account update -n <DOCINTEL_NAME> -g <RESOURCE_GROUP> --sku S0`.
 - **Managed Postgres** (Azure Flexible Server, ~$15/mo and up) is the first
   upgrade worth buying once you have users whose data you cannot lose — it
   brings real backups and point-in-time restore.

--- a/docs/runbooks/azure-lean-deploy.md
+++ b/docs/runbooks/azure-lean-deploy.md
@@ -1,0 +1,453 @@
+# Deploying LaunchStack on a single Azure VM ("lean" stack)
+
+This is the complete, reproducible guide to running LaunchStack publicly on one
+Azure VM. It is written to be followed from an empty Azure subscription, and it
+also documents the instance that is currently live.
+
+**What "lean" means.** The full Compose stack self-hosts everything, including
+a Whisper transcription model and the Docling document-parsing engine — roughly
+7 GB of resident memory, which forces a 16 GB VM. The lean stack moves those two
+workloads to pay-per-use APIs, drops to ~4.3 GB, and fits an 8 GB VM at about
+half the monthly cost. Everything else — the app, the worker, Postgres with
+pgvector, object storage, the document services — still runs on your own box.
+
+`docker-compose.prod.yml` is the overlay that encodes this shape.
+`docker/Caddyfile.prod` terminates TLS.
+
+---
+
+## Current live instance
+
+| | |
+|---|---|
+| **URL** | https://20.110.112.248.sslip.io |
+| **Files origin** | https://files.20.110.112.248.sslip.io |
+| Resource group | `launchstack-prod` (subscription "Azure subscription 1") |
+| VM | `launchstack-vm` — Standard_D2as_v7 (2 vCPU / 8 GB), Ubuntu 24.04, eastus2 |
+| Public IP | `20.110.112.248` (static) |
+| SSH | `ssh launchstack@20.110.112.248` |
+| Open ports | 22, 80, 443 (Azure NSG) |
+| Stack location | `/home/launchstack/LaunchStack` |
+| OCR | `launchstack-docintel` — Azure Document Intelligence, **F0 free tier (500 pages/month)** |
+| Backups | Storage account `lsbackup0fd637`, container `db-backups`, 30-day retention |
+
+`*.sslip.io` is wildcard DNS that resolves any `<ip>.sslip.io` name to that IP —
+it gives a real, publicly valid HTTPS hostname with no registrar. Swapping in
+your own domain is a two-minute change; see
+[Moving to your own domain](#moving-to-your-own-domain).
+
+---
+
+## Prerequisites
+
+- An Azure subscription and the `az` CLI, logged in (`az login`).
+- The images published to GHCR by `.github/workflows/docker.yml`. They are
+  public, so the VM pulls them without credentials, and they carry no
+  build-time secrets — every value is read at runtime, so one image serves any
+  deployment.
+- Accounts for the services the app depends on: an OpenAI-compatible chat
+  endpoint and an embeddings provider. Authentication is self-hosted
+  (better-auth), so there is no auth vendor to sign up with.
+
+---
+
+## Step 1 — Provision the Azure resources
+
+```bash
+az group create -n launchstack-prod -l eastus2
+
+az vm create \
+  -g launchstack-prod -n launchstack-vm -l eastus2 \
+  --image Ubuntu2404 --size Standard_D2as_v7 \
+  --os-disk-size-gb 64 --storage-sku StandardSSD_LRS \
+  --public-ip-sku Standard --public-ip-address-allocation static \
+  --admin-username launchstack --generate-ssh-keys \
+  --custom-data cloud-init.yaml
+
+az vm open-port -g launchstack-prod -n launchstack-vm --port 80,443 --priority 900
+```
+
+with `cloud-init.yaml` installing Docker on first boot:
+
+```yaml
+#cloud-config
+package_update: true
+packages: [ca-certificates, curl, git]
+runcmd:
+  - curl -fsSL https://get.docker.com | sh
+  - systemctl enable --now docker
+  - usermod -aG docker launchstack
+```
+
+**On VM sizing.** Any 2 vCPU / 8 GB size works. The B-series burstable sizes
+(`Standard_B2ms`) are the cheapest on paper, but were unavailable to this
+subscription in every US region tested — `SkuNotAvailable ... Capacity
+Restrictions`. `Standard_D2as_v7` is the same class at a comparable price and
+isn't subject to burst-credit throttling. If a size fails, list what your
+subscription can actually get:
+
+```bash
+az vm list-skus -l eastus2 --resource-type virtualMachines --query \
+  "[?!restrictions[0]].name" -o tsv | sort -u
+```
+
+Then provision OCR (free tier) and the backup storage account:
+
+```bash
+az provider register --namespace Microsoft.CognitiveServices   # once per subscription
+
+az cognitiveservices account create \
+  -n launchstack-docintel -g launchstack-prod \
+  --kind FormRecognizer --sku F0 -l eastus2 --yes
+
+az storage account create -n <unique-name> -g launchstack-prod -l eastus2 \
+  --sku Standard_LRS --kind StorageV2 --access-tier Cool --allow-blob-public-access false
+az storage container create -n db-backups --account-name <unique-name>
+```
+
+---
+
+## Step 2 — Install the stack on the VM
+
+```bash
+ssh launchstack@<PUBLIC_IP>
+git clone --depth 1 https://github.com/Deodat-Lawson/LaunchStack.git
+```
+
+Copy `docker-compose.prod.yml` and `docker/Caddyfile.prod` up if you are ahead
+of what is committed on `main`.
+
+---
+
+## Step 3 — Configure `.env`
+
+Create `/home/launchstack/LaunchStack/.env` (mode `600`, never committed).
+
+**Generate every internal secret** — do not ship the `pdr_local_*` defaults from
+`docker-compose.yml`. They exist so `make up` works locally and are marked
+"override in production" for good reason:
+
+```bash
+openssl rand -hex 24    # one per secret below
+```
+
+| Variable | Notes |
+|---|---|
+| `DOMAIN` | The hostname you serve from. `files.$DOMAIN` is derived from it. |
+| `POSTGRES_PASSWORD` | Also authenticates SeaweedFS's filer store — see [Troubleshooting](#seaweedfs-wont-start-failed-sasl-auth). |
+| `S3_ACCESS_KEY` / `S3_SECRET_KEY` / `S3_BUCKET_NAME` / `S3_REGION` | SeaweedFS credentials. |
+| `TRANSCRIPTION_SERVICE_API_KEY`, `ADEU_SERVICE_API_KEY`, `DOCUMENT_CONVERTER_API_KEY` | Each service authenticates fail-closed; a mismatch returns 401 on every call. |
+| `FILE_ACCESS_TOKEN_SECRET` | Signs internal `/api/files` URLs. **App and worker must share one value**, or database-backed ingestion fails closed. |
+| `EMAIL_UNSUBSCRIBE_SECRET` | Min 16 chars; required to send email campaigns. |
+| `METRICS_SCRAPE_TOKEN` | Bearer token for `/api/metrics`; unset means the route fails closed at 503. |
+
+**Required third-party credentials** (the app will not boot without the first
+three):
+
+| Variable | Notes |
+|---|---|
+| `BETTER_AUTH_SECRET` | **Required — the app will not boot without it.** Signs session cookies and verification tokens: `openssl rand -base64 32`. Rotating it invalidates every live session. |
+| `BETTER_AUTH_URL` | The public origin (`https://$DOMAIN`). Optional in dev; set it behind a proxy so callback URLs and trusted origins resolve to the outside hostname. |
+| `GOTENBERG_SERVICE_PASSWORD` | Basic-auth password for the PDF-rendering service (ADR-009). Fails closed like the other services — override the local default. |
+| `CHAT_BASE_URL` (+ `CHAT_API_KEY`) | One OpenAI-compatible endpoint. Model IDs live in `apps/web/config/chat-models.yaml`, not env vars. |
+| `OPENAI_API_KEY` | Backs embeddings and other non-chat capabilities. Never used for chat. |
+| `GOOGLE_AI_API_KEY` | Cloud transcription defaults to Gemini. Alternatively set `TRANSCRIPTION_API_BASE_URL` + `TRANSCRIPTION_API_KEY` to any OpenAI-compatible endpoint. |
+
+**Lean-stack specifics:**
+
+```bash
+OCR_DEFAULT_PROVIDER=AZURE
+AZURE_DOC_INTELLIGENCE_ENDPOINT=https://<name>.cognitiveservices.azure.com/
+AZURE_DOC_INTELLIGENCE_KEY=<key>          # az cognitiveservices account keys list
+
+# SSRF allowlists must include the public files origin, or the document
+# services refuse to fetch objects by reference.
+CONVERTER_ALLOWED_FETCH_ORIGINS=http://app:3000,http://seaweedfs:8333,https://files.$DOMAIN
+ADEU_ALLOWED_FETCH_ORIGINS=http://app:3000,http://seaweedfs:8333,https://files.$DOMAIN
+
+DEPLOYMENT_MODE=self-hosted
+```
+
+**Optional — Inngest.** `INNGEST_EVENT_KEY` / `INNGEST_SIGNING_KEY` enable the
+background verticals (trend search, prospector, founder weekly review,
+predictive analysis, reindex). Document **ingestion does not need them** — that
+runs through the Postgres transactional outbox (ADR-003). Leave them empty and
+you get a warning at boot and a working instance. To enable, register the
+**worker's** `https://$DOMAIN/api/inngest` in Inngest Cloud; the app no longer
+serves that endpoint.
+
+---
+
+## Step 4 — Point DNS at the VM
+
+Using `sslip.io`, there is nothing to do: `<ip>.sslip.io` and
+`files.<ip>.sslip.io` already resolve.
+
+For your own domain, create two **A records** at your registrar:
+
+| Type | Name | Value |
+|---|---|---|
+| A | `app` | `<PUBLIC_IP>` |
+| A | `files.app` | `<PUBLIC_IP>` |
+
+Behind Cloudflare, set both to **DNS only** (grey cloud). Proxied records break
+the HTTP-01 challenge Caddy uses. Verify before continuing — certificate
+issuance will fail otherwise:
+
+```bash
+dig +short app.example.com files.app.example.com   # both must print the IP
+```
+
+---
+
+## Step 5 — Start it
+
+```bash
+cd ~/LaunchStack
+docker compose -f docker-compose.yml -f docker-compose.prod.yml --env-file .env up -d
+```
+
+Order is handled for you: Postgres becomes healthy, the one-shot `migrate`
+service applies the ordered SQL migrations and exits, then the app and worker
+start. **Nothing applies schema on container boot** — migrations only ever run
+through that service.
+
+Caddy then obtains Let's Encrypt certificates for both hostnames, usually within
+30 seconds of first start.
+
+---
+
+## Step 6 — Verify
+
+```bash
+# From anywhere — expect a 307 to /signin and a valid certificate
+curl -sS -o /dev/null -w "%{http_code} %{ssl_verify_result}\n" https://$DOMAIN/
+
+# On the VM — every service up, migrate exited 0
+docker compose -f docker-compose.yml -f docker-compose.prod.yml --env-file .env ps -a
+docker exec pdr_ai_v2-worker wget -qO- http://localhost:8020/healthz    # {"status":"ok"}
+```
+
+Then in a browser:
+
+1. Open `https://$DOMAIN` — you should get the sign-in page with a padlock.
+2. **Sign up immediately.** The first account to register becomes the workspace
+   owner, already verified, with no approval step. Do this before sharing the
+   URL.
+3. Upload a small PDF at `/employer/upload`. The returned URL should be
+   `https://files.$DOMAIN/<bucket>/documents/…` and should download when opened.
+4. If the upload is processed rather than just stored, the whole chain — app,
+   outbox, worker, storage, OCR — is confirmed.
+
+---
+
+## Deploying updates
+
+Images publish to GHCR on every push to `main`.
+
+```bash
+ssh launchstack@<PUBLIC_IP> 'cd LaunchStack && git pull && \
+  docker compose -f docker-compose.yml -f docker-compose.prod.yml --env-file .env pull app worker && \
+  docker compose -f docker-compose.yml -f docker-compose.prod.yml --env-file .env up -d --build'
+```
+
+`--build` rebuilds `migrate` (so new migrations apply) and the two Python
+services when their sources changed. After changing `.env`, add
+`--force-recreate app worker` — Compose does not restart containers for env
+changes on its own.
+
+---
+
+## Secrets: Azure Key Vault
+
+`.env` on the VM is a **derived artifact**. The source of record is Key Vault
+`launchstack-kv-a9be20`, which holds 29 secrets (empty-valued variables are not
+stored — Key Vault rejects empty values, and Compose treats absent and empty
+identically through its `${VAR:-}` defaults).
+
+Nothing in the application changed for this. Compose cannot read Key Vault and
+the app reads plain environment variables, so rather than touch application
+code, a script regenerates the `.env` Compose already consumes.
+
+**No credential is stored on the VM.** The VM has a system-assigned managed
+identity (`55e2e28d-7476-48db-b199-2e8c8b68a8aa`) holding exactly one role on
+the vault — `Key Vault Secrets User`, read-only. The token comes from IMDS
+(`169.254.169.254`), which only answers processes on that machine. Writes are
+refused with HTTP 403; the seeding step used a temporary
+`Key Vault Secrets Officer` grant that has since been revoked.
+
+Regenerate `.env` before bringing the stack up:
+
+```bash
+python3 ~/sync-env-from-keyvault.py launchstack-kv-a9be20
+```
+
+It writes atomically via a temp file, saves the previous copy as `.env.bak`,
+chmods 600, and **fails without touching the existing file** if the vault is
+unreachable — a stale `.env` still boots the stack, a truncated one does not.
+
+Note that running containers do **not** re-read `.env`; Compose bakes the
+environment in at container creation. So syncing matters immediately before a
+`docker compose up`, not on reboot.
+
+To change a secret, set the new value in Key Vault, re-run the sync, and
+recreate the affected services:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.prod.yml --env-file .env \
+  up -d --force-recreate app worker
+```
+
+Key Vault secret names allow `[0-9a-zA-Z-]` only, so `FOO_BAR` is stored as
+`FOO-BAR` and mapped back on read. Environment variable names cannot contain
+dashes, so the reverse mapping is unambiguous.
+
+## Backups and restore
+
+`/home/launchstack/backup-db.sh` runs nightly at **03:10 UTC** via cron: it
+pipes `pg_dump` of `pdr_ai_v2` through gzip into the `db-backups` container
+using a **write-only SAS token** (valid ~2 years — rotate before mid-2028). A
+storage lifecycle policy deletes blobs after 30 days. Check `~/backup.log`.
+
+Restore:
+
+```bash
+az storage blob download --account-name <acct> -c db-backups \
+  -n launchstack-db-<DATE>.sql.gz -f - | gunzip | \
+  docker exec -i pdr_ai_v2-postgres psql -U postgres pdr_ai_v2
+```
+
+**Scope caveat:** this backs up Postgres only. Uploaded source files live in
+SeaweedFS on the VM disk and are **not** included — extracted evidence and all
+application data survive a restore, but original uploads would not. Acceptable
+early on; revisit when originals become irreplaceable.
+
+---
+
+## Moving to your own domain
+
+1. Create the two A records (Step 4) and confirm with `dig`.
+2. On the VM, rewrite the hostname everywhere it appears:
+
+   ```bash
+   cd ~/LaunchStack
+   sed -i "s/20.110.112.248.sslip.io/app.example.com/g" .env
+   docker compose -f docker-compose.yml -f docker-compose.prod.yml --env-file .env up -d \
+     --force-recreate app worker caddy
+   ```
+
+   That one substitution covers `DOMAIN`, the public S3 endpoint, and both SSRF
+   allowlists.
+3. Update `BETTER_AUTH_URL` to the new origin in the same pass — it is one of
+   the values the substitution above rewrites.
+
+Objects already stored keep URLs on the old hostname. Keep the old DNS record
+alive, or rewrite `document_versions.url` if you migrate before real traffic.
+
+---
+
+## Scaling up later
+
+- **Whisper back on-box:** `--profile whisper` plus
+  `TRANSCRIPTION_PROVIDER=sidecar`. Budget ~1.5 GB.
+- **Docling back on-box:** `--profile ocr` plus `OCR_DEFAULT_PROVIDER=DOCLING`.
+  Budget ~1.2 GB.
+- Either one needs a bigger VM first: stop it, `az vm resize -g launchstack-prod
+  -n launchstack-vm --size Standard_D4as_v7` (16 GB), start it.
+- **Document Intelligence** F0 caps at 500 pages/month. Upgrade in place:
+  `az cognitiveservices account update -n launchstack-docintel -g launchstack-prod --sku S0`.
+- **Managed Postgres** (Azure Flexible Server, ~$15/mo and up) is the first
+  upgrade worth buying once you have users whose data you cannot lose — it
+  brings real backups and point-in-time restore.
+
+---
+
+## Troubleshooting
+
+### SeaweedFS won't start (`failed SASL auth`)
+
+SeaweedFS keeps its filer metadata in Postgres, and `docker/filer.toml` is
+mounted read-only, so its `password` line can only ever hold the local default.
+The real credential comes from `WEED_POSTGRES_PASSWORD`, which
+`docker-compose.yml` sets from `POSTGRES_PASSWORD` (SeaweedFS overlays any
+`filer.toml` key from `WEED_<SECTION>_<KEY>`). Without it, **every deployment
+using a real password** crash-loops here and object storage never comes up,
+while the rest of the stack looks healthy — the visible symptom is a 502 from
+`files.$DOMAIN`.
+
+If you hit it, confirm the filer's database survived (it is created by
+`docker/init-db.sql` on first initialisation only):
+
+```bash
+docker exec pdr_ai_v2-postgres psql -U postgres -tAc \
+  "SELECT datname FROM pg_database WHERE datname='seaweedfs'"
+docker exec pdr_ai_v2-postgres psql -U postgres -d seaweedfs -tAc \
+  "SELECT tablename FROM pg_tables WHERE tablename='filemeta'"
+```
+
+Both must return a row. If they do not, the volume was initialised before
+`init-db.sql` existed — create them by hand from that file rather than wiping
+the volume.
+
+### Certificates aren't issued
+
+`docker logs pdr_ai_v2-caddy --tail 30`. Nearly always DNS: the record does not
+resolve yet, or it is proxied through Cloudflare. Caddy retries on its own once
+DNS is correct.
+
+### Uploads accepted but never processed
+
+Ingestion is the worker's job, not the app's. Check
+`docker exec pdr_ai_v2-worker wget -qO- http://localhost:8020/healthz` and see
+[`docs/runbooks/outbox.md`](./outbox.md) for inspecting and replaying outbox
+rows.
+
+### `Cannot load "@napi-rs/canvas"` in the app log
+
+Benign. pdf.js looks for an optional native canvas for server-side rendering;
+the same warnings appear in local development.
+
+### Transcription or OCR returns "API key not configured"
+
+Base URL and key are read as a **pair** at every level. Forwarding a model name
+or a lone key is not enough — without its base URL, a capability falls through
+to that error at call time.
+
+---
+
+## Cost
+
+| Item | Monthly |
+|---|---|
+| VM (D2as_v7, pay-as-you-go) | ~$62–70 |
+| Managed disk (64 GB StandardSSD) | ~$5 |
+| Static public IP | ~$4 |
+| Backup storage (Cool, small) | ~$1 |
+| Document Intelligence F0 | $0 (500 pages/mo) |
+| **Total** | **~$72** |
+
+After a month of stable running, a 1-year reservation or savings plan takes the
+VM down by roughly a third (~$51/mo all-in). Microsoft for Startups Founders Hub
+grants $1,000 in Azure credits at the entry tier with no funding requirement —
+enough to cover this for over a year.
+
+---
+
+## Relationship to Vercel
+
+`apps/landing` (the marketing site) is a separate application with no deploy
+pipeline in this repo, and it is deliberately **not** part of a self-hosted
+deployment. Keeping it on Vercel is the intended split:
+
+- `example.com` → landing site on Vercel
+- `app.example.com` → this stack on the Azure VM
+
+Point the landing site's sign-in links at the app with `NEXT_PUBLIC_APP_URL`,
+and set `NEXT_PUBLIC_SITE_URL` on the app to the landing origin. On a
+self-hosted instance `/` redirects to `/signin`, so the app never tries to serve
+marketing pages itself.
+
+Running `apps/web` **on** Vercel is a different architecture, not a config flag:
+Postgres, the S3 endpoint, and all three compute services would have to be
+publicly exposed over TLS with connection pooling in front of the database. The
+lean VM stack exists to avoid exactly that.

--- a/scripts/ci/check-dockerfile-manifests.mjs
+++ b/scripts/ci/check-dockerfile-manifests.mjs
@@ -13,6 +13,13 @@
  * That is exactly how `packages/google-drive` broke the image build with
  * "Cannot find module 'zod'" while its package.json declared zod all along.
  *
+ * The reverse is just as easy to get wrong and fails harder: renaming or
+ * removing a package leaves a COPY pointing at a path that no longer exists,
+ * and BuildKit aborts immediately with
+ *   failed to compute cache key: "/packages/<name>/package.json": not found
+ * That is how the `packages/search` -> `packages/retrieval` rename broke both
+ * images. So this checks both directions.
+ *
  * Run:
  *   node scripts/ci/check-dockerfile-manifests.mjs
  *
@@ -66,17 +73,41 @@ for (const dockerfile of DOCKERFILES) {
     }
 }
 
-if (failures.length > 0) {
-    console.error(
-        `[check-dockerfile-manifests] ${failures.length} workspace manifest(s) missing from a Dockerfile deps layer:`
-    );
-    for (const { dockerfile, manifest } of failures) {
-        console.error(`  ✗ ${dockerfile} — add: COPY ${manifest} ./${manifest.slice(0, manifest.lastIndexOf("/"))}/`);
+// Reverse direction: a COPY naming a path that no longer exists aborts the
+// build outright, so a rename must update the Dockerfiles in the same commit.
+const stale = [];
+for (const dockerfile of DOCKERFILES) {
+    const path = join(ROOT, dockerfile);
+    if (!existsSync(path)) continue;
+    for (const line of readFileSync(path, "utf8").split("\n")) {
+        const m = /^COPY\s+((?:packages|pipelines|apps)\/[^\s]*package\.json)\s/.exec(line.trim());
+        if (m && !existsSync(join(ROOT, m[1]))) {
+            stale.push({ dockerfile, manifest: m[1] });
+        }
     }
-    console.error(
-        "\nWithout the COPY, pnpm installs a workspace that is missing this member and the\n" +
-            "image build fails later with an unresolvable dependency the package does declare."
-    );
+}
+
+if (failures.length > 0 || stale.length > 0) {
+    for (const { dockerfile, manifest } of failures) {
+        console.error(
+            `  ✗ ${dockerfile} — missing, add: COPY ${manifest} ./${manifest.slice(0, manifest.lastIndexOf("/"))}/`
+        );
+    }
+    for (const { dockerfile, manifest } of stale) {
+        console.error(`  ✗ ${dockerfile} — stale, no such path: COPY ${manifest} (renamed or removed?)`);
+    }
+    if (failures.length > 0) {
+        console.error(
+            "\nA missing COPY makes pnpm install a workspace without that member; the image\n" +
+                "build then fails with an unresolvable dependency the package does declare."
+        );
+    }
+    if (stale.length > 0) {
+        console.error(
+            "\nA stale COPY aborts the build immediately with\n" +
+                '  failed to compute cache key: "/<path>": not found'
+        );
+    }
     process.exit(1);
 }
 

--- a/scripts/ci/check-dockerfile-manifests.mjs
+++ b/scripts/ci/check-dockerfile-manifests.mjs
@@ -29,7 +29,11 @@ import { readFileSync, readdirSync, existsSync } from "node:fs";
 import { join, resolve as resolvePath } from "node:path";
 
 const ROOT = resolvePath(import.meta.dirname, "../..");
-const DOCKERFILES = ["apps/web/Dockerfile", "apps/worker/Dockerfile"];
+const DOCKERFILES = [
+    "apps/web/Dockerfile",
+    "apps/web/Dockerfile.prebuilt",
+    "apps/worker/Dockerfile",
+];
 
 /** Workspace dirs that ship a package.json, as the Dockerfiles address them. */
 function workspaceManifests() {


### PR DESCRIPTION
Everything needed to run this stack in production on a single VM, plus the bug that deployment surfaced.

Five commits, each independently reviewable — the first is a bug fix that stands on its own merits regardless of whether you want the rest.

## 1 · `fix:` the SeaweedFS filer authenticates with the real Postgres password

**This affects every self-hosted deployment, not just ours.**

`docker/filer.toml` is mounted read-only, so its `password = "password"` line can only ever carry the local default. SeaweedFS keeps filer metadata in Postgres, so any deployment that sets a real `POSTGRES_PASSWORD` — that is, every production one — fails authentication:

```
FATAL: password authentication failed for user "postgres" (SQLSTATE 28P01)
```

SeaweedFS then exits, and because that service carries no restart policy it stays down while the app, worker, database and both document services keep reporting healthy. The only visible symptom is a 502 from the file origin, which nothing alerts on. Uploads are accepted and stored; every read of a stored object fails.

SeaweedFS overlays any `filer.toml` key from `WEED_<SECTION>_<KEY>`, so the fix is to pass `WEED_POSTGRES_PASSWORD` from `POSTGRES_PASSWORD`. The literal stays as the local-default fallback, now documented as such. Verified backward compatible: with no `.env`, it still resolves to `password`.

Found on a live deployment where object storage had been crash-looping for two days behind an otherwise-green `docker compose ps`.

## 2 · `feat:` production Compose overlay and deployment runbook

The repo documents Compose as the deployment path but ships only the local stack, so every production deploy re-derives the same overrides by hand.

`docker-compose.prod.yml` layers over the base file: GHCR images instead of host builds, no self-hosted Whisper and no Docling (the two heaviest containers, ~2.7 GB resident, move behind opt-in profiles so an 8 GB host suffices), no Inngest dev server, Caddy terminating TLS for `$DOMAIN` and `files.$DOMAIN`, and no host ports published except Caddy's. `seaweedfs` also gains `restart: unless-stopped` — it was the only service without one.

`docs/runbooks/azure-lean-deploy.md` is the full guide: provisioning from an empty subscription, every environment variable and what breaks when it is wrong, DNS and TLS, updates, backup and restore, moving to a real domain, scaling Whisper/Docling back on-box, Key Vault for secrets, and troubleshooting. Written against a live deployment, so its failure modes are ones that actually happened.

Verified the overlay composes cleanly against current `main`, including the new `gotenberg` service from ADR-009, and that only Caddy publishes host ports.

## 3 · `docs:` self-host readiness design (draft)

Proposes four workstreams to close the *class* of defect commit 1 belongs to — configuration that cannot reach the component it configures, and fails silently when it doesn't. Preflight validation, the no-hand-mirrored-config rule, completing the `StoragePort` seam so object storage is a choice rather than a fork, and deployment ergonomics.

Status is Draft with no approved brief, which the template forbids; §9 records that as the first open question rather than papering over it.

## 4 · `config:` chat routes to Gemini 3.7 Flash

`primary`/`vision` → `google/gemini-3.7-flash`, `fast` → `google/gemini-3.5-flash-lite`, `reasoning` unchanged on 2.5 Pro (no 3.7-generation Pro is published). The 3.x models have no preset entry, so both declare behavior in full. Every model id was exercised against the configured endpoint before landing.

**This changes the default for local development too.** Drop this commit if local dev should stay on 2.5.

## 5 · `docs:` placeholders for deployment-specific identifiers

The runbook was written against a live instance and named its resource group, VM, IP, admin user, Key Vault, storage account and managed-identity object ID. None are credentials, but this is a public repository — replaced with an inventory table the operator fills in once, which also makes the guide usable by anyone else.

## Notes

- Nothing here changes the local stack. `docker compose -f docker-compose.yml config` still resolves all ten services, and `WEED_POSTGRES_PASSWORD` defaults to `password` exactly as before.
- Deploying `main` after this still needs `BETTER_AUTH_SECRET` set before the app will boot — it is `requiredString()` since the better-auth migration. That is a separate planned cutover, covered in the runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> SeaweedFS and production Compose/TLS changes affect every self-hosted deploy; default chat model config also changes local dev behavior unless overridden.
> 
> **Overview**
> Fixes a **production-breaking SeaweedFS bug**: filer Postgres auth used a hardcoded password in mounted `filer.toml`, so any real `POSTGRES_PASSWORD` caused silent object-storage failure while the rest of the stack looked healthy. Compose now sets **`WEED_POSTGRES_PASSWORD`** from `POSTGRES_PASSWORD`, with docs in `filer.toml` and the new runbook.
> 
> Adds **`docker-compose.prod.yml`** and **`docker/Caddyfile.prod`** for single-VM production: GHCR images, Caddy TLS for app and `files.$DOMAIN`, Inngest dev/Whisper behind profiles, tightened ports/restart policy, and public URL env for app/worker.
> 
> Ships **`docs/runbooks/azure-lean-deploy.md`** (end-to-end lean deploy) and a draft **`docs/design/self-host-readiness.md`** (preflight, config mirroring, storage seam). **`docs/deployment.md`** points at the prod overlay.
> 
> **Docker/CI**: Dockerfiles swap `packages/search` → **`packages/retrieval`**; prebuilt deps layer gains missing workspace COPYs; **`check-dockerfile-manifests.mjs`** covers `Dockerfile.prebuilt` and **stale COPY** paths; CI **`next build`** gets a placeholder **`BETTER_AUTH_SECRET`**.
> 
> **`apps/web/config/chat-models.yaml`** moves default chat to **Gemini 3.7 / 3.5-lite** with explicit `behavior` blocks (reasoning tier stays on 2.5 Pro preset).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ff7f639d97f0d0f6e0e0df1e3b50ca9edcf4874. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


---

## Added after review of CI (commits 6–7)

Opening this PR surfaced that `main`'s image builds were broken again, for a reason the guard from #370 did not catch. Both are fixed here.

**`packages/search` was renamed to `packages/retrieval`**, and all three Dockerfiles still `COPY` the old path. BuildKit aborts before anything compiles:

```
failed to compute cache key: "/packages/search/package.json": not found
```

The #370 guard only checked one direction — every workspace package appears in the Dockerfiles — so it correctly flagged the *missing* `retrieval` and said nothing about the *stale* `search` that was actually breaking the build. It now checks both, and reports them separately because they fail at different points:

| | symptom |
|---|---|
| missing COPY | pnpm resolves a workspace without that member; fails later on an unresolvable declared dependency |
| stale COPY | build aborts immediately on the missing path |

**`apps/web/Dockerfile.prebuilt` keeps its own copy of the same list**, and the guard was not looking at it — so it reported "ok" while that image aborted. All three Dockerfiles are now covered; any file maintaining such a list has to be in the guard's list or the guard is only as good as who remembered to add it.

Also sets `BETTER_AUTH_SECRET` for the prebuilt build step. That job builds the Next app on the host, where better-auth throws on the default secret, and `SKIP_ENV_VALIDATION` only bypasses the zod schema rather than better-auth's own check. `CI.yml`'s `check` job already sets a placeholder; this one was missed when auth changed.

## CI status

| | `main` | this PR |
|---|---|---|
| `check` | **fail** | **pass** |
| docker `build` (web + worker) | **fail** | **pass** |
| `Build prebuilt runner` | fail | **pass** |
| `compose-smoke` | fail | fail *(pre-existing)* |
| `migrations-apply` | fail | fail *(pre-existing)* |

`compose-smoke` and `migrations-apply` ("Assert the two schemas are identical") fail identically on `main` and are untouched by this branch — `main` is red on schema drift as well as on the image build, and only the latter is in scope here.
