### PR TITLE
docs: keep the firewall posture in the runbook inventory

### DIFF
--- a/docs/runbooks/azure-lean-deploy.md
+++ b/docs/runbooks/azure-lean-deploy.md
@@ -29,6 +29,7 @@ below use these names.
 | VM | `<VM_NAME>` — Standard_D2as_v7 (2 vCPU / 8 GB), Ubuntu 24.04 |
 | Public IP | `<PUBLIC_IP>` (static) |
 | SSH | `ssh <ADMIN_USER>@<PUBLIC_IP>` |
+| Open ports | 22, 80, 443 (Azure NSG) — nothing else is reachable from outside |
 | Stack location | `/home/<ADMIN_USER>/LaunchStack` |
 | OCR | `<DOCINTEL_NAME>` — Azure Document Intelligence, F0 free tier (500 pages/month) |
 | Secrets | Key Vault `<VAULT_NAME>` |


### PR DESCRIPTION
Follow-up to #372, which merged while this was in flight.

## What changed

One row restored to the runbook's inventory table:

```
| Open ports | 22, 80, 443 (Azure NSG) — nothing else is reachable from outside |
```

## Why

#372 replaced the live-instance table with a placeholder inventory so a public repo wouldn't carry one deployment's resource names. The open-ports row was dropped in that pass.

It's worth stating explicitly rather than leaving a reader to infer it from the `az vm open-port` call in the provisioning section. `docker-compose.prod.yml` deliberately publishes no host ports except Caddy's, and the reasoning behind that only lands if the reader also knows the NSG admits nothing else — the two facts are the same decision expressed at different layers.

Documentation only; no behavior change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the Azure lean deploy runbook; no application or infrastructure behavior is modified.
> 
> **Overview**
> **Restores firewall posture to the deployment inventory table** in `docs/runbooks/azure-lean-deploy.md`, after it was dropped when live resource names were replaced with placeholders (#372).
> 
> The new row documents that **only ports 22, 80, and 443** are exposed via the Azure NSG and that **no other services are reachable from the internet**. That makes the edge policy explicit alongside the existing `az vm open-port` step (80/443) and the prod Compose overlay that publishes host ports only through Caddy—documentation only, no runtime change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit caaf464e7ad7e7361a67cfb12a7ba28ca61756b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->