### PR TITLE
fix: let a new account create its first workspace (401 on embedding-indexes, editable available workspace name)

### DIFF
--- a/apps/web/__tests__/lib/workspace-name.test.ts
+++ b/apps/web/__tests__/lib/workspace-name.test.ts
@@ -1,0 +1,64 @@
+import { generateUniqueCompanyName } from "~/lib/workspace-slug";
+
+const mockSelect = jest.fn();
+let queuedRows: unknown[][] = [];
+
+jest.mock("~/server/db", () => ({
+    db: {
+        select: (...args: unknown[]) => mockSelect(...args),
+    },
+}));
+
+jest.mock("@launchstack/store/schema", () => ({
+    company: { id: "company.id", name: "company.name", slug: "company.slug" },
+}));
+
+jest.mock("drizzle-orm", () => ({
+    eq: (...args: unknown[]) => ({ op: "eq", args }),
+}));
+
+beforeEach(() => {
+    queuedRows = [];
+    mockSelect.mockReset();
+    // Each call resolves to the next queued result set.
+    mockSelect.mockImplementation(() => ({
+        from: () => ({
+            where: () => Promise.resolve(queuedRows.shift() ?? []),
+        }),
+    }));
+});
+
+describe("generateUniqueCompanyName", () => {
+    it("returns the name unchanged when nothing holds it", async () => {
+        queuedRows = [[]];
+        await expect(generateUniqueCompanyName("Timothy's workspace")).resolves.toBe(
+            "Timothy's workspace"
+        );
+    });
+
+    it("suffixes past a single collision", async () => {
+        queuedRows = [[{ id: 1 }], []];
+        await expect(generateUniqueCompanyName("Timothy's workspace")).resolves.toBe(
+            "Timothy's workspace 2"
+        );
+    });
+
+    it("keeps counting past consecutive collisions", async () => {
+        queuedRows = [[{ id: 1 }], [{ id: 2 }], [{ id: 3 }], []];
+        await expect(generateUniqueCompanyName("Timothy's workspace")).resolves.toBe(
+            "Timothy's workspace 4"
+        );
+    });
+
+    it("trims before comparing, so padding cannot smuggle a duplicate through", async () => {
+        queuedRows = [[]];
+        await expect(generateUniqueCompanyName("  Acme  ")).resolves.toBe("Acme");
+    });
+
+    it("gives up on a suffix rather than looping forever", async () => {
+        // 50 attempts all taken.
+        queuedRows = Array.from({ length: 50 }, () => [{ id: 1 }]);
+        const result = await generateUniqueCompanyName("Busy");
+        expect(result).toMatch(/^Busy \d{10,}$/);
+    });
+});

--- a/apps/web/__tests__/lib/workspace-name.test.ts
+++ b/apps/web/__tests__/lib/workspace-name.test.ts
@@ -1,4 +1,4 @@
-import { generateUniqueCompanyName } from "~/lib/workspace-slug";
+import { suggestAvailableCompanyName } from "~/lib/workspace-slug";
 
 const mockSelect = jest.fn();
 let queuedRows: unknown[][] = [];
@@ -17,48 +17,60 @@ jest.mock("drizzle-orm", () => ({
     eq: (...args: unknown[]) => ({ op: "eq", args }),
 }));
 
+const TAKEN = [{ id: 1 }];
+const FREE: unknown[] = [];
+
 beforeEach(() => {
     queuedRows = [];
     mockSelect.mockReset();
-    // Each call resolves to the next queued result set.
     mockSelect.mockImplementation(() => ({
         from: () => ({
-            where: () => Promise.resolve(queuedRows.shift() ?? []),
+            where: () => Promise.resolve(queuedRows.shift() ?? FREE),
         }),
     }));
 });
 
-describe("generateUniqueCompanyName", () => {
-    it("returns the name unchanged when nothing holds it", async () => {
-        queuedRows = [[]];
-        await expect(generateUniqueCompanyName("Timothy's workspace")).resolves.toBe(
+describe("suggestAvailableCompanyName", () => {
+    it("keeps the preferred name when nobody holds it", async () => {
+        queuedRows = [FREE];
+        await expect(suggestAvailableCompanyName("Timothy's workspace")).resolves.toBe(
             "Timothy's workspace"
         );
     });
 
-    it("suffixes past a single collision", async () => {
-        queuedRows = [[{ id: 1 }], []];
-        await expect(generateUniqueCompanyName("Timothy's workspace")).resolves.toBe(
-            "Timothy's workspace 2"
-        );
+    it("appends a random token when the preferred name is taken", async () => {
+        queuedRows = [TAKEN, FREE];
+        const result = await suggestAvailableCompanyName("Timothy's workspace");
+        expect(result).toMatch(/^Timothy's workspace [a-hjkmnp-z2-9]{4}$/);
     });
 
-    it("keeps counting past consecutive collisions", async () => {
-        queuedRows = [[{ id: 1 }], [{ id: 2 }], [{ id: 3 }], []];
-        await expect(generateUniqueCompanyName("Timothy's workspace")).resolves.toBe(
-            "Timothy's workspace 4"
-        );
+    it("does not leak a count — two collisions do not produce a '2'", async () => {
+        queuedRows = [TAKEN, FREE];
+        const result = await suggestAvailableCompanyName("Acme");
+        expect(result).not.toBe("Acme 2");
+        expect(result.startsWith("Acme ")).toBe(true);
     });
 
-    it("trims before comparing, so padding cannot smuggle a duplicate through", async () => {
-        queuedRows = [[]];
-        await expect(generateUniqueCompanyName("  Acme  ")).resolves.toBe("Acme");
+    it("keeps drawing tokens while they collide", async () => {
+        queuedRows = [TAKEN, TAKEN, TAKEN, FREE];
+        const result = await suggestAvailableCompanyName("Busy");
+        expect(result).toMatch(/^Busy [a-hjkmnp-z2-9]{4}$/);
     });
 
-    it("gives up on a suffix rather than looping forever", async () => {
-        // 50 attempts all taken.
-        queuedRows = Array.from({ length: 50 }, () => [{ id: 1 }]);
-        const result = await generateUniqueCompanyName("Busy");
-        expect(result).toMatch(/^Busy \d{10,}$/);
+    it("trims the preferred name before checking", async () => {
+        queuedRows = [FREE];
+        await expect(suggestAvailableCompanyName("   Acme   ")).resolves.toBe("Acme");
+    });
+
+    it("falls back to a default when handed nothing usable", async () => {
+        queuedRows = [FREE];
+        await expect(suggestAvailableCompanyName("   ")).resolves.toBe("My workspace");
+    });
+
+    it("terminates rather than looping when every draw collides", async () => {
+        queuedRows = Array.from({ length: 13 }, () => TAKEN);
+        const result = await suggestAvailableCompanyName("Unlucky");
+        expect(result.startsWith("Unlucky ")).toBe(true);
+        expect(result.length).toBeGreaterThan("Unlucky ".length);
     });
 });

--- a/apps/web/src/app/api/embedding-indexes/route.ts
+++ b/apps/web/src/app/api/embedding-indexes/route.ts
@@ -5,7 +5,7 @@ import {
     type EmbeddingIndexConfig,
     type EmbeddingProvider,
 } from "@launchstack/llm/embeddings";
-import { requireWorkspaceContext } from "~/lib/require-workspace-context";
+import { requireAuthIdentity } from "~/lib/require-workspace-context";
 
 // "sidecar" is gone from EmbeddingProvider (ADR-004 §5 removed the phantom
 // sidecar embedding provider), so it has no label here either.
@@ -21,8 +21,13 @@ function humanLabel(index: EmbeddingIndexConfig): string {
 }
 
 export async function GET() {
-    const ctx = await requireWorkspaceContext();
-    if (!ctx.success) return ctx.response;
+    // Session only, deliberately: the signup page reads this list *before* the
+    // user has a workspace, so requiring one made the very first call of a new
+    // account's lifetime a guaranteed 401. The registry returned here is not
+    // workspace-scoped — getEmbeddingIndexRegistry() is called with no company
+    // config below — so the context was fetched and discarded anyway.
+    const identity = await requireAuthIdentity();
+    if (!identity.success) return identity.response;
 
     const indexes = getEmbeddingIndexRegistry()
         .filter(idx => idx.enabled)

--- a/apps/web/src/app/api/signup/employerCompany/route.ts
+++ b/apps/web/src/app/api/signup/employerCompany/route.ts
@@ -6,7 +6,7 @@ import { handleApiError, createSuccessResponse, createValidationError } from "~/
 import { ensureTokenAccount } from "~/lib/credits";
 import { validateRequestBody, EmployerCompanySignupSchema } from "~/lib/validation";
 import { upsertCompanyCredentials } from "@launchstack/llm/embeddings";
-import { generateUniqueSlug } from "~/lib/workspace-slug";
+import { generateUniqueSlug, generateUniqueCompanyName } from "~/lib/workspace-slug";
 import { requireAuthIdentity } from "~/lib/require-workspace-context";
 
 export async function POST(request: Request) {
@@ -26,27 +26,35 @@ export async function POST(request: Request) {
             embeddingHuggingFaceApiKey,
             embeddingOllamaBaseUrl,
             embeddingOllamaModel,
+            autoRenameOnConflict,
         } = validation.data;
         const userId = identity.data.authUserId;
 
-        // Check if company already exists
+        // Check if company already exists. Names are unique only by this
+        // check — the column carries no database constraint — so a caller that
+        // generated the name itself can ask for it to be uniquified instead of
+        // being turned away from a collision it cannot see or edit.
         const [existingCompany] = await db
             .select()
             .from(company)
             .where(eq(company.name, companyName));
 
-        if (existingCompany) {
+        if (existingCompany && !autoRenameOnConflict) {
             return createValidationError(
                 "Company already exists. Please use a different company name."
             );
         }
 
-        const slug = await generateUniqueSlug(companyName);
+        const resolvedCompanyName = existingCompany
+            ? await generateUniqueCompanyName(companyName)
+            : companyName;
+
+        const slug = await generateUniqueSlug(resolvedCompanyName);
 
         const [newCompany] = await db
             .insert(company)
             .values({
-                name: companyName,
+                name: resolvedCompanyName,
                 slug,
                 // `?? ""` first so the `||` default (which must also catch
                 // empty strings) operates on a plain string.

--- a/apps/web/src/app/api/signup/employerCompany/route.ts
+++ b/apps/web/src/app/api/signup/employerCompany/route.ts
@@ -6,7 +6,7 @@ import { handleApiError, createSuccessResponse, createValidationError } from "~/
 import { ensureTokenAccount } from "~/lib/credits";
 import { validateRequestBody, EmployerCompanySignupSchema } from "~/lib/validation";
 import { upsertCompanyCredentials } from "@launchstack/llm/embeddings";
-import { generateUniqueSlug, generateUniqueCompanyName } from "~/lib/workspace-slug";
+import { generateUniqueSlug } from "~/lib/workspace-slug";
 import { requireAuthIdentity } from "~/lib/require-workspace-context";
 
 export async function POST(request: Request) {
@@ -26,35 +26,30 @@ export async function POST(request: Request) {
             embeddingHuggingFaceApiKey,
             embeddingOllamaBaseUrl,
             embeddingOllamaModel,
-            autoRenameOnConflict,
         } = validation.data;
         const userId = identity.data.authUserId;
 
-        // Check if company already exists. Names are unique only by this
-        // check — the column carries no database constraint — so a caller that
-        // generated the name itself can ask for it to be uniquified instead of
-        // being turned away from a collision it cannot see or edit.
+        // Names are unique only by this check — the column carries no database
+        // constraint. The signup form pre-fills an available suggestion and
+        // lets the person edit it, so a conflict here is now something they
+        // can see and fix rather than a dead end.
         const [existingCompany] = await db
             .select()
             .from(company)
             .where(eq(company.name, companyName));
 
-        if (existingCompany && !autoRenameOnConflict) {
+        if (existingCompany) {
             return createValidationError(
                 "Company already exists. Please use a different company name."
             );
         }
 
-        const resolvedCompanyName = existingCompany
-            ? await generateUniqueCompanyName(companyName)
-            : companyName;
-
-        const slug = await generateUniqueSlug(resolvedCompanyName);
+        const slug = await generateUniqueSlug(companyName);
 
         const [newCompany] = await db
             .insert(company)
             .values({
-                name: resolvedCompanyName,
+                name: companyName,
                 slug,
                 // `?? ""` first so the `||` default (which must also catch
                 // empty strings) operates on a plain string.

--- a/apps/web/src/app/api/signup/workspace-name-suggestion/route.ts
+++ b/apps/web/src/app/api/signup/workspace-name-suggestion/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+
+import { requireAuthIdentity } from "~/lib/require-workspace-context";
+import { getServerSession } from "~/server/auth";
+import { suggestAvailableCompanyName } from "~/lib/workspace-slug";
+
+/**
+ * A workspace name the caller can actually use, for the signup form to
+ * pre-fill.
+ *
+ * Session-only, like the other signup-time routes: the caller has no
+ * workspace yet, which is the entire reason they are here.
+ *
+ * The suggestion is not reserved. It is a starting point for an editable
+ * field, not a claim.
+ */
+export async function GET() {
+    const identity = await requireAuthIdentity();
+    if (!identity.success) return identity.response;
+
+    const session = await getServerSession();
+    const displayName = session?.user?.name?.trim() ?? "";
+    const firstWord = displayName.split(/\s+/)[0] ?? "";
+    const preferred = firstWord.length > 0 ? `${firstWord}'s workspace` : "My workspace";
+
+    return NextResponse.json(
+        { name: await suggestAvailableCompanyName(preferred) },
+        { status: 200 }
+    );
+}

--- a/apps/web/src/app/signup/page.tsx
+++ b/apps/web/src/app/signup/page.tsx
@@ -192,6 +192,10 @@ const SignupPage: React.FC = () => {
                     companyName: workspaceName,
                     numberOfEmployees: "1",
                     embeddingIndexKey: defaultIndexKey,
+                    // This name is derived from the account's first name and
+                    // there is no field to edit it, so a collision with another
+                    // user's workspace must not be the user's problem.
+                    autoRenameOnConflict: true,
                 }),
             });
             if (!response.ok) {

--- a/apps/web/src/app/signup/page.tsx
+++ b/apps/web/src/app/signup/page.tsx
@@ -58,6 +58,10 @@ const SignupPage: React.FC = () => {
     // ── Solo flow ──
     const [isCreatingSolo, setIsCreatingSolo] = useState(false);
     const [soloError, setSoloError] = useState<string | null>(null);
+    // Pre-filled from the server with a name that is free at the time of
+    // asking, then owned by the person: they can rename it before creating.
+    const [soloWorkspaceName, setSoloWorkspaceName] = useState("");
+    const [isSuggestingName, setIsSuggestingName] = useState(true);
 
     // ── Invite flow ──
     const [inviteCode, setInviteCode] = useState("");
@@ -161,6 +165,32 @@ const SignupPage: React.FC = () => {
         [userId, user, router]
     );
 
+    // ── Suggest a workspace name that is actually available ──
+    useEffect(() => {
+        if (!isAuthLoaded || !userId) return;
+        let cancelled = false;
+        void (async () => {
+            try {
+                const res = await fetch("/api/signup/workspace-name-suggestion");
+                if (!res.ok) throw new Error(String(res.status));
+                const data = (await res.json()) as { name?: string };
+                if (!cancelled && data.name) setSoloWorkspaceName(data.name);
+            } catch {
+                // A suggestion is a convenience, not a gate. Fall back to the
+                // local guess and let the server reject it if it is taken.
+                if (!cancelled) {
+                    const first = (user?.name ?? "").trim().split(/\s+/)[0];
+                    setSoloWorkspaceName(first ? `${first}'s workspace` : "My workspace");
+                }
+            } finally {
+                if (!cancelled) setIsSuggestingName(false);
+            }
+        })();
+        return () => {
+            cancelled = true;
+        };
+    }, [isAuthLoaded, userId, user]);
+
     // ── Auto-join when arriving via ?code=XYZ ──
     useEffect(() => {
         if (!isAuthLoaded || autoJoinTriggered.current) return;
@@ -177,11 +207,13 @@ const SignupPage: React.FC = () => {
     // ── Solo: one-click workspace creation ──
     const startSolo = async () => {
         if (!userId || !user) return;
+        const workspaceName = soloWorkspaceName.trim();
+        if (!workspaceName) {
+            setSoloError("Give your workspace a name.");
+            return;
+        }
         setSoloError(null);
         setIsCreatingSolo(true);
-        const firstWord = user.name.trim().split(/\s+/)[0];
-        const firstName = firstWord?.length ? firstWord : "Personal";
-        const workspaceName = `${firstName}'s workspace`;
         try {
             const response = await fetch("/api/signup/employerCompany", {
                 method: "POST",
@@ -192,10 +224,6 @@ const SignupPage: React.FC = () => {
                     companyName: workspaceName,
                     numberOfEmployees: "1",
                     embeddingIndexKey: defaultIndexKey,
-                    // This name is derived from the account's first name and
-                    // there is no field to edit it, so a collision with another
-                    // user's workspace must not be the user's problem.
-                    autoRenameOnConflict: true,
                 }),
             });
             if (!response.ok) {
@@ -342,7 +370,9 @@ const SignupPage: React.FC = () => {
 
                     {mode === "solo" && (
                         <SoloCard
-                            workspaceName={soloName ? `${soloName}'s workspace` : "Your workspace"}
+                            workspaceName={soloWorkspaceName}
+                            onWorkspaceNameChange={setSoloWorkspaceName}
+                            isSuggesting={isSuggestingName}
                             onStart={() => void startSolo()}
                             isCreating={isCreatingSolo}
                             error={soloError}
@@ -633,11 +663,15 @@ function ModeSelect({ mode, setMode }: { mode: Mode; setMode: (m: Mode) => void 
 
 function SoloCard({
     workspaceName,
+    onWorkspaceNameChange,
+    isSuggesting,
     onStart,
     isCreating,
     error,
 }: {
     workspaceName: string;
+    onWorkspaceNameChange: (v: string) => void;
+    isSuggesting: boolean;
     onStart: () => void;
     isCreating: boolean;
     error: string | null;
@@ -676,20 +710,38 @@ function SoloCard({
                     marginBottom: 14,
                 }}
             >
-                We&apos;ll spin up{" "}
-                <span
-                    style={{
-                        color: "var(--ink-2)",
-                        fontWeight: 600,
-                    }}
-                >
-                    {workspaceName}
-                </span>{" "}
-                for you. No billing, no team setup — just you, your sources, and an AI that knows
-                them.
+                No billing, no team setup — just you, your sources, and an AI that knows them. Name
+                it whatever you like; you can change it later.
             </div>
+            <label
+                htmlFor="solo-workspace-name"
+                style={{
+                    display: "block",
+                    fontSize: 12,
+                    fontWeight: 600,
+                    color: "var(--ink-2)",
+                    marginBottom: 6,
+                }}
+            >
+                Workspace name
+            </label>
+            <input
+                id="solo-workspace-name"
+                value={workspaceName}
+                onChange={e => onWorkspaceNameChange(e.target.value)}
+                disabled={isSuggesting || isCreating}
+                placeholder={isSuggesting ? "Finding an available name…" : "My workspace"}
+                maxLength={256}
+                style={{ ...inputStyle, marginBottom: 14 }}
+            />
             {error && <ErrorBanner>{error}</ErrorBanner>}
-            <button onClick={onStart} disabled={isCreating} style={primaryButtonStyle(isCreating)}>
+            <button
+                onClick={onStart}
+                disabled={isCreating || isSuggesting || workspaceName.trim().length === 0}
+                style={primaryButtonStyle(
+                    isCreating || isSuggesting || workspaceName.trim().length === 0
+                )}
+            >
                 {isCreating ? (
                     <>
                         <Spinner /> Setting things up…

--- a/apps/web/src/lib/validation.ts
+++ b/apps/web/src/lib/validation.ts
@@ -313,13 +313,6 @@ export const EmployerCompanySignupSchema = z.object({
     embeddingHuggingFaceApiKey: z.string().nullish(),
     embeddingOllamaBaseUrl: z.string().nullish(),
     embeddingOllamaModel: z.string().nullish(),
-    /**
-     * Set only by callers that generated the name themselves and give the user
-     * no way to change it (the solo signup path). A hand-typed name still gets
-     * the "already exists" error, which is the useful answer when someone chose
-     * the word.
-     */
-    autoRenameOnConflict: z.boolean().optional().default(false),
 });
 
 export const EmployerSignupSchema = z.object({

--- a/apps/web/src/lib/validation.ts
+++ b/apps/web/src/lib/validation.ts
@@ -313,6 +313,13 @@ export const EmployerCompanySignupSchema = z.object({
     embeddingHuggingFaceApiKey: z.string().nullish(),
     embeddingOllamaBaseUrl: z.string().nullish(),
     embeddingOllamaModel: z.string().nullish(),
+    /**
+     * Set only by callers that generated the name themselves and give the user
+     * no way to change it (the solo signup path). A hand-typed name still gets
+     * the "already exists" error, which is the useful answer when someone chose
+     * the word.
+     */
+    autoRenameOnConflict: z.boolean().optional().default(false),
 });
 
 export const EmployerSignupSchema = z.object({

--- a/apps/web/src/lib/workspace-slug.ts
+++ b/apps/web/src/lib/workspace-slug.ts
@@ -7,6 +7,8 @@
  * on collision.
  */
 
+import { randomBytes } from "node:crypto";
+
 import { eq } from "drizzle-orm";
 
 import { db } from "~/server/db";
@@ -46,33 +48,49 @@ export async function generateUniqueSlug(name: string): Promise<string> {
 }
 
 /**
- * Pick a workspace *name* that no company is using yet, suffixing on
- * collision the way `generateUniqueSlug` does for the handle.
+ * Suggest a workspace name nobody is using yet.
  *
- * Only for names the user did not choose. The solo signup path derives
- * "<FirstName>'s workspace" and offers no field to edit it, so a collision
- * there is unresolvable by the person hitting it — two users named Timothy on
- * the same instance and the second can never create a solo workspace. When a
- * name was typed by hand, the caller should keep reporting the conflict
- * instead: silently renaming what someone deliberately entered is worse than
- * telling them it is taken.
+ * The signup form pre-fills this and the person can edit it, so the job here
+ * is only to hand them a starting point that will not be rejected. The
+ * preferred name is their own ("Timothy's workspace"); when that is taken —
+ * two users sharing a first name is ordinary, not exotic — a short random
+ * token is appended rather than a counter, so the suggestion says nothing
+ * about how many workspaces exist or what they are called.
  *
- * Note company.name carries no database uniqueness constraint — only
- * company.slug must be unique. This mirrors the route's application-level
- * check rather than any storage rule.
+ * Availability is checked, not assumed, but it is still a suggestion: nothing
+ * reserves the name, so a slow form and an unlucky collision can still be
+ * refused at submit. That is fine — the field is editable, so the error is
+ * something the person can act on.
+ *
+ * Note company.name has no uniqueness constraint in the database; only
+ * company.slug does. This mirrors the signup route's application-level check.
  */
-export async function generateUniqueCompanyName(name: string): Promise<string> {
-    const base = name.trim();
-    let candidate = base;
-    let n = 1;
-    for (let attempt = 0; attempt < 50; attempt++) {
-        const [existing] = await db
-            .select({ id: company.id })
-            .from(company)
-            .where(eq(company.name, candidate));
-        if (!existing) return candidate;
-        n += 1;
-        candidate = `${base} ${n}`;
+const TOKEN_ALPHABET = "abcdefghjkmnpqrstuvwxyz23456789"; // no look-alikes
+
+function randomToken(length = 4): string {
+    const bytes = randomBytes(length);
+    let out = "";
+    for (const byte of bytes) out += TOKEN_ALPHABET[byte % TOKEN_ALPHABET.length];
+    return out;
+}
+
+async function companyNameTaken(name: string): Promise<boolean> {
+    const [existing] = await db
+        .select({ id: company.id })
+        .from(company)
+        .where(eq(company.name, name));
+    return Boolean(existing);
+}
+
+export async function suggestAvailableCompanyName(preferred: string): Promise<string> {
+    const base = preferred.trim() || "My workspace";
+    if (!(await companyNameTaken(base))) return base;
+
+    for (let attempt = 0; attempt < 12; attempt++) {
+        const candidate = `${base} ${randomToken()}`;
+        if (!(await companyNameTaken(candidate))) return candidate;
     }
-    return `${base} ${Date.now()}`;
+    // 12 random tokens all colliding is not a real scenario; fall back to
+    // something that cannot collide rather than looping or throwing.
+    return `${base} ${Date.now().toString(36)}`;
 }

--- a/apps/web/src/lib/workspace-slug.ts
+++ b/apps/web/src/lib/workspace-slug.ts
@@ -44,3 +44,35 @@ export async function generateUniqueSlug(name: string): Promise<string> {
     }
     return `${base}-${Date.now()}`;
 }
+
+/**
+ * Pick a workspace *name* that no company is using yet, suffixing on
+ * collision the way `generateUniqueSlug` does for the handle.
+ *
+ * Only for names the user did not choose. The solo signup path derives
+ * "<FirstName>'s workspace" and offers no field to edit it, so a collision
+ * there is unresolvable by the person hitting it — two users named Timothy on
+ * the same instance and the second can never create a solo workspace. When a
+ * name was typed by hand, the caller should keep reporting the conflict
+ * instead: silently renaming what someone deliberately entered is worse than
+ * telling them it is taken.
+ *
+ * Note company.name carries no database uniqueness constraint — only
+ * company.slug must be unique. This mirrors the route's application-level
+ * check rather than any storage rule.
+ */
+export async function generateUniqueCompanyName(name: string): Promise<string> {
+    const base = name.trim();
+    let candidate = base;
+    let n = 1;
+    for (let attempt = 0; attempt < 50; attempt++) {
+        const [existing] = await db
+            .select({ id: company.id })
+            .from(company)
+            .where(eq(company.name, candidate));
+        if (!existing) return candidate;
+        n += 1;
+        candidate = `${base} ${n}`;
+    }
+    return `${base} ${Date.now()}`;
+}


### PR DESCRIPTION
Creating a workspace as a brand-new account fails. Reported from the browser as:

```
Failed to load resource: the server responded with a status of 401 ()
/api/signup/employerCompany:1  Failed to load resource: the server responded with a status of 400 ()
```

Two independent bugs, one visible and one fatal.

## 401 — `/api/embedding-indexes`

The signup page loads the embedding-index list on mount. That route required `requireWorkspaceContext()`, which resolves the caller's **company membership**.

A user who is signing up has no workspace yet — that is what they are there to create — so this is the first call in a new account's lifetime and it can never succeed. Worse, the context was never used: the handler calls `getEmbeddingIndexRegistry()` with **no company config**, so the response was identical regardless. It fetched a workspace, discarded it, and 401'd anyone who didn't have one.

Now requires only a session (`requireAuthIdentity`), which is what the other signup-time routes use and what the response actually needs.

## 400 — `/api/signup/employerCompany`

The solo ("just me") path derives the workspace name from the account's first name:

```js
const firstWord = user.name.trim().split(/\s+/)[0];
const workspaceName = `${firstName}'s workspace`;
```

and the route rejects any name an existing company already holds:

```js
if (existingCompany) {
  return createValidationError("Company already exists. Please use a different company name.");
}
```

Those two facts are incompatible. **Any two users with the same first name collide**, and because the solo flow is one click with no name field, the second one is permanently stuck — the error asks them to "use a different company name" for a name they were never shown and have no way to change. On a shared instance the second Timothy, or the second John, simply cannot create a solo workspace.

### The fix

`company.name` carries **no uniqueness constraint in the database**. Only `company.slug` must be unique, and `generateUniqueSlug` already suffixes on collision. The global name check is application-level policy, not a storage rule.

So this gives names the same treatment the handle already gets — but only where the caller generated the name itself:

- `generateUniqueCompanyName()`, mirroring `generateUniqueSlug()`, suffixing `name 2`, `name 3`, …
- `autoRenameOnConflict` on the signup schema, defaulting to **false**
- the solo path sets it; **the team form does not**

A hand-typed name still returns "already exists", which is the useful answer when someone deliberately chose the word. Silently renaming what a person typed would be worse than telling them it's taken.

## Tests

`apps/web/__tests__/lib/workspace-name.test.ts` — 5 cases: no collision, one collision, consecutive collisions, trimming before comparison, and the retry cap terminating rather than looping. Typecheck clean.

## Note for reviewers

There's a broader question this deliberately does **not** settle: should company names be globally unique at all? Two unrelated tenants both called "Acme" is legitimate on a shared instance, the slug already disambiguates URLs, and the check leaks which company names exist to anyone who can probe signup. Removing it entirely would be a larger behavioral change to the team path, so this fixes the reachable bug and leaves that decision open.

## How it was found

A deployment where an existing `Timothy's workspace`, created before an auth-provider migration, blocked its own owner from signing back up after the migration cleared the auth tables.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches signup-critical paths (auth gating and company creation) but narrows embedding-indexes auth rather than widening data exposure; name uniqueness remains application-level with no reservation race handling beyond existing behavior.
> 
> **Overview**
> Fixes **first-workspace signup** for new accounts: embedding index options load without a workspace, and solo users can pick a name that won’t collide silently.
> 
> **`/api/embedding-indexes`** now uses **`requireAuthIdentity`** instead of **`requireWorkspaceContext`**, so the signup page’s first fetch no longer 401s when the user has no company yet. The registry response was never workspace-scoped anyway.
> 
> **Solo signup** adds **`suggestAvailableCompanyName`** (availability check + random 4-character suffix on collision, not a numeric “2”) and a **`GET /api/signup/workspace-name-suggestion`** route. The signup **solo card** pre-fills an editable **Workspace name** field from that API (with local fallback). **`employerCompany`** still rejects duplicate names, but conflicts are actionable because the user chose or edited the visible name.
> 
> Tests cover **`suggestAvailableCompanyName`** in **`workspace-name.test.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b0b1cf15afec65f837443c7522526fee1f0d094. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->