### PR TITLE
feat: containerize apps/landing so a deployment can serve its own front door

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,10 +12,18 @@
 # Generated assets (created by postinstall from node_modules)
 apps/web/public/vad
 
-# The public site (launchstack.app) is not containerized — docker-compose and
-# the GHCR images build apps/web only. This also keeps its 26MB deployment
-# demo video out of every build context.
-apps/landing
+# The public site is containerized only by apps/landing/Dockerfile, so a
+# self-hosted deployment can serve its own front door. The web and worker
+# images do not need it, but a .dockerignore is per-context, not per-image, so
+# excluding it outright is what stopped the landing image from building at all.
+#
+# The 26MB deployment demo video this used to exclude is no longer committed —
+# the whole app is ~0.5MB across 61 files — so the cost of carrying it is now
+# negligible. Heavy media stays excluded by extension below in case one comes
+# back.
+apps/landing/**/*.mp4
+apps/landing/**/*.webm
+apps/landing/**/*.mov
 
 # Git
 .git
@@ -67,6 +75,7 @@ sidecar
 docker-compose*.yml
 apps/web/Dockerfile
 apps/web/Dockerfile.*
+apps/landing/Dockerfile
 .dockerignore
 scripts/ops/start-database.sh
 

--- a/apps/landing/Dockerfile
+++ b/apps/landing/Dockerfile
@@ -1,0 +1,59 @@
+# syntax=docker/dockerfile:1
+
+# The marketing site, containerized so a self-hosted deployment can serve its
+# own front door instead of pointing users at launchstack.app. apps/web builds
+# from its own Dockerfile; this one exists alongside it.
+
+FROM node:20-alpine AS base
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable && corepack prepare pnpm@10.15.1 --activate
+WORKDIR /app
+
+# ── Dependencies ─────────────────────────────────────────────────────
+# pnpm resolves the whole workspace from the lockfile, so every member's
+# manifest has to be present even though only landing is installed. Keep this
+# list in step with the workspace — scripts/ci/check-dockerfile-manifests.mjs
+# fails the build if it drifts.
+FROM base AS deps
+COPY pnpm-workspace.yaml package.json pnpm-lock.yaml .pnpmfile.cjs ./
+COPY patches ./patches/
+COPY packages/runtime/package.json ./packages/runtime/
+COPY packages/evidence/package.json ./packages/evidence/
+COPY packages/store/package.json ./packages/store/
+COPY packages/llm/package.json ./packages/llm/
+COPY packages/conversion/package.json ./packages/conversion/
+COPY packages/indexing/package.json ./packages/indexing/
+COPY packages/retrieval/package.json ./packages/retrieval/
+COPY packages/orchestration/package.json ./packages/orchestration/
+COPY packages/editing/package.json ./packages/editing/
+COPY packages/collab/package.json ./packages/collab/
+COPY packages/engine/package.json ./packages/engine/
+COPY packages/schema-generator/package.json ./packages/schema-generator/
+COPY packages/tools/package.json ./packages/tools/
+COPY packages/design-tokens/package.json ./packages/design-tokens/
+COPY packages/document-conversion-engine/package.json ./packages/document-conversion-engine/
+COPY packages/google-drive/package.json ./packages/google-drive/
+COPY pipelines/package.json ./pipelines/
+COPY apps/web/package.json ./apps/web/
+COPY apps/landing/package.json ./apps/landing/
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm install --frozen-lockfile --filter @launchstack/landing...
+
+# ── Builder ──────────────────────────────────────────────────────────
+FROM deps AS builder
+COPY tsconfig.base.json ./
+COPY packages/design-tokens ./packages/design-tokens
+COPY apps/landing ./apps/landing
+ENV NEXT_TELEMETRY_DISABLED=1
+RUN pnpm --filter @launchstack/landing build
+
+# ── Runner ───────────────────────────────────────────────────────────
+# Not a standalone bundle: next.config.ts deliberately omits it, so the
+# runtime keeps node_modules rather than a traced copy.
+FROM builder AS runner
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+EXPOSE 3001
+WORKDIR /app/apps/landing
+CMD ["pnpm", "start"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -80,6 +80,22 @@ services:
   inngest-dev:
     profiles: ["inngest-dev"]
 
+  # The marketing site — the "home page" a signed-out visitor lands on.
+  # apps/web's `/` is the product's front door and redirects to /signin by
+  # design; this serves the public site on its own hostname so a self-hosted
+  # deployment does not have to send people to launchstack.app.
+  landing:
+    build:
+      context: .
+      dockerfile: apps/landing/Dockerfile
+      target: runner
+    container_name: pdr_ai_v2-landing
+    restart: unless-stopped
+    environment:
+      NEXT_PUBLIC_SITE_URL: https://home.${DOMAIN}
+      NEXT_PUBLIC_APP_URL: https://${DOMAIN}
+      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ""
+
   caddy:
     image: caddy:2
     container_name: pdr_ai_v2-caddy

--- a/docker/Caddyfile.prod
+++ b/docker/Caddyfile.prod
@@ -21,3 +21,9 @@
 files.{$DOMAIN} {
 	reverse_proxy seaweedfs:8333
 }
+
+# The marketing site. Kept on its own hostname so the app keeps the origin its
+# auth callbacks and stored object URLs were issued against.
+home.{$DOMAIN} {
+	reverse_proxy landing:3001
+}

--- a/scripts/ci/check-dockerfile-manifests.mjs
+++ b/scripts/ci/check-dockerfile-manifests.mjs
@@ -33,6 +33,7 @@ const DOCKERFILES = [
     "apps/web/Dockerfile",
     "apps/web/Dockerfile.prebuilt",
     "apps/worker/Dockerfile",
+    "apps/landing/Dockerfile",
 ];
 
 /** Workspace dirs that ship a package.json, as the Dockerfiles address them. */


### PR DESCRIPTION
`apps/web`'s `/` redirects to `/signin` by design — that origin is the product, and the public site lives in `apps/landing`. But `apps/landing` was never containerized, so a self-hosted deployment had **no front door of its own**, and `LANDING_URL` fell back to its hardcoded default:

```ts
export const LANDING_URL = process.env.NEXT_PUBLIC_SITE_URL ?? "https://launchstack.app";
```

Signing out therefore sent an operator's users to a domain the operator does not control.

## What this adds

- **`apps/landing/Dockerfile`**, alongside the web and worker images. Not a standalone bundle — `next.config.ts` deliberately omits `output: "standalone"`, so the runner keeps `node_modules` rather than a traced copy.
- **A `landing` service** in the production overlay, plus a Caddy route on `home.$DOMAIN`. Its own hostname on purpose: the app keeps the origin its auth callbacks and stored object URLs were issued against, so nothing existing has to be re-registered.
- **`.dockerignore` no longer excludes `apps/landing` outright.** That exclusion is what made the image unbuildable — a `.dockerignore` is per *context*, not per *image*, so excluding the app for the web build also hid it from its own.
- **The manifest guard now covers this Dockerfile too**, and immediately earned it: it caught `pipelines/package.json` missing from the deps layer before the build did.

## On the removed exclusion

The comment justified excluding `apps/landing` with "its 26MB deployment demo video". That video is no longer committed — the whole app is **~0.5 MB across 61 files**. Heavy media stays excluded by extension (`*.mp4`, `*.webm`, `*.mov`) in case one comes back, so the web and worker build contexts don't regress.

## Verified on a live deployment

Image builds, container serves (`HTTP 200` internally and through Caddy), and Caddy obtained a Let's Encrypt certificate for the new hostname. The app and file origins were unaffected throughout — `/signin` still 200, the files origin still 403 on anonymous listing.

## What this does *not* do

It does not repoint sign-out on its own. `LANDING_URL` reads `NEXT_PUBLIC_SITE_URL`, which **Next.js inlines at build time** — I confirmed `https://launchstack.app` is already compiled into the shipped client chunks. A deployment cannot set it without rebuilding the image, and baking a URL into a public image is the wrong fix for a self-hostable product, since every self-hoster would inherit whatever was baked.

Making `LANDING_URL` resolve at runtime (defaulting to `/signin` when no site is configured) is a separate, small change. Worth noting the two sign-out call sites currently disagree as well: `WorkspaceShell` and the sign-in page use `LANDING_URL`, while `WorkspaceSelectClient` hardcodes `/signin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new production service and public hostname in Caddy/TLS routing; scope is deployment-only and isolated from the app origin, but misconfiguration could affect how visitors reach the marketing site.
> 
> **Overview**
> Self-hosted deployments can now serve the **marketing site** instead of relying on `launchstack.app`, by adding a **`landing` Docker image and service** alongside the existing web and worker stack.
> 
> **`apps/landing/Dockerfile`** builds `@launchstack/landing` with the same pnpm workspace manifest pattern as the other app images (non-standalone Next, `pnpm start` on port **3001**). **`docker-compose.prod.yml`** adds a `landing` service with `NEXT_PUBLIC_SITE_URL` / `NEXT_PUBLIC_APP_URL` for that hostname, and **`docker/Caddyfile.prod`** terminates TLS on **`home.{$DOMAIN}`** and reverse-proxies to `landing:3001` so the main app origin stays unchanged for auth and file URLs.
> 
> **`.dockerignore`** no longer drops all of `apps/landing` (which blocked the landing image from the shared build context); it only excludes heavy video extensions under `apps/landing`. **`scripts/ci/check-dockerfile-manifests.mjs`** now validates **`apps/landing/Dockerfile`** so workspace `COPY` lines stay in sync.
> 
> This does **not** change where signed-out users are sent in the web app — `LANDING_URL` in `apps/web` is still build-time inlined unless addressed separately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07eb506742453833fd38bc1ae43a1db8a075d637. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->