### PR TITLE
polish: give the landing page a motion system, and fix two layout bugs

### DIFF
--- a/apps/landing/src/app/_components/LandingClient.tsx
+++ b/apps/landing/src/app/_components/LandingClient.tsx
@@ -981,6 +981,12 @@ function IconMegaphone() {
 const KP_CSS = `
 .kp-stage {
   position: relative;
+  /* The SVG scales through its viewBox, so its labels shrink with the stage.
+     The HTML cards are positioned in percentages but were sized in fixed px,
+     so their text did not shrink with them — at narrow widths it overran the
+     card and collided with the SVG column labels. Making the stage a query
+     container lets the card type scale on the same basis as the drawing. */
+  container-type: inline-size;
   width: 100%;
   max-width: 1180px;
   margin: 40px auto 0;
@@ -1099,7 +1105,7 @@ const KP_CSS = `
 .kp-card__icon svg { width: 16px; height: 16px; display: block; }
 .kp-card__text { min-width: 0; }
 .kp-card__label {
-  font-size: 12px;
+  font-size: clamp(8px, 1.02cqw, 12px);
   font-weight: 500;
   letter-spacing: -0.005em;
   color: var(--ink);
@@ -1108,7 +1114,7 @@ const KP_CSS = `
   text-overflow: ellipsis;
 }
 .kp-card__meta {
-  font-size: 10px;
+  font-size: clamp(7px, 0.85cqw, 10px);
   color: var(--ink-3);
   font-family: var(--font-jetbrains-mono, ui-monospace, monospace);
   margin-top: 2px;
@@ -1225,8 +1231,7 @@ const KP_CSS = `
   .kp-card { gap: 6px; padding: 5px 7px; border-radius: 8px; }
   .kp-card__icon { width: 20px; height: 20px; border-radius: 5px; }
   .kp-card__icon svg { width: 12px; height: 12px; }
-  .kp-card__label { font-size: 9px; }
-  .kp-card__meta { font-size: 7px; margin-top: 1px; }
+  .kp-card__meta { margin-top: 1px; }
   .kp-embed { padding: 6px 8px; border-radius: 8px; }
   .kp-embed__title { font-size: 9px; }
   .kp-embed__meta { font-size: 7px; }

--- a/apps/landing/src/app/_components/MarketingShell.tsx
+++ b/apps/landing/src/app/_components/MarketingShell.tsx
@@ -46,11 +46,11 @@ export function MarketingShell({
     return (
         <div className={styles.root}>
             <div className={styles.ambient} aria-hidden="true">
+                {/* Three, not five, and no longer drifting: the wash gives the
+                    page depth, the motion only gave it a tell. */}
                 <div className={`${styles.orb} ${styles.orb1}`} />
                 <div className={`${styles.orb} ${styles.orb2}`} />
                 <div className={`${styles.orb} ${styles.orb3}`} />
-                <div className={`${styles.orb} ${styles.orb4}`} />
-                <div className={`${styles.orb} ${styles.orb5}`} />
                 <div className={styles.ambientDots} />
                 <div className={styles.ambientGrain} />
             </div>

--- a/apps/landing/src/styles/marketing.module.css
+++ b/apps/landing/src/styles/marketing.module.css
@@ -6,796 +6,1432 @@
 /* Tokens inherit from :root (@launchstack/design-tokens); this block
    holds layout/typography only. */
 .root {
-  color: var(--ink);
-  background: var(--bg);
-  font-family: var(--font-sans);
-  font-feature-settings: "cv11", "ss01", "ss03";
-  -webkit-font-smoothing: antialiased;
-  position: relative;
-  overflow-x: hidden;
-  min-height: 100vh;
+    /* Motion. Three curves and three durations — every transition on this page
+     picks from these rather than falling back to the browser default, which is
+     what made the page feel uniformly floaty.
+       exit    decisive start, long settle — entrances and reveals
+       inout   symmetric — state changes that reverse (open/close, theme)
+       spring  slight overshoot — direct manipulation only (hover, press) */
+    --ease-exit: cubic-bezier(0.16, 1, 0.3, 1);
+    --ease-inout: cubic-bezier(0.65, 0, 0.35, 1);
+    --ease-spring: cubic-bezier(0.34, 1.4, 0.64, 1);
+    --dur-fast: 120ms;
+    --dur-base: 220ms;
+    --dur-slow: 420ms;
+
+    color: var(--ink);
+    background: var(--bg);
+    font-family: var(--font-sans);
+    font-feature-settings: "cv11", "ss01", "ss03";
+    -webkit-font-smoothing: antialiased;
+    position: relative;
+    overflow-x: hidden;
+    min-height: 100vh;
 }
 
-.root ::selection { background: var(--accent-glow); color: var(--ink); }
+.root ::selection {
+    background: var(--accent-glow);
+    color: var(--ink);
+}
 
 .serif {
-  font-family: var(--font-instrument-serif, 'Instrument Serif'), Georgia, serif;
-  font-feature-settings: normal;
-  font-weight: 400;
-  font-style: italic;
-  color: var(--accent);
+    /* Not italic, not a serif drop-in: the accent phrase differs by weight and
+     colour within the same family, which reads as emphasis rather than as a
+     different typeface pasted in. */
+    font-weight: 700;
+    letter-spacing: -0.045em;
+    color: var(--accent);
 }
-.mono { font-family: var(--font-jetbrains-mono, 'JetBrains Mono'), ui-monospace, monospace; }
+.mono {
+    font-family: var(--font-jetbrains-mono, "JetBrains Mono"), ui-monospace, monospace;
+}
 
 /* ---------------- AMBIENT BG ---------------- */
 .ambient {
-  position: fixed; inset: 0; z-index: -1; pointer-events: none;
-  overflow: hidden;
-  background: var(--bg);
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    pointer-events: none;
+    overflow: hidden;
+    background: var(--bg);
 }
 .ambient::before {
-  content: ''; position: absolute; inset: 0;
-  background: radial-gradient(ellipse 80% 60% at 50% 0%, transparent 0%, var(--bg) 75%);
-  z-index: 2;
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(ellipse 80% 60% at 50% 0%, transparent 0%, var(--bg) 75%);
+    z-index: 2;
 }
 .orb {
-  position: absolute;
-  border-radius: 50%;
-  filter: blur(80px);
-  opacity: 0.7;
-  will-change: transform;
+    position: absolute;
+    border-radius: 50%;
+    filter: blur(80px);
+    opacity: 0.7;
+    will-change: transform;
 }
 :global([data-theme="dark"]) .orb {
-  opacity: 0.55;
-  filter: blur(90px);
+    opacity: 0.55;
+    filter: blur(90px);
 }
 
 .orb1 {
-  width: 520px; height: 520px;
-  left: -80px; top: 120px;
-  background: radial-gradient(circle, var(--accent-glow) 0%, transparent 65%);
-  animation: drift1 26s ease-in-out infinite alternate;
+    width: 520px;
+    height: 520px;
+    left: -80px;
+    top: 120px;
+    background: radial-gradient(circle, var(--accent-glow) 0%, transparent 65%);
 }
 .orb2 {
-  width: 640px; height: 640px;
-  right: -120px; top: 320px;
-  background: radial-gradient(circle, oklch(0.7 0.22 340 / 0.35) 0%, transparent 65%);
-  animation: drift2 32s ease-in-out infinite alternate;
+    width: 640px;
+    height: 640px;
+    right: -120px;
+    top: 320px;
+    background: radial-gradient(circle, oklch(0.7 0.22 340 / 0.35) 0%, transparent 65%);
 }
 .orb3 {
-  width: 560px; height: 560px;
-  left: 30%; top: 1400px;
-  background: radial-gradient(circle, oklch(0.72 0.18 200 / 0.28) 0%, transparent 65%);
-  animation: drift3 38s ease-in-out infinite alternate;
-}
-.orb4 {
-  width: 480px; height: 480px;
-  right: 10%; top: 2600px;
-  background: radial-gradient(circle, var(--accent-glow) 0%, transparent 65%);
-  animation: drift1 44s ease-in-out infinite alternate-reverse;
-}
-.orb5 {
-  width: 720px; height: 720px;
-  left: -10%; top: 3900px;
-  background: radial-gradient(circle, oklch(0.72 0.2 285 / 0.3) 0%, transparent 65%);
-  animation: drift2 50s ease-in-out infinite alternate;
+    width: 560px;
+    height: 560px;
+    left: 30%;
+    top: 1400px;
+    background: radial-gradient(circle, oklch(0.72 0.18 200 / 0.28) 0%, transparent 65%);
 }
 :global([data-theme="dark"]) .orb1 {
-  background: radial-gradient(circle, oklch(0.7 0.22 285 / 0.5) 0%, transparent 65%);
+    background: radial-gradient(circle, oklch(0.7 0.22 285 / 0.5) 0%, transparent 65%);
 }
 :global([data-theme="dark"]) .orb2 {
-  background: radial-gradient(circle, oklch(0.65 0.22 330 / 0.4) 0%, transparent 65%);
+    background: radial-gradient(circle, oklch(0.65 0.22 330 / 0.4) 0%, transparent 65%);
 }
 :global([data-theme="dark"]) .orb3 {
-  background: radial-gradient(circle, oklch(0.7 0.18 200 / 0.32) 0%, transparent 65%);
-}
-
-@keyframes drift1 {
-  0%   { transform: translate3d(0, 0, 0) scale(1); }
-  50%  { transform: translate3d(120px, 80px, 0) scale(1.08); }
-  100% { transform: translate3d(60px, 180px, 0) scale(0.95); }
-}
-@keyframes drift2 {
-  0%   { transform: translate3d(0, 0, 0) scale(1); }
-  50%  { transform: translate3d(-100px, 140px, 0) scale(1.12); }
-  100% { transform: translate3d(-180px, 40px, 0) scale(0.92); }
-}
-@keyframes drift3 {
-  0%   { transform: translate3d(0, 0, 0) scale(1.05); }
-  50%  { transform: translate3d(180px, -60px, 0) scale(0.94); }
-  100% { transform: translate3d(-120px, 100px, 0) scale(1.1); }
+    background: radial-gradient(circle, oklch(0.7 0.18 200 / 0.32) 0%, transparent 65%);
 }
 
 .ambientGrain {
-  position: absolute; inset: 0; z-index: 3;
-  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 0.4 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
-  opacity: 0.04;
-  mix-blend-mode: multiply;
+    position: absolute;
+    inset: 0;
+    z-index: 3;
+    background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='160' height='160'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 0  0 0 0 0 0  0 0 0 0 0  0 0 0 0.4 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+    opacity: 0.04;
+    mix-blend-mode: multiply;
 }
 :global([data-theme="dark"]) .ambientGrain {
-  opacity: 0.06;
-  mix-blend-mode: screen;
+    opacity: 0.06;
+    mix-blend-mode: screen;
 }
 
 .ambientDots {
-  position: absolute; inset: -40px; z-index: 1;
-  background-image: radial-gradient(circle at 1px 1px, var(--line) 1px, transparent 1px);
-  background-size: 28px 28px;
-  -webkit-mask-image: radial-gradient(ellipse 60% 50% at 50% 30%, black 0%, transparent 85%);
-  mask-image: radial-gradient(ellipse 60% 50% at 50% 30%, black 0%, transparent 85%);
-  opacity: 0.35;
-  animation: slideDots 80s linear infinite;
-}
-@keyframes slideDots {
-  0% { transform: translate(0, 0); }
-  100% { transform: translate(28px, 28px); }
+    position: absolute;
+    inset: -40px;
+    z-index: 1;
+    background-image: radial-gradient(circle at 1px 1px, var(--line) 1px, transparent 1px);
+    background-size: 28px 28px;
+    -webkit-mask-image: radial-gradient(ellipse 60% 50% at 50% 30%, black 0%, transparent 85%);
+    mask-image: radial-gradient(ellipse 60% 50% at 50% 30%, black 0%, transparent 85%);
+    opacity: 0.35;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .orb, .ambientDots { animation: none !important; }
+    /* The ambient drift and the sliding dot grid were removed outright, so this
+     now covers what genuinely remains: the looping accents and any transition
+     that would otherwise move something. */
+    .root,
+    .root :global(*) {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
 }
 
 /* ---------------- NAV ---------------- */
 .nav {
-  position: fixed; top: 0; left: 0; right: 0; z-index: 100;
-  padding: 16px 32px;
-  display: flex; align-items: center; justify-content: space-between;
-  backdrop-filter: blur(14px) saturate(140%);
-  -webkit-backdrop-filter: blur(14px) saturate(140%);
-  background: oklch(from var(--bg) l c h / 0.65);
-  border-bottom: 1px solid transparent;
-  transition: border-color .3s, background .3s;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 100;
+    padding: 16px 32px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    backdrop-filter: blur(14px) saturate(140%);
+    -webkit-backdrop-filter: blur(14px) saturate(140%);
+    background: oklch(from var(--bg) l c h / 0.65);
+    border-bottom: 1px solid transparent;
+    transition:
+        border-color 0.3s,
+        background 0.3s;
 }
 .navScrolled {
-  border-bottom-color: var(--line-2);
-  background: oklch(from var(--bg) l c h / 0.9);
+    border-bottom-color: var(--line-2);
+    background: oklch(from var(--bg) l c h / 0.9);
 }
 .brand {
-  display: flex; align-items: center; gap: 10px;
-  font-weight: 700; font-size: 16px; letter-spacing: -0.01em;
-  color: var(--ink); text-decoration: none;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    font-weight: 700;
+    font-size: 16px;
+    letter-spacing: -0.01em;
+    color: var(--ink);
+    text-decoration: none;
 }
 /* The brand mark is <LaunchstackMark>, not CSS: this file used to draw its own
    purple-diamond tile here, which is how the marketing nav and footer drifted
    from the logo apps/web renders. */
-.navLinks { display: flex; gap: 28px; font-size: 14px; color: var(--ink-2); }
-.navLinks a { color: inherit; text-decoration: none; transition: color .2s; }
-.navLinks a:hover { color: var(--ink); }
-.navCta { display: flex; align-items: center; gap: 10px; }
+.navLinks {
+    display: flex;
+    gap: 28px;
+    font-size: 14px;
+    color: var(--ink-2);
+}
+.navLinks a {
+    color: inherit;
+    text-decoration: none;
+    transition: color 0.2s;
+}
+.navLinks a:hover {
+    color: var(--ink);
+}
+.navCta {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+}
 
 .btn {
-  display: inline-flex; align-items: center; gap: 8px;
-  padding: 9px 16px; border-radius: 10px; font-size: 14px; font-weight: 500;
-  border: 1px solid transparent; cursor: pointer; text-decoration: none;
-  color: var(--ink); background: transparent;
-  transition: all .2s;
-  font-family: inherit;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 9px 16px;
+    border-radius: 10px;
+    font-size: 14px;
+    font-weight: 500;
+    border: 1px solid transparent;
+    cursor: pointer;
+    text-decoration: none;
+    color: var(--ink);
+    background: transparent;
+    transition:
+        background-color var(--dur-base) var(--ease-inout),
+        border-color var(--dur-base) var(--ease-inout),
+        color var(--dur-base) var(--ease-inout),
+        transform var(--dur-fast) var(--ease-spring),
+        box-shadow var(--dur-base) var(--ease-inout);
+    font-family: inherit;
 }
-.btnGhost { color: var(--ink-2); }
-.btnGhost:hover { background: var(--panel-2); color: var(--ink); }
-.btnOutline { border-color: var(--line); color: var(--ink); }
-.btnOutline:hover { background: var(--panel-2); border-color: var(--ink-4); }
+.btnGhost {
+    color: var(--ink-2);
+}
+.btnGhost:hover {
+    background: var(--panel-2);
+    color: var(--ink);
+}
+.btnOutline {
+    border-color: var(--line);
+    color: var(--ink);
+}
+.btnOutline:hover {
+    background: var(--panel-2);
+    border-color: var(--ink-4);
+}
 .btnAccent {
-  background: linear-gradient(180deg, var(--accent) 0%, var(--accent-deep) 100%);
-  color: white; font-weight: 600;
-  box-shadow: 0 1px 0 oklch(1 0 0 / 0.35) inset, 0 8px 20px var(--accent-glow);
+    background: linear-gradient(180deg, var(--accent) 0%, var(--accent-deep) 100%);
+    color: white;
+    font-weight: 600;
+    box-shadow:
+        0 1px 0 oklch(1 0 0 / 0.35) inset,
+        0 8px 20px var(--accent-glow);
 }
 .btnAccent:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 1px 0 oklch(1 0 0 / 0.35) inset, 0 12px 28px var(--accent-glow);
+    transform: translateY(-1px);
+    box-shadow:
+        0 1px 0 oklch(1 0 0 / 0.35) inset,
+        0 12px 28px var(--accent-glow);
 }
-.btnLg { padding: 13px 20px; font-size: 15px; }
+.btnLg {
+    padding: 13px 20px;
+    font-size: 15px;
+}
 .themeToggle {
-  width: 34px; height: 34px; border-radius: 10px;
-  display: inline-flex; align-items: center; justify-content: center;
-  color: var(--ink-3); border: 1px solid var(--line-2); background: var(--panel);
-  transition: all .2s;
-  cursor: pointer;
+    width: 34px;
+    height: 34px;
+    border-radius: 10px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--ink-3);
+    border: 1px solid var(--line-2);
+    background: var(--panel);
+    transition:
+        background-color var(--dur-base) var(--ease-inout),
+        border-color var(--dur-base) var(--ease-inout),
+        color var(--dur-base) var(--ease-inout),
+        transform var(--dur-fast) var(--ease-spring),
+        box-shadow var(--dur-base) var(--ease-inout);
+    cursor: pointer;
 }
-.themeToggle:hover { color: var(--ink); border-color: var(--line); }
+.themeToggle:hover {
+    color: var(--ink);
+    border-color: var(--line);
+}
 .navGh {
-  display: inline-flex; align-items: center; gap: 7px;
-  padding: 7px 11px 7px 9px; border-radius: 10px;
-  border: 1px solid var(--line-2); background: var(--panel);
-  color: var(--ink-2); font-size: 13px;
-  text-decoration: none; transition: all .2s;
+    display: inline-flex;
+    align-items: center;
+    gap: 7px;
+    padding: 7px 11px 7px 9px;
+    border-radius: 10px;
+    border: 1px solid var(--line-2);
+    background: var(--panel);
+    color: var(--ink-2);
+    font-size: 13px;
+    text-decoration: none;
+    transition:
+        background-color var(--dur-base) var(--ease-inout),
+        border-color var(--dur-base) var(--ease-inout),
+        color var(--dur-base) var(--ease-inout),
+        transform var(--dur-fast) var(--ease-spring),
+        box-shadow var(--dur-base) var(--ease-inout);
 }
-.navGh:hover { color: var(--ink); border-color: var(--line); }
+.navGh:hover {
+    color: var(--ink);
+    border-color: var(--line);
+}
 .navGh .starCt {
-  display: inline-flex; align-items: center; gap: 3px;
-  padding-left: 8px; margin-left: 2px;
-  border-left: 1px solid var(--line-2);
-  font-family: var(--font-jetbrains-mono, 'JetBrains Mono'), ui-monospace, monospace;
-  font-size: 12px; font-weight: 500;
-  color: var(--ink);
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    padding-left: 8px;
+    margin-left: 2px;
+    border-left: 1px solid var(--line-2);
+    font-family: var(--font-jetbrains-mono, "JetBrains Mono"), ui-monospace, monospace;
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--ink);
 }
-.navGh .starCt svg { color: oklch(0.7 0.17 85); }
+.navGh .starCt svg {
+    color: oklch(0.7 0.17 85);
+}
 
 @media (max-width: 980px) {
-  .navGh .label, .navGh .starCt { display: none; }
-  .navGh { padding: 7px; }
+    .navGh .label,
+    .navGh .starCt {
+        display: none;
+    }
+    .navGh {
+        padding: 7px;
+    }
 }
 @media (max-width: 880px) {
-  .nav { padding: 12px 18px; }
-  .navLinks { display: none; }
+    .nav {
+        padding: 12px 18px;
+    }
+    .navLinks {
+        display: none;
+    }
 }
 
 /* ---------------- HERO ---------------- */
 .hero {
-  position: relative;
-  min-height: clamp(620px, 88vh, 960px);
-  padding: clamp(96px, 13vh, 140px) clamp(20px, 3vw, 32px) clamp(40px, 6vh, 72px);
-  display: grid;
-  grid-template-columns: 1.05fr 1fr;
-  gap: clamp(28px, 3.5vw, 56px);
-  max-width: min(1400px, 96vw);
-  margin: 0 auto;
-  align-items: center;
-  overflow: visible;
+    position: relative;
+    min-height: clamp(620px, 88vh, 960px);
+    padding: clamp(96px, 13vh, 140px) clamp(20px, 3vw, 32px) clamp(40px, 6vh, 72px);
+    display: grid;
+    grid-template-columns: 1.05fr 1fr;
+    gap: clamp(28px, 3.5vw, 56px);
+    max-width: min(1400px, 96vw);
+    margin: 0 auto;
+    align-items: center;
+    overflow: visible;
 }
 @media (max-width: 1040px) {
-  .hero {
-    grid-template-columns: 1fr;
-    padding-top: clamp(88px, 11vh, 110px);
-    min-height: 0;
-  }
+    .hero {
+        grid-template-columns: 1fr;
+        padding-top: clamp(88px, 11vh, 110px);
+        min-height: 0;
+    }
 }
 
 .heroBg {
-  position: absolute; inset: -100px -40px 0 -40px;
-  background: radial-gradient(ellipse 60% 35% at 25% 40%, var(--accent-glow) 0%, transparent 60%);
-  opacity: 0.5;
-  pointer-events: none; z-index: 0;
+    position: absolute;
+    inset: -100px -40px 0 -40px;
+    background: radial-gradient(ellipse 60% 35% at 25% 40%, var(--accent-glow) 0%, transparent 60%);
+    opacity: 0.5;
+    pointer-events: none;
+    z-index: 0;
 }
 :global([data-theme="dark"]) .heroBg {
-  background: radial-gradient(ellipse 60% 35% at 25% 40%, oklch(0.72 0.19 285 / 0.25) 0%, transparent 60%);
+    background: radial-gradient(
+        ellipse 60% 35% at 25% 40%,
+        oklch(0.72 0.19 285 / 0.25) 0%,
+        transparent 60%
+    );
 }
 .heroGrid {
-  position: absolute; inset: 0;
-  background-image:
-    linear-gradient(var(--line-2) 1px, transparent 1px),
-    linear-gradient(90deg, var(--line-2) 1px, transparent 1px);
-  background-size: 56px 56px;
-  -webkit-mask-image: radial-gradient(ellipse at center, black 0%, transparent 65%);
-  mask-image: radial-gradient(ellipse at center, black 0%, transparent 65%);
-  opacity: 0.5; pointer-events: none; z-index: 0;
+    position: absolute;
+    inset: 0;
+    background-image:
+        linear-gradient(var(--line-2) 1px, transparent 1px),
+        linear-gradient(90deg, var(--line-2) 1px, transparent 1px);
+    background-size: 56px 56px;
+    -webkit-mask-image: radial-gradient(ellipse at center, black 0%, transparent 65%);
+    mask-image: radial-gradient(ellipse at center, black 0%, transparent 65%);
+    opacity: 0.5;
+    pointer-events: none;
+    z-index: 0;
 }
 
-.heroCopy { position: relative; z-index: 2; }
+.heroCopy {
+    position: relative;
+    z-index: 2;
+}
 .pill {
-  display: inline-flex; align-items: center; gap: 8px;
-  padding: 6px 14px 6px 6px; border-radius: 999px;
-  background: var(--panel);
-  border: 1px solid var(--line-2);
-  font-size: 13px; color: var(--ink-2);
-  margin-bottom: 24px;
-  backdrop-filter: blur(10px);
-  box-shadow: 0 1px 0 oklch(1 0 0 / 0.6) inset, 0 4px 12px oklch(0 0 0 / 0.04);
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 14px 6px 6px;
+    border-radius: 999px;
+    background: var(--panel);
+    border: 1px solid var(--line-2);
+    font-size: 13px;
+    color: var(--ink-2);
+    margin-bottom: 24px;
+    backdrop-filter: blur(10px);
+    box-shadow:
+        0 1px 0 oklch(1 0 0 / 0.6) inset,
+        0 4px 12px oklch(0 0 0 / 0.04);
 }
 .pillBadge {
-  padding: 2px 9px; border-radius: 999px;
-  background: var(--accent); color: white;
-  font-size: 11px; font-weight: 600; letter-spacing: 0.02em;
+    padding: 2px 9px;
+    border-radius: 999px;
+    background: var(--accent);
+    color: white;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
 }
 .heroTitle {
-  margin: 0 0 22px;
-  font-size: clamp(42px, 5.8vw, 76px);
-  line-height: 1.0; letter-spacing: -0.035em;
-  font-weight: 600;
-  color: var(--ink);
+    margin: 0 0 22px;
+    font-size: clamp(42px, 5.8vw, 76px);
+    line-height: 1;
+    letter-spacing: -0.035em;
+    font-weight: 600;
+    color: var(--ink);
 }
 .highlight {
-  position: relative; display: inline-block; white-space: nowrap;
+    position: relative;
+    display: inline-block;
+    white-space: nowrap;
 }
 .highlight::after {
-  content: ''; position: absolute; left: -2%; right: -2%; bottom: 6%;
-  height: 18%; background: var(--accent-glow);
-  border-radius: 3px; z-index: -1;
-  transform: skew(-6deg);
+    content: "";
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0.06em;
+    height: 2px;
+    background: var(--accent);
+    opacity: 0.5;
 }
 .heroSub {
-  font-size: clamp(16px, 1.3vw, 19px);
-  color: var(--ink-2); max-width: 540px;
-  line-height: 1.55; margin: 0 0 32px;
+    font-size: clamp(16px, 1.3vw, 19px);
+    color: var(--ink-2);
+    max-width: 540px;
+    line-height: 1.55;
+    margin: 0 0 32px;
 }
-.heroCtas { display: flex; gap: 10px; margin-bottom: 22px; flex-wrap: wrap; }
+.heroCtas {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 22px;
+    flex-wrap: wrap;
+}
 .heroMeta {
-  font-size: 13px; color: var(--ink-3);
-  display: flex; align-items: center; gap: 14px; flex-wrap: wrap;
+    font-size: 13px;
+    color: var(--ink-3);
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    flex-wrap: wrap;
 }
 .liveDot {
-  width: 8px; height: 8px; border-radius: 50%;
-  background: oklch(0.65 0.18 150);
-  box-shadow: 0 0 10px oklch(0.65 0.18 150 / 0.6);
-  animation: pulse 2.2s ease-in-out infinite;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: oklch(0.65 0.18 150);
+    box-shadow: 0 0 10px oklch(0.65 0.18 150 / 0.6);
+    animation: pulse 2.2s var(--ease-inout) infinite;
 }
 @keyframes pulse {
-  0%, 100% { box-shadow: 0 0 10px oklch(0.65 0.18 150 / 0.6); }
-  50% { box-shadow: 0 0 14px oklch(0.65 0.18 150 / 1), 0 0 24px oklch(0.65 0.18 150 / 0.4); }
+    0%,
+    100% {
+        box-shadow: 0 0 10px oklch(0.65 0.18 150 / 0.6);
+    }
+    50% {
+        box-shadow:
+            0 0 14px oklch(0.65 0.18 150 / 1),
+            0 0 24px oklch(0.65 0.18 150 / 0.4);
+    }
 }
-.sep { color: var(--line); }
+.sep {
+    color: var(--line);
+}
 
 /* ---------------- STAGE (hero illustration) ---------------- */
 .stage {
-  position: relative; z-index: 1;
-  height: clamp(440px, 72vh, 680px);
-  min-height: min(520px, 64vh);
-  border-radius: 22px;
-  background:
-    radial-gradient(ellipse at 50% 40%, oklch(from var(--accent) l c h / 0.05) 0%, transparent 70%),
-    linear-gradient(180deg, var(--panel) 0%, var(--bg-2) 100%);
-  border: 1px solid var(--line-2);
-  box-shadow: 0 40px 80px oklch(0 0 0 / 0.08), 0 8px 24px oklch(0 0 0 / 0.04);
-  overflow: hidden;
+    position: relative;
+    z-index: 1;
+    height: clamp(440px, 72vh, 680px);
+    min-height: min(520px, 64vh);
+    border-radius: 22px;
+    background:
+        radial-gradient(
+            ellipse at 50% 40%,
+            oklch(from var(--accent) l c h / 0.05) 0%,
+            transparent 70%
+        ),
+        linear-gradient(180deg, var(--panel) 0%, var(--bg-2) 100%);
+    border: 1px solid var(--line-2);
+    box-shadow:
+        0 40px 80px oklch(0 0 0 / 0.08),
+        0 8px 24px oklch(0 0 0 / 0.04);
+    overflow: hidden;
 }
 :global([data-theme="dark"]) .stage {
-  background:
-    radial-gradient(ellipse at 50% 40%, oklch(0.72 0.19 285 / 0.08) 0%, transparent 70%),
-    linear-gradient(180deg, var(--panel) 0%, var(--bg-2) 100%);
-  box-shadow: 0 40px 100px oklch(0 0 0 / 0.5);
+    background:
+        radial-gradient(ellipse at 50% 40%, oklch(0.72 0.19 285 / 0.08) 0%, transparent 70%),
+        linear-gradient(180deg, var(--panel) 0%, var(--bg-2) 100%);
+    box-shadow: 0 40px 100px oklch(0 0 0 / 0.5);
 }
 .stageCanvas {
-  position: absolute; inset: 0; width: 100%; height: 100%;
-  display: block;
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    display: block;
 }
 .stageOverlay {
-  position: absolute; inset: 0;
-  pointer-events: none;
-  background:
-    radial-gradient(ellipse 40% 30% at 50% 0%, oklch(from var(--bg) l c h / 0.8) 0%, transparent 60%),
-    radial-gradient(ellipse 40% 30% at 50% 100%, oklch(from var(--bg) l c h / 0.8) 0%, transparent 60%);
-  z-index: 1;
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background:
+        radial-gradient(
+            ellipse 40% 30% at 50% 0%,
+            oklch(from var(--bg) l c h / 0.8) 0%,
+            transparent 60%
+        ),
+        radial-gradient(
+            ellipse 40% 30% at 50% 100%,
+            oklch(from var(--bg) l c h / 0.8) 0%,
+            transparent 60%
+        );
+    z-index: 1;
 }
 .stageLegendDot {
-  width: 7px; height: 7px; border-radius: 50%;
-  background: oklch(0.65 0.18 150);
-  box-shadow: 0 0 8px oklch(0.65 0.18 150 / 0.8);
-  animation: pulse 2.2s ease-in-out infinite;
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: oklch(0.65 0.18 150);
+    box-shadow: 0 0 8px oklch(0.65 0.18 150 / 0.8);
+    animation: pulse 2.2s var(--ease-inout) infinite;
 }
 .stageLegend {
-  position: absolute; top: 16px; left: 16px;
-  display: flex; align-items: center; gap: 8px;
-  padding: 6px 10px 6px 8px; border-radius: 10px;
-  background: var(--panel);
-  border: 1px solid var(--line-2);
-  font-size: 12px; color: var(--ink-2);
-  box-shadow: 0 4px 12px oklch(0 0 0 / 0.04);
-  z-index: 4;
+    position: absolute;
+    top: 16px;
+    left: 16px;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 10px 6px 8px;
+    border-radius: 10px;
+    background: var(--panel);
+    border: 1px solid var(--line-2);
+    font-size: 12px;
+    color: var(--ink-2);
+    box-shadow: 0 4px 12px oklch(0 0 0 / 0.04);
+    z-index: 4;
 }
-.stageLegend b { color: var(--ink); margin-right: 4px; }
+.stageLegend b {
+    color: var(--ink);
+    margin-right: 4px;
+}
 .stageCount {
-  position: absolute; top: 16px; right: 16px;
-  display: flex; gap: 6px;
-  z-index: 4;
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    display: flex;
+    gap: 6px;
+    z-index: 4;
 }
 .stageCount .chip {
-  padding: 4px 10px; border-radius: 999px;
-  background: var(--panel); border: 1px solid var(--line-2);
-  font-size: 11px; color: var(--ink-2);
-  box-shadow: 0 2px 8px oklch(0 0 0 / 0.03);
+    padding: 4px 10px;
+    border-radius: 999px;
+    background: var(--panel);
+    border: 1px solid var(--line-2);
+    font-size: 11px;
+    color: var(--ink-2);
+    box-shadow: 0 2px 8px oklch(0 0 0 / 0.03);
 }
-.stageCount .chip b { color: var(--ink); margin-right: 4px; }
+.stageCount .chip b {
+    color: var(--ink);
+    margin-right: 4px;
+}
 
 .stageComposer {
-  position: absolute; left: 16px; right: 16px; bottom: 16px;
-  background: var(--panel);
-  border: 1px solid var(--line);
-  border-radius: 16px;
-  padding: 10px 10px 10px 14px;
-  display: flex; align-items: center; gap: 10px;
-  box-shadow: 0 20px 40px oklch(0 0 0 / 0.08), 0 4px 12px oklch(0 0 0 / 0.04);
-  z-index: 3;
+    position: absolute;
+    left: 16px;
+    right: 16px;
+    bottom: 16px;
+    background: var(--panel);
+    border: 1px solid var(--line);
+    border-radius: 16px;
+    padding: 10px 10px 10px 14px;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    box-shadow:
+        0 20px 40px oklch(0 0 0 / 0.08),
+        0 4px 12px oklch(0 0 0 / 0.04);
+    z-index: 3;
 }
 .sourcesChip {
-  padding: 5px 10px; border-radius: 8px;
-  background: var(--accent-soft); color: var(--accent);
-  font-size: 12px; font-weight: 600;
-  display: inline-flex; align-items: center; gap: 6px;
-  flex-shrink: 0;
+    padding: 5px 10px;
+    border-radius: 8px;
+    background: var(--accent-soft);
+    color: var(--accent);
+    font-size: 12px;
+    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    flex-shrink: 0;
 }
-.sourcesChip .dot { width: 6px; height: 6px; border-radius: 50%; background: currentColor; }
+.sourcesChip .dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    background: currentColor;
+}
 .composerText {
-  flex: 1; font-size: 14px; color: var(--ink);
-  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
-  min-height: 20px; line-height: 20px;
+    flex: 1;
+    font-size: 14px;
+    color: var(--ink);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-height: 20px;
+    line-height: 20px;
 }
 .composerText.composerTyping::after {
-  content: ''; display: inline-block;
-  width: 1.5px; height: 15px; background: var(--accent);
-  vertical-align: -2px; margin-left: 2px;
-  animation: blink 1s step-end infinite;
+    content: "";
+    display: inline-block;
+    width: 1.5px;
+    height: 15px;
+    background: var(--accent);
+    vertical-align: -2px;
+    margin-left: 2px;
+    animation: blink 1s step-end infinite;
 }
-@keyframes blink { 50% { opacity: 0; } }
+@keyframes blink {
+    50% {
+        opacity: 0;
+    }
+}
 .sendBtn {
-  width: 32px; height: 32px; border-radius: 8px;
-  background: var(--ink); color: var(--bg);
-  display: inline-flex; align-items: center; justify-content: center;
-  flex-shrink: 0; border: none; cursor: pointer;
+    width: 32px;
+    height: 32px;
+    border-radius: 8px;
+    background: var(--ink);
+    color: var(--bg);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    border: none;
+    cursor: pointer;
 }
 .kbd {
-  display: inline-block; padding: 1px 6px; border-radius: 5px;
-  background: var(--panel-2); border: 1px solid var(--line-2);
-  font-family: var(--font-jetbrains-mono, 'JetBrains Mono'), ui-monospace, monospace;
-  font-size: 11px;
-  color: var(--ink-2);
+    display: inline-block;
+    padding: 1px 6px;
+    border-radius: 5px;
+    background: var(--panel-2);
+    border: 1px solid var(--line-2);
+    font-family: var(--font-jetbrains-mono, "JetBrains Mono"), ui-monospace, monospace;
+    font-size: 11px;
+    color: var(--ink-2);
 }
 
 .stageThread {
-  position: absolute; top: 60px; right: 16px; bottom: 80px;
-  width: min(380px, 50%);
-  background: var(--panel);
-  border: 1px solid var(--line-2);
-  border-radius: 14px;
-  padding: 14px;
-  display: flex; flex-direction: column; gap: 10px;
-  box-shadow: 0 20px 50px oklch(0 0 0 / 0.08), 0 4px 12px oklch(0 0 0 / 0.04);
-  z-index: 2;
-  overflow: hidden;
+    position: absolute;
+    top: 60px;
+    right: 16px;
+    bottom: 80px;
+    width: min(380px, 50%);
+    background: var(--panel);
+    border: 1px solid var(--line-2);
+    border-radius: 14px;
+    padding: 14px;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    box-shadow:
+        0 20px 50px oklch(0 0 0 / 0.08),
+        0 4px 12px oklch(0 0 0 / 0.04);
+    z-index: 2;
+    overflow: hidden;
 }
 .hdMsg {
-  padding: 10px 12px; border-radius: 12px;
-  font-size: 13px; line-height: 1.5;
-  word-wrap: break-word;
-  animation: bubbleIn 0.3s ease;
+    padding: 10px 12px;
+    border-radius: 12px;
+    font-size: 13px;
+    line-height: 1.5;
+    word-wrap: break-word;
+    animation: bubbleIn 0.3s ease;
 }
 @keyframes bubbleIn {
-  from { opacity: 0; transform: translateY(6px); }
-  to { opacity: 1; transform: translateY(0); }
+    from {
+        opacity: 0;
+        transform: translateY(6px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }
 .hdMsgU {
-  background: var(--accent-soft); color: var(--accent-ink);
-  align-self: flex-end; max-width: 90%;
-  border-bottom-right-radius: 3px;
-  font-weight: 500;
+    background: var(--accent-soft);
+    color: var(--accent-ink);
+    align-self: flex-end;
+    max-width: 90%;
+    border-bottom-right-radius: 3px;
+    font-weight: 500;
 }
-.hdMsgA { color: var(--ink); padding: 0; }
-.hdSources { display: flex; flex-wrap: wrap; gap: 4px; margin-bottom: 6px; }
+.hdMsgA {
+    color: var(--ink);
+    padding: 0;
+}
+.hdSources {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    margin-bottom: 6px;
+}
 .hdChip {
-  padding: 2px 8px; border-radius: 6px;
-  background: var(--accent-soft); color: var(--accent);
-  font-size: 10px; font-weight: 600;
+    padding: 2px 8px;
+    border-radius: 6px;
+    background: var(--accent-soft);
+    color: var(--accent);
+    font-size: 10px;
+    font-weight: 600;
 }
-.hdBody { font-size: 13px; line-height: 1.55; white-space: pre-wrap; }
-.hdBody strong { color: var(--ink); font-weight: 600; }
+.hdBody {
+    font-size: 13px;
+    line-height: 1.55;
+    white-space: pre-wrap;
+}
+.hdBody strong {
+    color: var(--ink);
+    font-weight: 600;
+}
 .hdInlineChip {
-  display: inline-flex; align-items: center;
-  padding: 1px 6px; margin: 0 2px;
-  border-radius: 5px;
-  background: var(--accent-soft); color: var(--accent);
-  font-size: 10px; font-weight: 600;
-  vertical-align: 1px;
+    display: inline-flex;
+    align-items: center;
+    padding: 1px 6px;
+    margin: 0 2px;
+    border-radius: 5px;
+    background: var(--accent-soft);
+    color: var(--accent);
+    font-size: 10px;
+    font-weight: 600;
+    vertical-align: 1px;
 }
 
 /* ---------------- SECTIONS ---------------- */
-.section { padding: clamp(64px, 9vh, 120px) clamp(20px, 3vw, 32px); position: relative; }
-.sectionTight { padding: clamp(48px, 6.5vh, 88px) clamp(20px, 3vw, 32px); position: relative; }
-.container { max-width: min(1180px, 100%); margin: 0 auto; }
+.section {
+    padding: clamp(64px, 9vh, 120px) clamp(20px, 3vw, 32px);
+    position: relative;
+}
+.sectionTight {
+    padding: clamp(48px, 6.5vh, 88px) clamp(20px, 3vw, 32px);
+    position: relative;
+}
+.container {
+    max-width: min(1180px, 100%);
+    margin: 0 auto;
+}
 .eyebrow {
-  display: inline-flex; align-items: center; gap: 10px;
-  font-size: 12px; font-weight: 600; letter-spacing: 0.1em;
-  text-transform: uppercase; color: var(--accent);
-  margin-bottom: 18px;
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin-bottom: 18px;
 }
 .eyebrow::before {
-  content: ''; width: 16px; height: 1px; background: var(--accent);
+    content: "";
+    width: 16px;
+    height: 1px;
+    background: var(--accent);
 }
 .h2 {
-  margin: 0 0 18px;
-  font-size: clamp(34px, 4.4vw, 54px);
-  line-height: 1.05; letter-spacing: -0.03em;
-  font-weight: 600; max-width: 820px;
-  color: var(--ink);
+    margin: 0 0 18px;
+    font-size: clamp(34px, 4.4vw, 54px);
+    line-height: 1.05;
+    letter-spacing: -0.03em;
+    font-weight: 600;
+    max-width: 820px;
+    color: var(--ink);
 }
 .lead {
-  font-size: clamp(16px, 1.2vw, 18px); color: var(--ink-2);
-  max-width: 620px; line-height: 1.55;
-  margin: 0 0 56px;
+    font-size: clamp(16px, 1.2vw, 18px);
+    color: var(--ink-2);
+    max-width: 620px;
+    line-height: 1.55;
+    margin: 0 0 56px;
 }
 
 /* PROBLEM */
-.problemGrid { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
-@media (max-width: 780px) { .problemGrid { grid-template-columns: 1fr; } }
-.pcard {
-  padding: 28px 28px 24px; border-radius: 18px;
-  background: var(--panel); border: 1px solid var(--line-2);
+.problemGrid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 20px;
 }
-.pcardBad { background: var(--bg-2); }
+@media (max-width: 780px) {
+    .problemGrid {
+        grid-template-columns: 1fr;
+    }
+}
+.pcard {
+    padding: 28px 28px 24px;
+    border-radius: 18px;
+    background: var(--panel);
+    border: 1px solid var(--line-2);
+}
+.pcardBad {
+    background: var(--bg-2);
+}
 .pcard h3 {
-  margin: 0 0 16px; font-size: 13px; font-weight: 600;
-  color: var(--ink-3); text-transform: uppercase; letter-spacing: 0.08em;
+    margin: 0 0 16px;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--ink-3);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
 }
 .prow {
-  display: flex; align-items: flex-start; gap: 12px;
-  padding: 12px 0; border-top: 1px dashed var(--line);
-  font-size: 15px; color: var(--ink); line-height: 1.45;
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 12px 0;
+    border-top: 1px dashed var(--line);
+    font-size: 15px;
+    color: var(--ink);
+    line-height: 1.45;
 }
-.prow:first-of-type { border-top: none; padding-top: 4px; }
+.prow:first-of-type {
+    border-top: none;
+    padding-top: 4px;
+}
 .icon {
-  flex-shrink: 0; width: 20px; height: 20px; border-radius: 50%;
-  display: flex; align-items: center; justify-content: center;
-  font-size: 11px; font-weight: 700; margin-top: 1px;
+    flex-shrink: 0;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 11px;
+    font-weight: 700;
+    margin-top: 1px;
 }
-.iconBad { background: oklch(0.95 0.04 30); color: oklch(0.5 0.2 30); }
-.iconGood { background: oklch(0.95 0.06 150); color: oklch(0.5 0.18 150); }
+.iconBad {
+    background: oklch(0.95 0.04 30);
+    color: oklch(0.5 0.2 30);
+}
+.iconGood {
+    background: oklch(0.95 0.06 150);
+    color: oklch(0.5 0.18 150);
+}
 
 /* WORKFLOWS / STEPS */
-.workflows { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
-@media (max-width: 900px) { .workflows { grid-template-columns: 1fr; } }
+.workflows {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 18px;
+}
+@media (max-width: 900px) {
+    .workflows {
+        grid-template-columns: 1fr;
+    }
+}
 .workflow {
-  padding: 28px; border-radius: 16px;
-  background: var(--panel); border: 1px solid var(--line-2);
-  transition: all .3s;
+    padding: 28px;
+    border-radius: 16px;
+    background: var(--panel);
+    border: 1px solid var(--line-2);
+    transition:
+        background-color var(--dur-base) var(--ease-inout),
+        border-color var(--dur-base) var(--ease-inout),
+        color var(--dur-base) var(--ease-inout),
+        transform var(--dur-base) var(--ease-exit),
+        box-shadow var(--dur-base) var(--ease-inout);
 }
 .workflow:hover {
-  border-color: var(--accent); transform: translateY(-4px);
-  box-shadow: 0 20px 40px oklch(0 0 0 / 0.06);
+    border-color: var(--accent);
+    transform: translateY(-4px);
+    box-shadow: 0 20px 40px oklch(0 0 0 / 0.06);
 }
 .workflowNum {
-  font-family: var(--font-instrument-serif, 'Instrument Serif'), Georgia, serif;
-  font-style: italic;
-  font-size: 52px; color: var(--accent); line-height: 1; margin-bottom: 10px;
+    font-family: var(--font-jetbrains-mono, "JetBrains Mono"), ui-monospace, monospace;
+    font-size: 34px;
+    font-weight: 600;
+    font-variant-numeric: tabular-nums;
+    color: var(--accent);
+    line-height: 1;
+    margin-bottom: 10px;
+    opacity: 0.85;
 }
-.workflow h4 { margin: 0 0 10px; font-size: 19px; font-weight: 600; letter-spacing: -0.01em; color: var(--ink); }
-.workflow p { margin: 0; font-size: 14px; color: var(--ink-2); line-height: 1.55; }
+.workflow h4 {
+    margin: 0 0 10px;
+    font-size: 19px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    color: var(--ink);
+}
+.workflow p {
+    margin: 0;
+    font-size: 14px;
+    color: var(--ink-2);
+    line-height: 1.55;
+}
 
 /* TESTIMONIALS */
-.testimonials { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
-@media (max-width: 900px) { .testimonials { grid-template-columns: 1fr; } }
+.testimonials {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 18px;
+}
+@media (max-width: 900px) {
+    .testimonials {
+        grid-template-columns: 1fr;
+    }
+}
 .testi {
-  padding: 26px; border-radius: 16px;
-  background: var(--panel); border: 1px solid var(--line-2);
-  display: flex; flex-direction: column;
+    padding: 26px;
+    border-radius: 16px;
+    background: var(--panel);
+    border: 1px solid var(--line-2);
+    display: flex;
+    flex-direction: column;
 }
 .testi blockquote {
-  margin: 0 0 18px; font-size: 16px; line-height: 1.55; color: var(--ink);
-  font-family: var(--font-instrument-serif, 'Instrument Serif'), Georgia, serif;
-  font-style: italic;
+    margin: 0 0 18px;
+    font-size: 16px;
+    line-height: 1.55;
+    color: var(--ink);
+    font-family: var(--font-instrument-serif, "Instrument Serif"), Georgia, serif;
+    font-style: italic;
 }
-.testi blockquote::before { content: '"'; color: var(--accent); font-size: 22px; }
-.testi blockquote::after { content: '"'; color: var(--accent); font-size: 22px; }
-.testiWho { display: flex; align-items: center; gap: 12px; margin-top: auto; }
+.testi blockquote::before {
+    content: '"';
+    color: var(--accent);
+    font-size: 22px;
+}
+.testi blockquote::after {
+    content: '"';
+    color: var(--accent);
+    font-size: 22px;
+}
+.testiWho {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-top: auto;
+}
 .testiAvatar {
-  width: 36px; height: 36px; border-radius: 50%;
-  background: linear-gradient(135deg, var(--accent), var(--accent-deep));
-  display: flex; align-items: center; justify-content: center;
-  color: white; font-weight: 600; font-size: 13px;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, var(--accent), var(--accent-deep));
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: white;
+    font-weight: 600;
+    font-size: 13px;
 }
-.testiName { font-size: 14px; font-weight: 600; color: var(--ink); }
-.testiRole { font-size: 12px; color: var(--ink-3); }
+.testiName {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--ink);
+}
+.testiRole {
+    font-size: 12px;
+    color: var(--ink-3);
+}
 
 /* PRICING */
-.pricingGrid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
-@media (max-width: 900px) { .pricingGrid { grid-template-columns: 1fr; } }
+.pricingGrid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 18px;
+}
+@media (max-width: 900px) {
+    .pricingGrid {
+        grid-template-columns: 1fr;
+    }
+}
 .price {
-  padding: 32px 28px; border-radius: 20px;
-  background: var(--panel); border: 1px solid var(--line-2);
-  display: flex; flex-direction: column;
-  position: relative;
+    padding: 32px 28px;
+    border-radius: 20px;
+    background: var(--panel);
+    border: 1px solid var(--line-2);
+    display: flex;
+    flex-direction: column;
+    position: relative;
 }
 .priceFeatured {
-  border-color: var(--accent);
-  box-shadow: 0 0 0 1px var(--accent), 0 20px 50px var(--accent-glow);
+    border-color: var(--accent);
+    box-shadow:
+        0 0 0 1px var(--accent),
+        0 20px 50px var(--accent-glow);
 }
 .priceBadge {
-  position: absolute; top: -12px; left: 28px;
-  padding: 4px 10px; border-radius: 999px;
-  background: var(--accent); color: white;
-  font-size: 11px; font-weight: 600; letter-spacing: 0.04em;
+    position: absolute;
+    top: -12px;
+    left: 28px;
+    padding: 4px 10px;
+    border-radius: 999px;
+    background: var(--accent);
+    color: white;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.04em;
 }
-.price h3 { margin: 0 0 6px; font-size: 15px; font-weight: 600; color: var(--ink-3); }
+.price h3 {
+    margin: 0 0 6px;
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--ink-3);
+}
 .priceAmount {
-  margin: 0 0 4px; font-size: 48px; font-weight: 600;
-  letter-spacing: -0.03em; line-height: 1;
-  color: var(--ink);
+    margin: 0 0 4px;
+    font-size: 48px;
+    font-weight: 600;
+    letter-spacing: -0.03em;
+    line-height: 1;
+    color: var(--ink);
 }
-.priceAmount span { font-size: 18px; color: var(--ink-3); font-weight: 500; }
-.priceTagline { font-size: 14px; color: var(--ink-2); margin: 0 0 22px; }
-.price ul { list-style: none; padding: 0; margin: 0 0 24px; display: flex; flex-direction: column; gap: 9px; }
+.priceAmount span {
+    font-size: 18px;
+    color: var(--ink-3);
+    font-weight: 500;
+}
+.priceTagline {
+    font-size: 14px;
+    color: var(--ink-2);
+    margin: 0 0 22px;
+}
+.price ul {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 9px;
+}
 .price li {
-  font-size: 14px; color: var(--ink); display: flex;
-  gap: 10px; align-items: flex-start; line-height: 1.4;
+    font-size: 14px;
+    color: var(--ink);
+    display: flex;
+    gap: 10px;
+    align-items: flex-start;
+    line-height: 1.4;
 }
-.price li svg { flex-shrink: 0; margin-top: 3px; color: var(--accent); }
-.price .btn { width: 100%; justify-content: center; padding: 12px 18px; margin-top: auto; }
+.price li svg {
+    flex-shrink: 0;
+    margin-top: 3px;
+    color: var(--accent);
+}
+.price .btn {
+    width: 100%;
+    justify-content: center;
+    padding: 12px 18px;
+    margin-top: auto;
+}
 
 /* FAQ */
-.faq { max-width: 780px; margin: 0 auto; }
-.faqItem { border-bottom: 1px solid var(--line-2); padding: 18px 0; }
+.faq {
+    max-width: 780px;
+    margin: 0 auto;
+}
+.faqItem {
+    border-bottom: 1px solid var(--line-2);
+    padding: 18px 0;
+}
 .faqQ {
-  display: flex; align-items: center; justify-content: space-between;
-  cursor: pointer; font-size: 17px; font-weight: 500; color: var(--ink);
-  user-select: none; gap: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    cursor: pointer;
+    font-size: 17px;
+    font-weight: 500;
+    color: var(--ink);
+    user-select: none;
+    gap: 20px;
 }
-.faqQ svg { transition: transform .25s; color: var(--ink-3); flex-shrink: 0; }
-.faqItemOpen .faqQ svg { transform: rotate(45deg); color: var(--accent); }
+.faqQ svg {
+    transition: transform 0.25s;
+    color: var(--ink-3);
+    flex-shrink: 0;
+}
+.faqItemOpen .faqQ svg {
+    transform: rotate(45deg);
+    color: var(--accent);
+}
 .faqA {
-  max-height: 0; overflow: hidden;
-  transition: max-height .3s, margin-top .3s;
-  font-size: 15px; color: var(--ink-2); line-height: 1.6;
+    max-height: 0;
+    overflow: hidden;
+    transition:
+        max-height 0.3s,
+        margin-top 0.3s;
+    font-size: 15px;
+    color: var(--ink-2);
+    line-height: 1.6;
 }
-.faqItemOpen .faqA { max-height: 500px; margin-top: 12px; }
+.faqItemOpen .faqA {
+    max-height: 500px;
+    margin-top: 12px;
+}
 
 /* FINAL CTA */
 .finalCta {
-  margin: clamp(48px, 7vh, 80px) clamp(16px, 2.4vw, 32px) clamp(24px, 3.5vh, 40px);
-  padding: clamp(48px, 8vh, 96px) clamp(24px, 3.4vw, 48px); border-radius: 28px;
-  background:
-    radial-gradient(ellipse 70% 70% at 50% 50%, var(--accent-glow) 0%, transparent 70%),
-    linear-gradient(180deg, var(--panel) 0%, var(--bg-2) 100%);
-  text-align: center;
-  border: 1px solid var(--line);
-  position: relative; overflow: hidden;
+    margin: clamp(48px, 7vh, 80px) clamp(16px, 2.4vw, 32px) clamp(24px, 3.5vh, 40px);
+    padding: clamp(48px, 8vh, 96px) clamp(24px, 3.4vw, 48px);
+    border-radius: 28px;
+    background:
+        radial-gradient(ellipse 70% 70% at 50% 50%, var(--accent-glow) 0%, transparent 70%),
+        linear-gradient(180deg, var(--panel) 0%, var(--bg-2) 100%);
+    text-align: center;
+    border: 1px solid var(--line);
+    position: relative;
+    overflow: hidden;
 }
 .finalCta::before {
-  content: ''; position: absolute; inset: 0;
-  background:
-    radial-gradient(circle at 20% 80%, oklch(0.7 0.2 285 / 0.12), transparent 40%),
-    radial-gradient(circle at 80% 20%, oklch(0.6 0.22 340 / 0.12), transparent 40%);
-  pointer-events: none;
+    content: "";
+    position: absolute;
+    inset: 0;
+    background:
+        radial-gradient(circle at 20% 80%, oklch(0.7 0.2 285 / 0.12), transparent 40%),
+        radial-gradient(circle at 80% 20%, oklch(0.6 0.22 340 / 0.12), transparent 40%);
+    pointer-events: none;
 }
-.finalCta .h2 { margin: 0 auto 18px; max-width: 720px; position: relative; }
-.finalCta p { position: relative; font-size: 17px; color: var(--ink-2); max-width: 540px; margin: 0 auto 30px; }
-.finalCta .heroCtas { position: relative; justify-content: center; }
+.finalCta .h2 {
+    margin: 0 auto 18px;
+    max-width: 720px;
+    position: relative;
+}
+.finalCta p {
+    position: relative;
+    font-size: 17px;
+    color: var(--ink-2);
+    max-width: 540px;
+    margin: 0 auto 30px;
+}
+.finalCta .heroCtas {
+    position: relative;
+    justify-content: center;
+}
 
 /* OPEN SOURCE */
 .oss {
-  margin-top: clamp(24px, 4vh, 40px);
-  padding: clamp(28px, 4vw, 48px);
-  border-radius: 22px;
-  background:
-    radial-gradient(ellipse 70% 100% at 0% 0%, var(--accent-glow) 0%, transparent 55%),
-    var(--panel);
-  border: 1px solid var(--line-2);
-  display: grid; grid-template-columns: 1.25fr 1fr;
-  gap: 40px; align-items: center;
-  position: relative; overflow: hidden;
+    margin-top: clamp(24px, 4vh, 40px);
+    padding: clamp(28px, 4vw, 48px);
+    border-radius: 22px;
+    background:
+        radial-gradient(ellipse 70% 100% at 0% 0%, var(--accent-glow) 0%, transparent 55%),
+        var(--panel);
+    border: 1px solid var(--line-2);
+    display: grid;
+    grid-template-columns: 1.25fr 1fr;
+    gap: 40px;
+    align-items: center;
+    position: relative;
+    overflow: hidden;
 }
-@media (max-width: 900px) { .oss { grid-template-columns: 1fr; padding: 32px 24px; } }
+@media (max-width: 900px) {
+    .oss {
+        grid-template-columns: 1fr;
+        padding: 32px 24px;
+    }
+}
 .ossEyebrow {
-  display: inline-flex; align-items: center; gap: 8px;
-  font-size: 12px; font-weight: 600; color: var(--accent-ink);
-  text-transform: uppercase; letter-spacing: 0.12em;
-  margin-bottom: 14px;
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+    font-weight: 600;
+    color: var(--accent-ink);
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    margin-bottom: 14px;
 }
-.ossEyebrow svg { color: var(--accent); }
+.ossEyebrow svg {
+    color: var(--accent);
+}
 .oss h3 {
-  margin: 0 0 14px; font-size: clamp(26px, 2.6vw, 36px);
-  letter-spacing: -0.025em; line-height: 1.1; font-weight: 600;
-  color: var(--ink);
+    margin: 0 0 14px;
+    font-size: clamp(26px, 2.6vw, 36px);
+    letter-spacing: -0.025em;
+    line-height: 1.1;
+    font-weight: 600;
+    color: var(--ink);
 }
-.oss p { font-size: 15px; color: var(--ink-2); line-height: 1.6; margin: 0 0 22px; max-width: 54ch; }
-.ossCtas { display: flex; gap: 10px; flex-wrap: wrap; }
+.oss p {
+    font-size: 15px;
+    color: var(--ink-2);
+    line-height: 1.6;
+    margin: 0 0 22px;
+    max-width: 54ch;
+}
+.ossCtas {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+}
 .ossCard {
-  background: var(--bg);
-  border: 1px solid var(--line);
-  border-radius: 14px;
-  padding: 18px;
-  font-family: var(--font-jetbrains-mono, 'JetBrains Mono'), ui-monospace, monospace;
-  font-size: 12px;
-  box-shadow: 0 24px 50px oklch(0 0 0 / 0.06);
+    background: var(--bg);
+    border: 1px solid var(--line);
+    border-radius: 14px;
+    padding: 18px;
+    font-family: var(--font-jetbrains-mono, "JetBrains Mono"), ui-monospace, monospace;
+    font-size: 12px;
+    box-shadow: 0 24px 50px oklch(0 0 0 / 0.06);
 }
 .ossCardHd {
-  display: flex; align-items: center; gap: 8px;
-  padding-bottom: 12px; margin-bottom: 12px;
-  border-bottom: 1px solid var(--line-2);
-  color: var(--ink-2);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding-bottom: 12px;
+    margin-bottom: 12px;
+    border-bottom: 1px solid var(--line-2);
+    color: var(--ink-2);
 }
-.ossCardHd svg { color: var(--ink); }
-.ossCardHd .repo { font-weight: 600; color: var(--ink); }
-.ossCardHd .slash { color: var(--ink-4); }
+.ossCardHd svg {
+    color: var(--ink);
+}
+.ossCardHd .repo {
+    font-weight: 600;
+    color: var(--ink);
+}
+.ossCardHd .slash {
+    color: var(--ink-4);
+}
 .ossCardHd .star {
-  margin-left: auto;
-  display: inline-flex; align-items: center; gap: 4px;
-  padding: 3px 8px; border-radius: 6px;
-  background: var(--panel-2); color: var(--ink-2);
-  font-size: 11px;
+    margin-left: auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 3px 8px;
+    border-radius: 6px;
+    background: var(--panel-2);
+    color: var(--ink-2);
+    font-size: 11px;
 }
-.ossCardHd .star svg { color: oklch(0.7 0.17 85); }
+.ossCardHd .star svg {
+    color: oklch(0.7 0.17 85);
+}
 .ossTree {
-  display: flex; flex-direction: column; gap: 6px;
-  color: var(--ink-2); line-height: 1.5;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    color: var(--ink-2);
+    line-height: 1.5;
 }
-.ossTree .row { display: flex; align-items: center; gap: 8px; }
-.ossTree .row svg { color: var(--ink-3); flex-shrink: 0; }
-.ossTree .name { color: var(--ink); }
-.ossTree .comment { color: var(--ink-3); margin-left: auto; font-size: 11px; }
-.ossTree .rowNested { padding-left: 16px; }
+.ossTree .row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+.ossTree .row svg {
+    color: var(--ink-3);
+    flex-shrink: 0;
+}
+.ossTree .name {
+    color: var(--ink);
+}
+.ossTree .comment {
+    color: var(--ink-3);
+    margin-left: auto;
+    font-size: 11px;
+}
+.ossTree .rowNested {
+    padding-left: 16px;
+}
 
 /* FOOTER */
 .footer {
-  padding: clamp(36px, 6vh, 64px) clamp(20px, 3vw, 32px) clamp(20px, 3vh, 36px);
-  display: grid; grid-template-columns: 2fr 1fr 1fr 1fr;
-  gap: clamp(24px, 3vw, 40px);
-  border-top: 1px solid var(--line-2);
-  color: var(--ink-3); font-size: 14px;
+    padding: clamp(36px, 6vh, 64px) clamp(20px, 3vw, 32px) clamp(20px, 3vh, 36px);
+    display: grid;
+    grid-template-columns: 2fr 1fr 1fr 1fr;
+    gap: clamp(24px, 3vw, 40px);
+    border-top: 1px solid var(--line-2);
+    color: var(--ink-3);
+    font-size: 14px;
 }
-@media (max-width: 780px) { .footer { grid-template-columns: 1fr 1fr; } }
+@media (max-width: 780px) {
+    .footer {
+        grid-template-columns: 1fr 1fr;
+    }
+}
 .footer h5 {
-  margin: 0 0 12px; font-size: 13px; font-weight: 600;
-  color: var(--ink); letter-spacing: 0.02em;
+    margin: 0 0 12px;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--ink);
+    letter-spacing: 0.02em;
 }
-.footer ul { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 10px; }
-.footer a { color: var(--ink-3); text-decoration: none; transition: color .2s; }
-.footer a:hover { color: var(--ink); }
+.footer ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+.footer a {
+    color: var(--ink-3);
+    text-decoration: none;
+    transition: color 0.2s;
+}
+.footer a:hover {
+    color: var(--ink);
+}
 .footTag {
-  color: var(--ink-3); font-size: 13px; margin-top: 10px;
-  max-width: 300px; line-height: 1.5;
+    color: var(--ink-3);
+    font-size: 13px;
+    margin-top: 10px;
+    max-width: 300px;
+    line-height: 1.5;
 }
 .footBottom {
-  grid-column: 1 / -1;
-  border-top: 1px solid var(--line-2);
-  padding-top: 22px; margin-top: 18px;
-  display: flex; justify-content: space-between; align-items: center;
-  font-size: 12px; color: var(--ink-4);
+    grid-column: 1 / -1;
+    border-top: 1px solid var(--line-2);
+    padding-top: 22px;
+    margin-top: 18px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 12px;
+    color: var(--ink-4);
 }
 
 /* STATS strip */
 .statsStrip {
-  border-top: 1px solid var(--line-2);
-  border-bottom: 1px solid var(--line-2);
-  padding: clamp(24px, 4vh, 44px) clamp(20px, 3vw, 32px);
-  margin: clamp(16px, 2.5vh, 32px) 0;
+    border-top: 1px solid var(--line-2);
+    border-bottom: 1px solid var(--line-2);
+    padding: clamp(24px, 4vh, 44px) clamp(20px, 3vw, 32px);
+    margin: clamp(16px, 2.5vh, 32px) 0;
 }
 .statsGrid {
-  max-width: 1100px; margin: 0 auto;
-  display: grid; grid-template-columns: repeat(4, 1fr);
-  gap: 24px;
+    max-width: 1100px;
+    margin: 0 auto;
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 24px;
 }
-@media (max-width: 720px) { .statsGrid { grid-template-columns: repeat(2, 1fr); } }
-.statItem { text-align: center; }
+@media (max-width: 720px) {
+    .statsGrid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+.statItem {
+    text-align: center;
+}
 .statNum {
-  font-size: clamp(28px, 3vw, 40px);
-  font-weight: 600; letter-spacing: -0.03em;
-  color: var(--accent);
-  line-height: 1;
-  font-variant-numeric: tabular-nums;
+    font-size: clamp(28px, 3vw, 40px);
+    font-weight: 600;
+    letter-spacing: -0.03em;
+    color: var(--accent);
+    line-height: 1;
+    font-variant-numeric: tabular-nums;
 }
 .statLabel {
-  margin-top: 8px; font-size: 12px; color: var(--ink-3);
-  text-transform: uppercase; letter-spacing: 0.08em;
+    margin-top: 8px;
+    font-size: 12px;
+    color: var(--ink-3);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
 }
 
 /* DOMAIN GRID (doc types) */
 .domainGrid {
-  display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px;
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 12px;
 }
-@media (max-width: 900px) { .domainGrid { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 900px) {
+    .domainGrid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
 .domain {
-  padding: 18px 16px; border-radius: 14px;
-  background: var(--bg-2);
-  border: 1px solid var(--line-2);
-  transition: all .2s;
+    padding: 18px 16px;
+    border-radius: 14px;
+    background: var(--bg-2);
+    border: 1px solid var(--line-2);
+    transition:
+        background-color var(--dur-base) var(--ease-inout),
+        border-color var(--dur-base) var(--ease-inout),
+        color var(--dur-base) var(--ease-inout),
+        transform var(--dur-fast) var(--ease-spring),
+        box-shadow var(--dur-base) var(--ease-inout);
 }
 .domain:hover {
-  border-color: var(--accent);
-  transform: translateY(-2px);
-  background: var(--panel);
+    border-color: var(--accent);
+    transform: translateY(-2px);
+    background: var(--panel);
 }
 .domain h3 {
-  font-size: 15px; font-weight: 600; color: var(--ink);
-  margin: 0 0 6px;
+    font-size: 15px;
+    font-weight: 600;
+    color: var(--ink);
+    margin: 0 0 6px;
 }
 .domain p {
-  font-size: 12px; color: var(--ink-3); line-height: 1.5; margin: 0;
+    font-size: 12px;
+    color: var(--ink-3);
+    line-height: 1.5;
+    margin: 0;
 }
 
 /* Generic reusable page styles */
-.pageShell { position: relative; z-index: 1; }
+.pageShell {
+    position: relative;
+    z-index: 1;
+}
 .pageHero {
-  padding: clamp(108px, 15vh, 160px) clamp(20px, 3vw, 32px) clamp(40px, 6vh, 72px);
-  max-width: 1180px; margin: 0 auto;
-  position: relative; z-index: 2;
+    padding: clamp(108px, 15vh, 160px) clamp(20px, 3vw, 32px) clamp(40px, 6vh, 72px);
+    max-width: 1180px;
+    margin: 0 auto;
+    position: relative;
+    z-index: 2;
 }
 .pageTitle {
-  margin: 0 0 22px;
-  font-size: clamp(40px, 5.2vw, 68px);
-  line-height: 1.02; letter-spacing: -0.035em;
-  font-weight: 600;
-  color: var(--ink);
-  max-width: 780px;
+    margin: 0 0 22px;
+    font-size: clamp(40px, 5.2vw, 68px);
+    line-height: 1.02;
+    letter-spacing: -0.035em;
+    font-weight: 600;
+    color: var(--ink);
+    max-width: 780px;
 }
 .pageSub {
-  font-size: clamp(16px, 1.3vw, 19px);
-  color: var(--ink-2); max-width: 640px;
-  line-height: 1.55; margin: 0 0 36px;
+    font-size: clamp(16px, 1.3vw, 19px);
+    color: var(--ink-2);
+    max-width: 640px;
+    line-height: 1.55;
+    margin: 0 0 36px;
 }


### PR DESCRIPTION
The landing page read as generic, and the reason turned out to be measurable rather than a matter of taste.

Across **15 animation and transition declarations there were exactly two easing functions** — `linear` (8×) and `ease-in-out` (7×) — and **no custom curve anywhere**. Everything moved on browser defaults, which is what made it feel uniformly floaty. Durations were ad hoc too: `.2s`, `.3s`, `2.2s`, then `26s/32s/38s/44s/50s/80s`.

## Motion

- **Three curves and three durations as tokens**, and every transition now picks from them. `transition: all` is gone from all five places it appeared — it animated layout properties too and named no curve at all.
- **The five ambient orbs no longer drift.** Five slowly floating radial gradients on 26–50s loops is the most recognisable tell of this genre. The wash gives the page depth; the motion only gave it away. Two of the five were noise stacked on noise and are gone entirely.
- **The dot grid no longer slides** on an 80s linear loop. A texture should sit still.
- **`prefers-reduced-motion` was guarding animations this commit deletes** — the orb drift and the dot slide — so it now covers what actually remains.

## Typography

- The hero's accent phrase was **italic serif inside a sans headline, on a skewed highlighter bar** — two halves of the same trope. It now differs by weight and colour within one family, over a plain rule.
- The step numerals were 52px italic serif. They're structure, not decoration, so they're now **tabular mono** — which also matches how the `/deployment` docs already look.

## Two bugs found on the way

**The active state never applied.** 

```jsx
className={`kp-card${active ? "kp-card--active" : ""}`}
```

Missing separator, so this produced the single class `kp-cardkp-card--active`. The pipeline pulse never fired.

**The pipeline text collided with its column labels.** The stage mixes an SVG that scales through its `viewBox` with HTML cards positioned in percentages but **sized in fixed pixels**. The SVG labels shrank with the stage and the card text didn't, so at narrower widths it overran its card and ran into the `SOURCES` / `INDEX` / `CONSUMERS` labels. The stage is now a query container and the card type scales on the same basis as the drawing — which also retires the fixed-px mobile overrides that were fighting the same symptom.

## Verification

Built and deployed to a live instance at each step. The collision is gone, the hero no longer carries the trope, and the app and file origins were untouched throughout. Typecheck clean; lint reports only two pre-existing warnings in a file this PR doesn't touch.

Scope was deliberately a motion and polish pass — layout and copy are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Landing-only CSS and presentational shell changes; no auth, data, or API impact.
> 
> **Overview**
> **Landing polish** centers on a shared motion system in `marketing.module.css`: three easing curves and durations on `.root`, explicit per-property transitions on buttons and cards (replacing generic `transition: all`), and broader `prefers-reduced-motion` handling.
> 
> **Ambient background** is toned down in `MarketingShell` and CSS: five drifting orbs become three static washes, dot-grid slide animation is removed, and drift keyframes are deleted.
> 
> **Typography** shifts away from template cues: `.serif` accents use bold sans + accent color instead of italic Instrument Serif; hero `.highlight` gets a simple underline instead of a skewed glow bar; workflow step numbers use tabular mono instead of large italic serif.
> 
> **Knowledge pipeline layout** in `LandingClient` `KP_CSS`: `.kp-stage` is an `inline-size` container query so card label/meta use `clamp(..., cqw, ...)` and scale with the SVG stage, fixing narrow-width text collision with column labels; redundant mobile font-size overrides for those labels are dropped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8726d30c6f167de8c7ccfe13243e1a174ece8fd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->