### PR TITLE
fix(distribution ui): lint errors surfaced by the repo-wide eslint run

### DIFF
--- a/apps/web/src/app/employer/tools/distribution/components/Overview.tsx
+++ b/apps/web/src/app/employer/tools/distribution/components/Overview.tsx
@@ -149,8 +149,8 @@ export function Overview({ state }: { state: DistributionState }) {
                         })}
                     </div>
                     <p className="text-ink-3 mt-3 text-[11px]">
-                        Cumulative: a partner at "qualified" also counts in every earlier stage.
-                        Median days per stage come from the timeline.
+                        Cumulative: a partner at &ldquo;qualified&rdquo; also counts in every
+                        earlier stage. Median days per stage come from the timeline.
                     </p>
                 </Card>
 
@@ -184,14 +184,13 @@ export function Overview({ state }: { state: DistributionState }) {
                                             <td className="text-ink-2 p-1 font-mono">{country}</td>
                                             {kinds.map(kind => {
                                                 const c = cell(country, kind);
-                                                const tone =
-                                                    !c || !c.targeted
-                                                        ? "bg-panel-2 text-ink-3"
-                                                        : c.covered > 0
-                                                          ? "bg-success-soft text-success"
-                                                          : c.inPipeline > 0
-                                                            ? "bg-brand-soft text-brand-ink"
-                                                            : "bg-warn-soft text-warn";
+                                                const tone = !c?.targeted
+                                                    ? "bg-panel-2 text-ink-3"
+                                                    : c.covered > 0
+                                                      ? "bg-success-soft text-success"
+                                                      : c.inPipeline > 0
+                                                        ? "bg-brand-soft text-brand-ink"
+                                                        : "bg-warn-soft text-warn";
                                                 const label = !c
                                                     ? "–"
                                                     : c.covered > 0

--- a/apps/web/src/app/employer/tools/distribution/components/PartnerDrawer.tsx
+++ b/apps/web/src/app/employer/tools/distribution/components/PartnerDrawer.tsx
@@ -56,29 +56,49 @@ function Cited({ label, ids }: { label: string; ids: number[] }) {
     );
 }
 
+/** Event payloads are untyped JSON; render scalars as text and anything else as JSON. */
+function text(value: unknown, fallback = ""): string {
+    if (value === null || value === undefined || value === "") return fallback;
+    if (typeof value === "string") return value;
+    if (typeof value === "number" || typeof value === "boolean") return String(value);
+    try {
+        return JSON.stringify(value);
+    } catch {
+        return fallback;
+    }
+}
+
 function eventText(e: EventDto): string {
-    const p = e.payload as Record<string, unknown>;
+    const p = e.payload;
     switch (e.type) {
         case "stage_changed":
-            return `Moved ${String(p.from)} → ${String(p.to)}`;
+            return `Moved ${text(p.from, "?")} → ${text(p.to, "?")}`;
         case "researched":
-            return `Researched (${String(p.status)}; fit ${String(p.fitScore)}; ${String(p.evidence)} evidence)`;
+            return `Researched (${text(p.status, "?")}; fit ${text(p.fitScore, "?")}; ${text(p.evidence, "0")} evidence)`;
         case "note":
-            return String(p.text ?? "Note");
+            return text(p.text, "Note");
         case "imported":
-            return `Imported at stage ${String(p.stage)}`;
-        case "agreement_signed":
-            return `Agreement recorded (${String(p.exclusivity)}${p.endsOn ? `, ends ${String(p.endsOn)}` : ""})`;
+            return `Imported at stage ${text(p.stage, "?")}`;
+        case "agreement_signed": {
+            const ends = text(p.endsOn);
+            return `Agreement recorded (${text(p.exclusivity, "none")}${ends ? `, ends ${ends}` : ""})`;
+        }
         case "owner_changed":
-            return `Owner set to ${String(p.ownerUserId)}`;
+            return `Owner set to ${text(p.ownerUserId, "?")}`;
         case "next_action_set":
-            return `Next action: ${String(p.nextAction ?? "—")}`;
-        case "reply_logged":
-            return `Reply logged${p.summary ? `: ${String(p.summary)}` : ""}`;
-        case "meeting":
-            return `Meeting${p.summary ? `: ${String(p.summary)}` : ""}`;
-        case "document_shared":
-            return `Document shared${p.title ? `: ${String(p.title)}` : ""}`;
+            return `Next action: ${text(p.nextAction, "—")}`;
+        case "reply_logged": {
+            const summary = text(p.summary);
+            return `Reply logged${summary ? `: ${summary}` : ""}`;
+        }
+        case "meeting": {
+            const summary = text(p.summary);
+            return `Meeting${summary ? `: ${summary}` : ""}`;
+        }
+        case "document_shared": {
+            const title = text(p.title);
+            return `Document shared${title ? `: ${title}` : ""}`;
+        }
         default:
             return e.type;
     }

--- a/apps/web/src/app/employer/tools/distribution/components/ProgramDialog.tsx
+++ b/apps/web/src/app/employer/tools/distribution/components/ProgramDialog.tsx
@@ -189,7 +189,9 @@ export function ProgramDialog({ open, mode, program, onClose, onSubmit }: Props)
                         />
                     </div>
                     <div className="grid gap-1.5">
-                        <Label htmlFor="pg-known">Existing partners' domains (one per line)</Label>
+                        <Label htmlFor="pg-known">
+                            Existing partners&rsquo; domains (one per line)
+                        </Label>
                         <Textarea
                             id="pg-known"
                             rows={2}


### PR DESCRIPTION
## Summary

- Follow-up to #384, which merged before this commit was pushed. The repo-wide `eslint .` run (as opposed to the per-directory runs used during development) flagged 11 errors in the new Distribution tool page: unescaped quotes in JSX text, an optional-chain preference, an unnecessary payload cast, and `String(unknown)` calls on event payload fields.
- Event payload fields now render through a small `text()` helper that prints scalars and JSON-encodes anything else.

## Related

Follow-up to https://github.com/Deodat-Lawson/LaunchStack/pull/384 (see its last comment for the full lint attribution).

## Checklist

- [x] `pnpm check` passes (lint + typecheck) — the touched directories lint clean from the repo root; web typecheck clean. One pre-existing repo-wide error remains in `apps/web/src/app/dev/sessions-browser/SessionsBrowserPreview.tsx`, untouched here.
- [x] `pnpm --filter @launchstack/web test` passes — no test files changed; UI components have no unit tests.
- [x] Changeset added — not needed (apps/web only, ignored by changesets).
- [x] New env vars documented — none.
- [ ] UI changes exercised in a browser — text-only and rendering-helper changes; not clicked through.
- [x] Docs updated if behavior changed — no behavior change.

## Testing

`pnpm exec eslint apps/web/src/app/employer/tools/distribution …` clean; `tsc --noEmit` in apps/web clean.

## Notes for reviewers

Three files, no behavior change beyond safer rendering of untyped timeline payloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint and display-string formatting only in Distribution UI; no API, auth, or data-path changes.
> 
> **Overview**
> Clears **repo-wide ESLint** failures in the employer Distribution tool UI (follow-up to #384) without changing product behavior.
> 
> **Overview** and **ProgramDialog** escape quotes/apostrophes in JSX copy (`qualified`, partners’ domains). **Overview** also rewrites coverage-cell styling to use optional chaining (`!c?.targeted`) per lint preference.
> 
> **PartnerDrawer** drops the redundant payload cast and routes timeline `eventText` fields through a new `text()` helper that renders strings/numbers/booleans and JSON-stringifies other payload values, with fallbacks instead of `String(unknown)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebcb3d82c9fe4c7e844d0d2c6f846bfd7637a37d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->