### PR TITLE
Mindmap: reliable text editing, unified shape library, bound connectors, Lucid-style canvas interactions

### DIFF
--- a/apps/web/src/app/employer/mindmap/_mindmap/__tests__/canvas.render.test.tsx
+++ b/apps/web/src/app/employer/mindmap/_mindmap/__tests__/canvas.render.test.tsx
@@ -223,7 +223,12 @@ describe("selection", () => {
         });
 
         expect(store.selectedNodeIds()).toEqual([root.id]);
-        expect(view.container.querySelectorAll("[data-handle]").length).toBe(9);
+        // 8 grips + the rotation grip + 4 invisible edge bands (each side of
+        // the outline resizes too, Lucid-style).
+        expect(view.container.querySelectorAll("[data-handle]").length).toBe(13);
+        expect(
+            view.container.querySelectorAll("rect[data-handle='e'][fill='transparent']").length
+        ).toBe(1);
     });
 
     it("adds to the selection with shift-click", () => {
@@ -368,6 +373,179 @@ describe("dragging", () => {
         // Dragging into empty space creates the target topic and the connector.
         expect(page.nodes).toHaveLength(3);
         expect(page.edges).toHaveLength(2);
+    });
+
+    it("leaves the connector dangling from a non-topic shape instead of inventing a box", () => {
+        // The mindmap drag-out gesture is wrong for a flowchart: missing the
+        // drop target there must not create a node — the arrow stays, with a
+        // free endpoint that can be re-dragged onto the intended shape.
+        const box = createNode({ shape: "rectangle", x: 100, y: 100, w: 160, h: 90, text: "A" });
+        const doc = createDoc("Flow", [{ ...createPage(), nodes: [box], edges: [] }]);
+        const { store, view } = mount(doc);
+        const svg = svgOf(view.container);
+        store.selectNodes([box.id]);
+        view.rerender(
+            <TooltipProvider>
+                <EditorProvider store={store}>
+                    <Canvas callbacks={{ onContextMenuAt: jest.fn(), onEditText: jest.fn() }} />
+                </EditorProvider>
+            </TooltipProvider>
+        );
+
+        const port = svgOf(view.container).querySelector(
+            `[data-node-id="${box.id}"][data-port="e"] circle`
+        );
+        expect(port).not.toBeNull();
+
+        act(() => {
+            port!.dispatchEvent(
+                pointer("pointerdown", box.x + box.w, box.y + box.h / 2, {
+                    button: 0,
+                    buttons: 1,
+                })
+            );
+        });
+        act(() => {
+            svg.dispatchEvent(pointer("pointermove", 700, 400, { buttons: 1 }));
+        });
+        act(() => {
+            svg.dispatchEvent(pointer("pointerup", 700, 400, { buttons: 0 }));
+        });
+
+        const page = store.getState().doc.pages[0]!;
+        expect(page.nodes).toHaveLength(1);
+        expect(page.edges).toHaveLength(1);
+        expect(page.edges[0]!.to).toEqual({ point: { x: 700, y: 400 } });
+    });
+
+    it("binds the connector to the shape it is dropped on", () => {
+        // The regression: the svg holds pointer capture during the drag, so
+        // `e.target` was the svg on every move, the hover hit-test never saw
+        // the shape underneath, and a drop "onto" a shape landed as a free
+        // point sitting on top of it — the arrow then stayed behind when the
+        // shape moved.
+        const a = createNode({ shape: "rectangle", x: 100, y: 100, w: 160, h: 90, text: "A" });
+        const b = createNode({ shape: "rectangle", x: 500, y: 300, w: 160, h: 90, text: "B" });
+        const doc = createDoc("Flow", [{ ...createPage(), nodes: [a, b], edges: [] }]);
+        const { store, view } = mount(doc);
+        const svg = svgOf(view.container);
+        store.selectNodes([a.id]);
+        view.rerender(
+            <TooltipProvider>
+                <EditorProvider store={store}>
+                    <Canvas callbacks={{ onContextMenuAt: jest.fn(), onEditText: jest.fn() }} />
+                </EditorProvider>
+            </TooltipProvider>
+        );
+
+        const port = svgOf(view.container).querySelector(
+            `[data-node-id="${a.id}"][data-port="e"] circle`
+        );
+        expect(port).not.toBeNull();
+
+        act(() => {
+            port!.dispatchEvent(
+                pointer("pointerdown", a.x + a.w, a.y + a.h / 2, { button: 0, buttons: 1 })
+            );
+        });
+        act(() => {
+            // jsdom has no elementFromPoint, so the handler falls back to the
+            // event's own target — dispatching the move on B is the honest
+            // stand-in for the pointer being over B.
+            nodeElement(view.container, b.id).dispatchEvent(
+                pointer("pointermove", b.x + b.w / 2, b.y + b.h / 2, { buttons: 1 })
+            );
+        });
+        act(() => {
+            svg.dispatchEvent(pointer("pointerup", b.x + b.w / 2, b.y + b.h / 2, { buttons: 0 }));
+        });
+
+        const page = store.getState().doc.pages[0]!;
+        expect(page.nodes).toHaveLength(2);
+        expect(page.edges).toHaveLength(1);
+        expect(page.edges[0]!.from).toEqual({ nodeId: a.id, port: "e" });
+        expect(page.edges[0]!.to).toEqual({ nodeId: b.id, port: "auto" });
+    });
+
+    it("spawns a connected twin when a port is clicked without dragging", () => {
+        // Lucid's click-a-port: the next shape in that direction, already
+        // wired up. Same shape and size as the source, not a mindmap topic.
+        const box = createNode({ shape: "rectangle", x: 100, y: 100, w: 160, h: 90, text: "A" });
+        const doc = createDoc("Flow", [{ ...createPage(), nodes: [box], edges: [] }]);
+        const { store, view } = mount(doc);
+        const svg = svgOf(view.container);
+        store.selectNodes([box.id]);
+        view.rerender(
+            <TooltipProvider>
+                <EditorProvider store={store}>
+                    <Canvas callbacks={{ onContextMenuAt: jest.fn(), onEditText: jest.fn() }} />
+                </EditorProvider>
+            </TooltipProvider>
+        );
+
+        const port = svgOf(view.container).querySelector(
+            `[data-node-id="${box.id}"][data-port="e"] circle`
+        );
+        expect(port).not.toBeNull();
+
+        act(() => {
+            port!.dispatchEvent(
+                pointer("pointerdown", box.x + box.w, box.y + box.h / 2, {
+                    button: 0,
+                    buttons: 1,
+                })
+            );
+        });
+        act(() => {
+            svg.dispatchEvent(
+                pointer("pointerup", box.x + box.w, box.y + box.h / 2, { buttons: 0 })
+            );
+        });
+
+        const page = store.getState().doc.pages[0]!;
+        expect(page.nodes).toHaveLength(2);
+        const spawned = page.nodes[1]!;
+        expect(spawned.shape).toBe("rectangle");
+        expect(spawned.w).toBe(box.w);
+        expect(spawned.x).toBeGreaterThan(box.x + box.w);
+        expect(page.edges).toHaveLength(1);
+        expect(page.edges[0]!.from).toEqual({ nodeId: box.id, port: "e" });
+        expect(page.edges[0]!.to).toEqual({ nodeId: spawned.id, port: "auto" });
+        expect(store.selectedNodeIds()).toEqual([spawned.id]);
+    });
+});
+
+describe("right button", () => {
+    it("pans the canvas with a right-drag, no menu", () => {
+        const { store, view, callbacks } = mount();
+        const svg = svgOf(view.container);
+        act(() => {
+            svg.dispatchEvent(pointer("pointerdown", 500, 300, { button: 2, buttons: 2 }));
+        });
+        act(() => {
+            svg.dispatchEvent(pointer("pointermove", 560, 340, { buttons: 2 }));
+        });
+        act(() => {
+            svg.dispatchEvent(pointer("pointerup", 560, 340, { button: 2, buttons: 0 }));
+        });
+        const viewport = store.getState().viewport;
+        expect({ x: viewport.x, y: viewport.y }).not.toEqual({ x: 0, y: 0 });
+        expect(callbacks.onContextMenuAt).not.toHaveBeenCalled();
+    });
+
+    it("opens the context menu on a right-click that never travelled", () => {
+        const { callbacks, view } = mount();
+        const svg = svgOf(view.container);
+        act(() => {
+            svg.dispatchEvent(pointer("pointerdown", 500, 300, { button: 2, buttons: 2 }));
+        });
+        act(() => {
+            svg.dispatchEvent(pointer("pointerup", 500, 300, { button: 2, buttons: 0 }));
+        });
+        expect(callbacks.onContextMenuAt).toHaveBeenCalledWith(
+            { x: 500, y: 300 },
+            { kind: "canvas" }
+        );
     });
 });
 
@@ -554,16 +732,19 @@ describe("shape palette and toolbar", () => {
     it("arms a shape when a palette tile is chosen", async () => {
         const user = userEvent.setup();
         const { store } = mountChrome();
-        await user.click(screen.getAllByLabelText("Decision")[0]!);
+        await user.click(screen.getAllByLabelText("Diamond")[0]!);
         expect(store.getState().tool).toBe("shape");
-        expect(store.getState().pendingShape).toBe("decision");
+        expect(store.getState().pendingShape).toBe("diamond");
     });
 
     it("filters the palette by search", async () => {
         const user = userEvent.setup();
         mountChrome();
+        // "cylinder" survives as a keyword on the Database tile.
         await user.type(screen.getByPlaceholderText("Search shapes…"), "cylinder");
-        expect(screen.getAllByLabelText("Cylinder").length).toBeGreaterThan(0);
-        expect(screen.queryByLabelText("Decision")).toBeNull();
+        expect(screen.getAllByLabelText("Database").length).toBeGreaterThan(0);
+        // "Diamond" would still match the toolbar's quick-shape button, so the
+        // absence assertion uses a palette-only tile.
+        expect(screen.queryByLabelText("Trapezoid")).toBeNull();
     });
 });

--- a/apps/web/src/app/employer/mindmap/_mindmap/__tests__/comments.panel.test.tsx
+++ b/apps/web/src/app/employer/mindmap/_mindmap/__tests__/comments.panel.test.tsx
@@ -1,0 +1,64 @@
+/** @jest-environment jsdom */
+
+import React from "react";
+import { act, render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { addComment } from "../model/commands";
+import { createDoc, createNode, createPage } from "../model/factory";
+import { EditorStore } from "../model/store";
+import { CommentsPanel } from "../ui/CommentsPanel";
+import { EditorProvider } from "../ui/EditorContext";
+
+/**
+ * The comments panel's selection scoping: clicking a shape must surface that
+ * shape's threads under their own header, with the rest of the page demoted
+ * below — "what was said about this box?" answered by clicking the box.
+ */
+
+function mountPanel() {
+    const box = createNode({ shape: "rectangle", x: 10, y: 10, text: "Billing service" });
+    const other = createNode({ shape: "rectangle", x: 400, y: 10, text: "Queue" });
+    const doc = createDoc("Test map", [{ ...createPage(), nodes: [box, other], edges: [] }]);
+    const store = new EditorStore(doc);
+    addComment(store, { nodeId: box.id, at: { x: 170, y: 10 }, author: "Ana", body: "Rename this?" });
+    addComment(store, { nodeId: null, at: { x: 50, y: 300 }, author: "Ben", body: "Page note" });
+    const view = render(
+        <EditorProvider store={store}>
+            <CommentsPanel author="Test" canvasSize={{ w: 1000, h: 700 }} />
+        </EditorProvider>
+    );
+    return { store, view, box };
+}
+
+describe("selection scoping", () => {
+    it("lists every thread flat when nothing is selected", () => {
+        mountPanel();
+        expect(screen.getByText("2 threads")).toBeInTheDocument();
+        expect(screen.getByText("Rename this?")).toBeInTheDocument();
+        expect(screen.getByText("Page note")).toBeInTheDocument();
+        expect(screen.queryByText(/^On “/)).toBeNull();
+    });
+
+    it("surfaces the selected shape's threads under their own header", () => {
+        const { store } = mountPanel();
+        act(() => store.selectNodes([storeBoxId(store)]));
+        expect(screen.getByText("On “Billing service”")).toBeInTheDocument();
+        expect(screen.getByText("Elsewhere on this page")).toBeInTheDocument();
+        expect(screen.getByText("Rename this?")).toBeInTheDocument();
+    });
+
+    it("says so when the selected shape has no threads yet", () => {
+        const { store } = mountPanel();
+        const queue = store.getState().doc.pages[0]!.nodes[1]!;
+        act(() => store.selectNodes([queue.id]));
+        expect(screen.getByText("On “Queue”")).toBeInTheDocument();
+        expect(
+            screen.getByText("Nothing here yet — the box above posts to this shape.")
+        ).toBeInTheDocument();
+    });
+});
+
+function storeBoxId(store: EditorStore): string {
+    return store.getState().doc.pages[0]!.nodes[0]!.id;
+}

--- a/apps/web/src/app/employer/mindmap/_mindmap/__tests__/factory.presets.test.ts
+++ b/apps/web/src/app/employer/mindmap/_mindmap/__tests__/factory.presets.test.ts
@@ -1,0 +1,22 @@
+import { createNode } from "../model/factory";
+
+describe("container presets", () => {
+    it("gives groups and frames a visible outline by default", () => {
+        // A zero-weight, stroke-none container placed on the canvas shows
+        // nothing at all — which reads as the tool being broken, not as
+        // minimalism. Both modes, both containers.
+        for (const mode of ["light", "dark"] as const) {
+            for (const shape of ["group", "frame"] as const) {
+                const nd = createNode({ shape, mode, x: 0, y: 0 });
+                expect(nd.style.stroke).not.toBe("none");
+                expect(nd.style.strokeWidth).toBeGreaterThan(0);
+            }
+        }
+    });
+
+    it("keeps the group's fill open so its contents stay clickable", () => {
+        const nd = createNode({ shape: "group", x: 0, y: 0 });
+        expect(nd.style.fill).toBe("none");
+        expect(nd.style.strokeStyle).toBe("dashed");
+    });
+});

--- a/apps/web/src/app/employer/mindmap/_mindmap/__tests__/shapes.test.ts
+++ b/apps/web/src/app/employer/mindmap/_mindmap/__tests__/shapes.test.ts
@@ -146,18 +146,50 @@ describe("lookups", () => {
 });
 
 describe("search", () => {
-    it("returns everything for an empty query", () => {
-        expect(searchShapes("  ")).toHaveLength(SHAPES.length);
+    it("returns every offered shape for an empty query", () => {
+        expect(searchShapes("  ")).toHaveLength(SHAPES.filter(s => !s.paletteHidden).length);
     });
 
     it("matches on keywords, not just names", () => {
-        const hits = searchShapes("database").map(s => s.id);
+        const hits = searchShapes("cylinder").map(s => s.id);
+        // The cylinder tile is gone; its name is a keyword on Database.
         expect(hits).toContain("database");
-        // "cylinder" carries `database` as a keyword.
-        expect(hits).toContain("cylinder");
     });
 
     it("matches case-insensitively", () => {
-        expect(searchShapes("DECISION").map(s => s.id)).toContain("decision");
+        expect(searchShapes("DECISION").map(s => s.id)).toContain("diamond");
+    });
+});
+
+describe("the offered palette", () => {
+    const offered = SHAPES.filter(s => !s.paletteHidden);
+    const hidden = SHAPES.filter(s => s.paletteHidden);
+
+    it("never offers two tiles with the same silhouette in the Standard group", () => {
+        // The regression this guards: "Basic" and "Flowchart" used to offer
+        // identical outlines under different names (diamond ≡ decision,
+        // cylinder ≡ database), which made the library read as padded.
+        const seen = new Map<string, string>();
+        for (const shape of offered.filter(s => s.category === "Standard")) {
+            const g = shapeGeometry(shape.id, shape.defaultSize.w, shape.defaultSize.h, 0);
+            if (!g.path && !g.decorations?.length) continue; // pure text marks
+            const signature = [g.path, ...(g.decorations ?? []), ...(g.backing ?? [])].join("|");
+            const prior = seen.get(signature);
+            expect(prior ? `${prior} ≡ ${shape.id}` : shape.id).toBe(shape.id);
+            seen.set(signature, shape.id);
+        }
+    });
+
+    it("keeps every hidden duplicate reachable by its old name", () => {
+        for (const dupe of hidden) {
+            // Searching "decision" must offer the diamond, not nothing.
+            expect(searchShapes(dupe.name).length).toBeGreaterThan(0);
+        }
+    });
+
+    it("still resolves hidden ids, so existing documents render unchanged", () => {
+        for (const dupe of hidden) {
+            expect(shapeDef(dupe.id).id).toBe(dupe.id);
+        }
     });
 });

--- a/apps/web/src/app/employer/mindmap/_mindmap/__tests__/texteditor.test.tsx
+++ b/apps/web/src/app/employer/mindmap/_mindmap/__tests__/texteditor.test.tsx
@@ -1,0 +1,150 @@
+/** @jest-environment jsdom */
+
+import React from "react";
+import { act, fireEvent, render } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { createDoc, createNode, createPage } from "../model/factory";
+import { EditorStore } from "../model/store";
+import { TextEditorOverlay } from "../ui/TextEditorOverlay";
+import { EditorProvider } from "../ui/EditorContext";
+
+/**
+ * The in-place label editor.
+ *
+ * The focus assertions here pin the property that failed in the field: a
+ * mounted-but-unfocused textarea eats every keystroke silently, because
+ * commit rides on blur and a field that never had focus never blurs. jsdom
+ * implements focus faithfully enough to assert `document.activeElement`.
+ */
+
+function mountWith(nodes: ReturnType<typeof createNode>[]) {
+    const doc = createDoc("Test map", [{ ...createPage(), nodes, edges: [] }]);
+    const store = new EditorStore(doc);
+    const view = render(
+        <EditorProvider store={store}>
+            <TextEditorOverlay />
+        </EditorProvider>
+    );
+    return { store, view };
+}
+
+function field(container: HTMLElement): HTMLTextAreaElement {
+    const el = container.querySelector("textarea");
+    if (!el) throw new Error("label editor not mounted");
+    return el;
+}
+
+function pageNodes(store: EditorStore) {
+    return store.getState().doc.pages[0]!.nodes;
+}
+
+describe("focus", () => {
+    it("owns the keyboard the moment editing starts", () => {
+        const node = createNode({ shape: "mind-branch", x: 10, y: 10, text: "hello" });
+        const { store, view } = mountWith([node]);
+        act(() => store.setEditing({ kind: "node", id: node.id }));
+        expect(document.activeElement).toBe(field(view.container));
+    });
+
+    it("re-takes focus when the field remounts within one session", () => {
+        // A gesture can clear `editing` and a dblclick restore it for the same
+        // node without the effect deps changing — the remount must focus on
+        // its own, not rely on the effect having re-run.
+        const node = createNode({ shape: "mind-branch", x: 10, y: 10, text: "hello" });
+        const { store, view } = mountWith([node]);
+        act(() => store.setEditing({ kind: "node", id: node.id }));
+        act(() => store.setEditing(null));
+        expect(view.container.querySelector("textarea")).toBeNull();
+        act(() => store.setEditing({ kind: "node", id: node.id }));
+        expect(document.activeElement).toBe(field(view.container));
+    });
+
+    it("moves focus when the edit target changes without a remount", () => {
+        const a = createNode({ shape: "mind-branch", x: 10, y: 10, text: "a" });
+        const b = createNode({ shape: "mind-branch", x: 300, y: 10, text: "b" });
+        const { store, view } = mountWith([a, b]);
+        act(() => store.setEditing({ kind: "node", id: a.id }));
+        const el = field(view.container);
+        el.blur();
+        act(() => store.setEditing({ kind: "node", id: b.id }));
+        expect(field(view.container).value).toBe("b");
+        expect(document.activeElement).toBe(field(view.container));
+    });
+});
+
+describe("commit", () => {
+    it("lands pending text when the session is ended from outside", () => {
+        // Clicking the canvas clears `editing` at pointerdown, unmounting the
+        // field — and a removed element fires no blur. The typed words must
+        // survive that teardown; losing them silently was the bug.
+        const node = createNode({ shape: "mind-branch", x: 10, y: 10, text: "old" });
+        const { store, view } = mountWith([node]);
+        act(() => store.setEditing({ kind: "node", id: node.id }));
+        fireEvent.change(field(view.container), { target: { value: "new words" } });
+        act(() => store.setEditing(null));
+        expect(pageNodes(store).find(n => n.id === node.id)!.text).toBe("new words");
+    });
+
+    it("does not re-commit a session that Escape already settled", () => {
+        const node = createNode({ shape: "mind-branch", x: 10, y: 10, text: "old" });
+        const { store, view } = mountWith([node]);
+        act(() => store.setEditing({ kind: "node", id: node.id }));
+        fireEvent.change(field(view.container), { target: { value: "discarded" } });
+        fireEvent.keyDown(field(view.container), { key: "Escape" });
+        expect(pageNodes(store).find(n => n.id === node.id)!.text).toBe("old");
+    });
+});
+
+describe("text marks", () => {
+    it("fits the box to the words on commit", () => {
+        const mark = createNode({ shape: "text", x: 10, y: 10, w: 180, h: 44, text: "" });
+        const { store, view } = mountWith([mark]);
+        act(() => store.setEditing({ kind: "node", id: mark.id }));
+        const el = field(view.container);
+        fireEvent.change(el, { target: { value: "one\ntwo\nthree\nfour\nfive\nsix" } });
+        fireEvent.blur(el);
+        const after = pageNodes(store).find(n => n.id === mark.id)!;
+        expect(after.text).toBe("one\ntwo\nthree\nfour\nfive\nsix");
+        expect(after.h).toBeGreaterThan(44);
+    });
+
+    it("does not resize other shapes on commit", () => {
+        const box = createNode({ shape: "rectangle", x: 10, y: 10, w: 160, h: 90, text: "" });
+        const { store, view } = mountWith([box]);
+        act(() => store.setEditing({ kind: "node", id: box.id }));
+        const el = field(view.container);
+        fireEvent.change(el, { target: { value: "one\ntwo\nthree\nfour\nfive\nsix" } });
+        fireEvent.blur(el);
+        const after = pageNodes(store).find(n => n.id === box.id)!;
+        expect(after.w).toBe(160);
+        expect(after.h).toBe(90);
+    });
+
+    it("evaporates when committed empty", () => {
+        // A bare text mark has no fill and no stroke: an empty one can never
+        // be seen or selected again, so nothing may leave one behind.
+        const mark = createNode({ shape: "text", x: 10, y: 10, text: "" });
+        const { store, view } = mountWith([mark]);
+        act(() => store.setEditing({ kind: "node", id: mark.id }));
+        fireEvent.blur(field(view.container));
+        expect(pageNodes(store).find(n => n.id === mark.id)).toBeUndefined();
+    });
+
+    it("evaporates when a fresh one is cancelled", () => {
+        const mark = createNode({ shape: "text", x: 10, y: 10, text: "" });
+        const { store, view } = mountWith([mark]);
+        act(() => store.setEditing({ kind: "node", id: mark.id }));
+        fireEvent.keyDown(field(view.container), { key: "Escape" });
+        expect(pageNodes(store).find(n => n.id === mark.id)).toBeUndefined();
+    });
+
+    it("survives cancel once it has words", () => {
+        const mark = createNode({ shape: "text", x: 10, y: 10, text: "keep me" });
+        const { store, view } = mountWith([mark]);
+        act(() => store.setEditing({ kind: "node", id: mark.id }));
+        fireEvent.keyDown(field(view.container), { key: "Escape" });
+        const after = pageNodes(store).find(n => n.id === mark.id)!;
+        expect(after.text).toBe("keep me");
+    });
+});

--- a/apps/web/src/app/employer/mindmap/_mindmap/model/commands.ts
+++ b/apps/web/src/app/employer/mindmap/_mindmap/model/commands.ts
@@ -705,11 +705,23 @@ export function applyTheme(store: EditorStore, themeId: string): void {
 // Text
 // ---------------------------------------------------------------------------
 
-export function setNodeText(store: EditorStore, nodeId: string, text: string): void {
-    store.updatePage(page => mapNodes(page, [nodeId], nd => ({ ...nd, text })), {
-        label: "Edit text",
-        coalesceKey: `text:${nodeId}`,
-    });
+export function setNodeText(
+    store: EditorStore,
+    nodeId: string,
+    text: string,
+    opts?: { fit?: boolean }
+): void {
+    store.updatePage(
+        page =>
+            mapNodes(page, [nodeId], nd => {
+                const next = { ...nd, text };
+                return opts?.fit ? fitToLabel(next) : next;
+            }),
+        {
+            label: "Edit text",
+            coalesceKey: `text:${nodeId}`,
+        }
+    );
 }
 
 export function setEdgeLabel(
@@ -742,26 +754,25 @@ export function setVAlign(store: EditorStore, valign: VAlign): void {
     styleTextSelection(store, { valign }, "Align text");
 }
 
+/** Width grows (never shrinks), height hugs the wrapped label. */
+function fitToLabel(nd: DiagramNode): DiagramNode {
+    if (!nd.text.trim()) return nd;
+    const box = shapeTextBox(nd.shape, nd.w, nd.h);
+    const padX = nd.w - box.w;
+    const padY = nd.h - box.h;
+    const laid = layoutText(nd.text, nd.textStyle, Math.max(box.w, 40));
+    const min = shapeDef(nd.shape).minSize;
+    return {
+        ...nd,
+        w: Math.max(nd.w, Math.ceil(laid.width + padX + 8), min.w),
+        h: Math.max(Math.ceil(laid.height + padY + 8), min.h),
+    };
+}
+
 /** Grow (never shrink below the shape minimum) so the label fits. */
 export function fitNodeToText(store: EditorStore, nodeIds: readonly string[]): void {
     if (nodeIds.length === 0) return;
-    store.updatePage(
-        page =>
-            mapNodes(page, nodeIds, nd => {
-                if (!nd.text.trim()) return nd;
-                const box = shapeTextBox(nd.shape, nd.w, nd.h);
-                const padX = nd.w - box.w;
-                const padY = nd.h - box.h;
-                const laid = layoutText(nd.text, nd.textStyle, Math.max(box.w, 40));
-                const min = shapeDef(nd.shape).minSize;
-                return {
-                    ...nd,
-                    w: Math.max(nd.w, Math.ceil(laid.width + padX + 8), min.w),
-                    h: Math.max(Math.ceil(laid.height + padY + 8), min.h),
-                };
-            }),
-        { label: "Fit to text" }
-    );
+    store.updatePage(page => mapNodes(page, nodeIds, fitToLabel), { label: "Fit to text" });
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/app/employer/mindmap/_mindmap/model/factory.ts
+++ b/apps/web/src/app/employer/mindmap/_mindmap/model/factory.ts
@@ -176,17 +176,27 @@ function presetFor(
             return {
                 style: {
                     // A frame is a slightly raised patch of paper, so it tracks
-                    // the paper rather than sitting at a fixed lightness.
-                    fill: mode === "dark" ? "oklch(0.235 0.018 285)" : "oklch(0.985 0.004 280)",
-                    stroke: mode === "dark" ? "oklch(0.36 0.02 285)" : "oklch(0.80 0.01 280)",
-                    strokeWidth: 1,
+                    // the paper rather than sitting at a fixed lightness — but
+                    // it must be *visibly* raised, or placing one reads as the
+                    // tool doing nothing.
+                    fill: mode === "dark" ? "oklch(0.245 0.018 285)" : "oklch(0.972 0.005 280)",
+                    stroke: mode === "dark" ? "oklch(0.42 0.02 285)" : "oklch(0.74 0.012 280)",
+                    strokeWidth: 1.5,
                     radius: 8,
                 },
                 text: { align: "left", valign: "middle", size: 12, color: n.inkSoft },
             };
         case "group":
             return {
-                style: { fill: "none", stroke: "none", strokeWidth: 0 },
+                // A brand-new group has to say it exists: a dashed hairline,
+                // the notation every tool uses for "these belong together".
+                // Zero-weight nothing made the feature look broken.
+                style: {
+                    fill: "none",
+                    stroke: n.hairline,
+                    strokeWidth: 1.5,
+                    strokeStyle: "dashed",
+                },
                 text: {},
             };
         case "swimlane-h":

--- a/apps/web/src/app/employer/mindmap/_mindmap/model/shapes.ts
+++ b/apps/web/src/app/employer/mindmap/_mindmap/model/shapes.ts
@@ -141,6 +141,12 @@ export interface ShapeDef {
     /** Rendered with no fill/stroke chrome — text or bitmap only. */
     chromeless?: boolean;
     /**
+     * Kept in the registry so existing documents render, but not offered in
+     * the palette: another tile with the same silhouette carries this shape's
+     * keywords (the diamond is the decision, the cylinder is the database).
+     */
+    paletteHidden?: boolean;
+    /**
      * Whether the shape carries a text label. Defaults to true: nearly every
      * shape here is a container you put words in, which is the whole point of
      * dropping one. The exceptions are the shapes with nothing to say — a
@@ -175,8 +181,8 @@ const BASIC: ShapeDef[] = [
     def({
         id: "rectangle",
         name: "Rectangle",
-        category: "Basic",
-        keywords: ["box", "square", "block"],
+        category: "Standard",
+        keywords: ["box", "square", "block", "process", "step"],
         defaultSize: { w: 160, h: 90 },
         minSize: { w: 12, h: 12 },
         ports: ALL8,
@@ -192,7 +198,7 @@ const BASIC: ShapeDef[] = [
     def({
         id: "rounded-rectangle",
         name: "Rounded rectangle",
-        category: "Basic",
+        category: "Standard",
         keywords: ["box", "card", "pill"],
         defaultSize: { w: 160, h: 90 },
         minSize: { w: 12, h: 12 },
@@ -203,7 +209,7 @@ const BASIC: ShapeDef[] = [
     def({
         id: "ellipse",
         name: "Ellipse",
-        category: "Basic",
+        category: "Standard",
         keywords: ["oval", "circle", "round"],
         defaultSize: { w: 160, h: 100 },
         minSize: { w: 12, h: 12 },
@@ -214,8 +220,8 @@ const BASIC: ShapeDef[] = [
     def({
         id: "circle",
         name: "Circle",
-        category: "Basic",
-        keywords: ["round", "dot"],
+        category: "Standard",
+        keywords: ["round", "dot", "connector", "junction"],
         defaultSize: { w: 120, h: 120 },
         minSize: { w: 12, h: 12 },
         keepAspect: true,
@@ -225,7 +231,7 @@ const BASIC: ShapeDef[] = [
     def({
         id: "diamond",
         name: "Diamond",
-        category: "Basic",
+        category: "Standard",
         keywords: ["rhombus", "decision", "choice"],
         defaultSize: { w: 160, h: 110 },
         minSize: { w: 24, h: 24 },
@@ -242,8 +248,8 @@ const BASIC: ShapeDef[] = [
     def({
         id: "triangle",
         name: "Triangle",
-        category: "Basic",
-        keywords: ["delta", "up"],
+        category: "Standard",
+        keywords: ["delta", "up", "extract", "split"],
         defaultSize: { w: 140, h: 120 },
         minSize: { w: 16, h: 16 },
         textBox: (w, h) => ({ x: w * 0.2, y: h * 0.42, w: w * 0.6, h: h * 0.5 }),
@@ -258,7 +264,7 @@ const BASIC: ShapeDef[] = [
     def({
         id: "right-triangle",
         name: "Right triangle",
-        category: "Basic",
+        category: "Standard",
         keywords: ["corner", "wedge"],
         defaultSize: { w: 130, h: 120 },
         minSize: { w: 16, h: 16 },
@@ -274,7 +280,7 @@ const BASIC: ShapeDef[] = [
     def({
         id: "pentagon",
         name: "Pentagon",
-        category: "Basic",
+        category: "Standard",
         keywords: ["five"],
         defaultSize: { w: 130, h: 120 },
         minSize: { w: 20, h: 20 },
@@ -283,7 +289,7 @@ const BASIC: ShapeDef[] = [
     def({
         id: "hexagon",
         name: "Hexagon",
-        category: "Basic",
+        category: "Standard",
         keywords: ["six", "preparation"],
         defaultSize: { w: 160, h: 100 },
         minSize: { w: 20, h: 20 },
@@ -302,7 +308,7 @@ const BASIC: ShapeDef[] = [
     def({
         id: "octagon",
         name: "Octagon",
-        category: "Basic",
+        category: "Standard",
         keywords: ["eight", "stop"],
         defaultSize: { w: 130, h: 120 },
         minSize: { w: 24, h: 24 },
@@ -326,7 +332,7 @@ const BASIC: ShapeDef[] = [
     def({
         id: "trapezoid",
         name: "Trapezoid",
-        category: "Basic",
+        category: "Standard",
         keywords: ["manual", "operation"],
         defaultSize: { w: 160, h: 90 },
         minSize: { w: 24, h: 16 },
@@ -342,8 +348,8 @@ const BASIC: ShapeDef[] = [
     def({
         id: "parallelogram",
         name: "Parallelogram",
-        category: "Basic",
-        keywords: ["data", "input", "output", "skew"],
+        category: "Standard",
+        keywords: ["data", "input", "output", "skew", "io"],
         defaultSize: { w: 170, h: 90 },
         minSize: { w: 24, h: 16 },
         geometry: (w, h) => ({
@@ -358,7 +364,7 @@ const BASIC: ShapeDef[] = [
     def({
         id: "star",
         name: "Star",
-        category: "Basic",
+        category: "Standard",
         keywords: ["favourite", "rating"],
         defaultSize: { w: 130, h: 125 },
         minSize: { w: 24, h: 24 },
@@ -368,7 +374,7 @@ const BASIC: ShapeDef[] = [
     def({
         id: "cross",
         name: "Cross",
-        category: "Basic",
+        category: "Standard",
         keywords: ["plus", "add"],
         defaultSize: { w: 120, h: 120 },
         minSize: { w: 24, h: 24 },
@@ -396,8 +402,9 @@ const BASIC: ShapeDef[] = [
     def({
         id: "cylinder",
         name: "Cylinder",
-        category: "Basic",
+        category: "Standard",
         keywords: ["database", "storage", "disk"],
+        paletteHidden: true,
         defaultSize: { w: 130, h: 140 },
         minSize: { w: 30, h: 40 },
         textBox: (w, h) => ({ x: TEXT_PAD, y: h * 0.24, w: Math.max(w - 16, 0), h: h * 0.6 }),
@@ -418,7 +425,7 @@ const BASIC: ShapeDef[] = [
     def({
         id: "cloud",
         name: "Cloud",
-        category: "Basic",
+        category: "Standard",
         keywords: ["internet", "service", "saas"],
         defaultSize: { w: 180, h: 110 },
         minSize: { w: 40, h: 30 },
@@ -437,7 +444,7 @@ const BASIC: ShapeDef[] = [
     def({
         id: "callout",
         name: "Callout",
-        category: "Basic",
+        category: "Standard",
         keywords: ["speech", "bubble", "comment"],
         defaultSize: { w: 170, h: 100 },
         minSize: { w: 40, h: 40 },
@@ -468,7 +475,7 @@ const BASIC: ShapeDef[] = [
     def({
         id: "chevron",
         name: "Chevron",
-        category: "Basic",
+        category: "Standard",
         keywords: ["step", "process", "phase"],
         defaultSize: { w: 170, h: 80 },
         minSize: { w: 40, h: 20 },
@@ -490,7 +497,7 @@ const BASIC: ShapeDef[] = [
     def({
         id: "bracket-pair",
         name: "Brackets",
-        category: "Basic",
+        category: "Standard",
         keywords: ["annotation", "span"],
         defaultSize: { w: 160, h: 90 },
         minSize: { w: 24, h: 24 },
@@ -646,8 +653,9 @@ const FLOWCHART: ShapeDef[] = [
     def({
         id: "process",
         name: "Process",
-        category: "Flowchart",
+        category: "Standard",
         keywords: ["step", "action", "rectangle"],
+        paletteHidden: true,
         defaultSize: { w: 170, h: 84 },
         minSize: { w: 24, h: 20 },
         rounded: true,
@@ -657,8 +665,9 @@ const FLOWCHART: ShapeDef[] = [
     def({
         id: "decision",
         name: "Decision",
-        category: "Flowchart",
+        category: "Standard",
         keywords: ["if", "branch", "diamond", "condition"],
+        paletteHidden: true,
         defaultSize: { w: 170, h: 110 },
         minSize: { w: 40, h: 30 },
         textBox: (w, h) => ({ x: w * 0.2, y: h * 0.25, w: w * 0.6, h: h * 0.5 }),
@@ -674,7 +683,7 @@ const FLOWCHART: ShapeDef[] = [
     def({
         id: "terminator",
         name: "Terminator",
-        category: "Flowchart",
+        category: "Standard",
         keywords: ["start", "end", "stadium", "pill"],
         defaultSize: { w: 160, h: 66 },
         minSize: { w: 40, h: 24 },
@@ -683,8 +692,9 @@ const FLOWCHART: ShapeDef[] = [
     def({
         id: "data",
         name: "Data",
-        category: "Flowchart",
+        category: "Standard",
         keywords: ["input", "output", "parallelogram", "io"],
+        paletteHidden: true,
         defaultSize: { w: 175, h: 84 },
         minSize: { w: 40, h: 24 },
         geometry: (w, h) => ({
@@ -699,7 +709,7 @@ const FLOWCHART: ShapeDef[] = [
     def({
         id: "document",
         name: "Document",
-        category: "Flowchart",
+        category: "Standard",
         keywords: ["report", "page", "paper"],
         defaultSize: { w: 165, h: 100 },
         minSize: { w: 40, h: 34 },
@@ -709,7 +719,7 @@ const FLOWCHART: ShapeDef[] = [
     def({
         id: "multi-document",
         name: "Multi-document",
-        category: "Flowchart",
+        category: "Standard",
         keywords: ["reports", "stack", "copies"],
         defaultSize: { w: 170, h: 110 },
         minSize: { w: 40, h: 40 },
@@ -732,7 +742,7 @@ const FLOWCHART: ShapeDef[] = [
     def({
         id: "predefined-process",
         name: "Predefined process",
-        category: "Flowchart",
+        category: "Standard",
         keywords: ["subroutine", "function", "call"],
         defaultSize: { w: 175, h: 84 },
         minSize: { w: 44, h: 24 },
@@ -762,7 +772,7 @@ const FLOWCHART: ShapeDef[] = [
     def({
         id: "internal-storage",
         name: "Internal storage",
-        category: "Flowchart",
+        category: "Standard",
         keywords: ["memory", "register"],
         defaultSize: { w: 165, h: 100 },
         minSize: { w: 40, h: 34 },
@@ -793,7 +803,7 @@ const FLOWCHART: ShapeDef[] = [
     def({
         id: "manual-input",
         name: "Manual input",
-        category: "Flowchart",
+        category: "Standard",
         keywords: ["keyboard", "entry"],
         defaultSize: { w: 165, h: 90 },
         minSize: { w: 40, h: 30 },
@@ -810,7 +820,7 @@ const FLOWCHART: ShapeDef[] = [
     def({
         id: "manual-operation",
         name: "Manual operation",
-        category: "Flowchart",
+        category: "Standard",
         keywords: ["hand", "manual", "trapezoid"],
         defaultSize: { w: 170, h: 88 },
         minSize: { w: 40, h: 26 },
@@ -826,8 +836,9 @@ const FLOWCHART: ShapeDef[] = [
     def({
         id: "preparation",
         name: "Preparation",
-        category: "Flowchart",
+        category: "Standard",
         keywords: ["setup", "init", "hexagon"],
+        paletteHidden: true,
         defaultSize: { w: 175, h: 90 },
         minSize: { w: 44, h: 26 },
         textBox: (w, h) => ({ x: w * 0.18, y: TEXT_PAD, w: w * 0.64, h: Math.max(h - 16, 0) }),
@@ -845,7 +856,7 @@ const FLOWCHART: ShapeDef[] = [
     def({
         id: "off-page-connector",
         name: "Off-page connector",
-        category: "Flowchart",
+        category: "Standard",
         keywords: ["link", "continue", "pentagon"],
         defaultSize: { w: 110, h: 100 },
         minSize: { w: 30, h: 30 },
@@ -863,8 +874,9 @@ const FLOWCHART: ShapeDef[] = [
     def({
         id: "connector-dot",
         name: "Connector",
-        category: "Flowchart",
+        category: "Standard",
         keywords: ["junction", "on-page", "circle"],
+        paletteHidden: true,
         defaultSize: { w: 64, h: 64 },
         minSize: { w: 16, h: 16 },
         keepAspect: true,
@@ -874,7 +886,7 @@ const FLOWCHART: ShapeDef[] = [
     def({
         id: "database",
         name: "Database",
-        category: "Flowchart",
+        category: "Standard",
         keywords: ["store", "sql", "cylinder", "disk"],
         defaultSize: { w: 130, h: 140 },
         minSize: { w: 32, h: 44 },
@@ -896,7 +908,7 @@ const FLOWCHART: ShapeDef[] = [
     def({
         id: "direct-data",
         name: "Direct data",
-        category: "Flowchart",
+        category: "Standard",
         keywords: ["drum", "disk"],
         defaultSize: { w: 165, h: 100 },
         minSize: { w: 44, h: 30 },
@@ -919,7 +931,7 @@ const FLOWCHART: ShapeDef[] = [
     def({
         id: "stored-data",
         name: "Stored data",
-        category: "Flowchart",
+        category: "Standard",
         keywords: ["archive", "tape"],
         defaultSize: { w: 165, h: 95 },
         minSize: { w: 44, h: 30 },
@@ -941,7 +953,7 @@ const FLOWCHART: ShapeDef[] = [
     def({
         id: "display",
         name: "Display",
-        category: "Flowchart",
+        category: "Standard",
         keywords: ["screen", "monitor", "output"],
         defaultSize: { w: 175, h: 90 },
         minSize: { w: 44, h: 30 },
@@ -963,7 +975,7 @@ const FLOWCHART: ShapeDef[] = [
     def({
         id: "delay",
         name: "Delay",
-        category: "Flowchart",
+        category: "Standard",
         keywords: ["wait", "pause"],
         defaultSize: { w: 165, h: 88 },
         minSize: { w: 44, h: 28 },
@@ -981,7 +993,7 @@ const FLOWCHART: ShapeDef[] = [
     def({
         id: "merge",
         name: "Merge",
-        category: "Flowchart",
+        category: "Standard",
         keywords: ["combine", "down triangle"],
         defaultSize: { w: 140, h: 90 },
         minSize: { w: 30, h: 24 },
@@ -997,8 +1009,9 @@ const FLOWCHART: ShapeDef[] = [
     def({
         id: "extract",
         name: "Extract",
-        category: "Flowchart",
+        category: "Standard",
         keywords: ["split", "up triangle"],
+        paletteHidden: true,
         defaultSize: { w: 140, h: 90 },
         minSize: { w: 30, h: 24 },
         textBox: (w, h) => ({ x: w * 0.2, y: h * 0.45, w: w * 0.6, h: h * 0.45 }),
@@ -1013,7 +1026,7 @@ const FLOWCHART: ShapeDef[] = [
     def({
         id: "or-junction",
         name: "Or",
-        category: "Flowchart",
+        category: "Standard",
         keywords: ["logical", "circle", "cross"],
         defaultSize: { w: 70, h: 70 },
         minSize: { w: 20, h: 20 },
@@ -1035,7 +1048,7 @@ const FLOWCHART: ShapeDef[] = [
     def({
         id: "summing-junction",
         name: "Summing junction",
-        category: "Flowchart",
+        category: "Standard",
         keywords: ["and", "circle", "x"],
         defaultSize: { w: 70, h: 70 },
         minSize: { w: 20, h: 20 },
@@ -1060,7 +1073,7 @@ const FLOWCHART: ShapeDef[] = [
     def({
         id: "sort",
         name: "Sort",
-        category: "Flowchart",
+        category: "Standard",
         keywords: ["order", "diamond"],
         defaultSize: { w: 150, h: 110 },
         minSize: { w: 30, h: 30 },
@@ -1083,7 +1096,7 @@ const FLOWCHART: ShapeDef[] = [
     def({
         id: "collate",
         name: "Collate",
-        category: "Flowchart",
+        category: "Standard",
         keywords: ["hourglass", "gather"],
         defaultSize: { w: 130, h: 110 },
         minSize: { w: 30, h: 30 },
@@ -1100,7 +1113,7 @@ const FLOWCHART: ShapeDef[] = [
     def({
         id: "loop-limit",
         name: "Loop limit",
-        category: "Flowchart",
+        category: "Standard",
         keywords: ["for", "while", "repeat"],
         defaultSize: { w: 165, h: 88 },
         minSize: { w: 44, h: 28 },
@@ -1553,8 +1566,7 @@ export const SHAPE_BY_ID: Record<string, ShapeDef> = Object.fromEntries(SHAPES.m
 export const SHAPE_CATEGORIES: readonly ShapeCategory[] = [
     "Nodes",
     "Annotate",
-    "Basic",
-    "Flowchart",
+    "Standard",
     "Arrows",
     "UML & ERD",
     "Containers",
@@ -1592,11 +1604,13 @@ export function isContainer(id: string): boolean {
     return shapeDef(id).container === true;
 }
 
-/** Free-text search over name + keywords, used by the palette filter. */
+/** Free-text search over name + keywords, used by the palette filter.
+ *  Hidden duplicates never match: their keywords live on the offered tile. */
 export function searchShapes(query: string): ShapeDef[] {
+    const offered = SHAPES.filter(s => !s.paletteHidden);
     const q = query.trim().toLowerCase();
-    if (!q) return [...SHAPES];
-    return SHAPES.filter(
+    if (!q) return offered;
+    return offered.filter(
         s =>
             s.name.toLowerCase().includes(q) ||
             s.id.includes(q) ||

--- a/apps/web/src/app/employer/mindmap/_mindmap/model/types.ts
+++ b/apps/web/src/app/employer/mindmap/_mindmap/model/types.ts
@@ -343,8 +343,7 @@ export type ShapeId =
 export type ShapeCategory =
     | "Nodes"
     | "Annotate"
-    | "Basic"
-    | "Flowchart"
+    | "Standard"
     | "UML & ERD"
     | "Containers"
     | "Arrows";

--- a/apps/web/src/app/employer/mindmap/_mindmap/ui/Canvas.tsx
+++ b/apps/web/src/app/employer/mindmap/_mindmap/ui/Canvas.tsx
@@ -352,6 +352,10 @@ export function Canvas({ callbacks, peers, onCursorMove, children }: CanvasProps
                                         at={at}
                                         zoom={viewport.zoom}
                                         replies={c.replies.length}
+                                        onOpen={() => {
+                                            if (c.nodeId) store.selectNodes([c.nodeId]);
+                                            callbacks.onOpenComments?.();
+                                        }}
                                     />
                                 );
                             })}
@@ -622,10 +626,29 @@ function Guides({ guides, zoom }: { guides: EditorState["guides"]; zoom: number 
     );
 }
 
-function CommentPin({ at, zoom, replies }: { at: Point; zoom: number; replies: number }) {
+function CommentPin({
+    at,
+    zoom,
+    replies,
+    onOpen,
+}: {
+    at: Point;
+    zoom: number;
+    replies: number;
+    onOpen: () => void;
+}) {
     const px = (v: number) => v / zoom;
     return (
-        <g transform={`translate(${at.x} ${at.y})`} style={{ pointerEvents: "none" }}>
+        <g
+            transform={`translate(${at.x} ${at.y})`}
+            style={{ pointerEvents: "all", cursor: "pointer" }}
+            onPointerDown={e => {
+                // A pin is a doorway to its thread, not part of the canvas —
+                // don't let the click start a marquee or clear the selection.
+                e.stopPropagation();
+                onOpen();
+            }}
+        >
             <circle r={px(11)} fill="var(--warn)" stroke="var(--panel)" strokeWidth={px(2)} />
             <path
                 d={`M ${-px(5)} ${-px(4)} h ${px(10)} v ${px(6)} h ${-px(6)} l ${-px(3)} ${px(3)} v ${-px(3)} h ${-px(1)} Z`}

--- a/apps/web/src/app/employer/mindmap/_mindmap/ui/CanvasContextMenu.tsx
+++ b/apps/web/src/app/employer/mindmap/_mindmap/ui/CanvasContextMenu.tsx
@@ -76,7 +76,7 @@ export function CanvasContextMenu({ children }: { children: React.ReactNode }) {
         for (const category of SHAPE_CATEGORIES) {
             map.set(
                 category,
-                SHAPES.filter(s => s.category === category)
+                SHAPES.filter(s => s.category === category && !s.paletteHidden)
             );
         }
         return map;

--- a/apps/web/src/app/employer/mindmap/_mindmap/ui/CommentsPanel.tsx
+++ b/apps/web/src/app/employer/mindmap/_mindmap/ui/CommentsPanel.tsx
@@ -46,18 +46,64 @@ export function CommentsPanel({
     const [showResolved, setShowResolved] = useState(false);
 
     const page = useMemo(() => activePage(doc), [doc]);
-    const threads = useMemo(
-        () =>
-            doc.comments
-                .filter(c => c.pageId === page.id)
-                .filter(c => showResolved || !c.resolved)
-                .slice()
-                .reverse(),
-        [doc.comments, page.id, showResolved]
-    );
-
     const anchorNodeId = selection.find(s => s.kind === "node")?.id ?? null;
     const anchorNode = anchorNodeId ? nodeById(page, anchorNodeId) : null;
+
+    // Selecting a shape scopes the list: its threads first under their own
+    // header, everything else demoted below — so "what was said about this
+    // box?" is one click on the box, not a scan of the whole page.
+    const { onShape, elsewhere } = useMemo(() => {
+        const visible = doc.comments
+            .filter(c => c.pageId === page.id)
+            .filter(c => showResolved || !c.resolved)
+            .slice()
+            .reverse();
+        if (!anchorNodeId) return { onShape: null, elsewhere: visible };
+        return {
+            onShape: visible.filter(c => c.nodeId === anchorNodeId),
+            elsewhere: visible.filter(c => c.nodeId !== anchorNodeId),
+        };
+    }, [doc.comments, page.id, showResolved, anchorNodeId]);
+    const total = (onShape?.length ?? 0) + elsewhere.length;
+
+    const threadGroups = useMemo(() => {
+        if (onShape === null) {
+            return [
+                {
+                    key: "all",
+                    header: null as string | null,
+                    empty: elsewhere.length === 0 ? "No comments yet." : null,
+                    highlight: false,
+                    threads: elsewhere,
+                },
+            ];
+        }
+        const name = anchorNode
+            ? trimmedOr(anchorNode.text.split("\n")[0], "this shape")
+            : "this shape";
+        const groups = [
+            {
+                key: "shape",
+                header: `On “${name}”`,
+                empty:
+                    onShape.length === 0
+                        ? "Nothing here yet — the box above posts to this shape."
+                        : null,
+                highlight: true,
+                threads: onShape,
+            },
+        ];
+        if (elsewhere.length > 0) {
+            groups.push({
+                key: "page",
+                header: "Elsewhere on this page",
+                empty: null,
+                highlight: false,
+                threads: elsewhere,
+            });
+        }
+        return groups;
+    }, [onShape, elsewhere, anchorNode]);
 
     const submit = () => {
         const body = draft.trim();
@@ -97,7 +143,7 @@ export function CommentsPanel({
 
             <div className="border-line flex items-center justify-between border-b px-3 py-1.5">
                 <span className="text-ink-3 font-mono text-[10px] font-semibold uppercase tracking-[0.08em]">
-                    {threads.length} thread{threads.length === 1 ? "" : "s"}
+                    {total} thread{total === 1 ? "" : "s"}
                 </span>
                 <button
                     type="button"
@@ -110,14 +156,24 @@ export function CommentsPanel({
 
             <ScrollArea className="min-h-0 flex-1">
                 <div className="space-y-2 p-3">
-                    {threads.length === 0 && (
-                        <p className="text-ink-3 py-6 text-center text-[13px]">No comments yet.</p>
-                    )}
-                    {threads.map(thread => (
+                    {threadGroups.map(group => (
+                        <React.Fragment key={group.key}>
+                            {group.header && (
+                                <h4 className="text-ink-3 pt-1 font-mono text-[10px] font-semibold uppercase tracking-[0.08em]">
+                                    {group.header}
+                                </h4>
+                            )}
+                            {group.empty && (
+                                <p className="text-ink-3 py-4 text-center text-[12.5px]">
+                                    {group.empty}
+                                </p>
+                            )}
+                            {group.threads.map(thread => (
                         <article
                             key={thread.id}
                             className={cn(
                                 "border-line bg-panel rounded-lg border p-2.5",
+                                group.highlight && "border-brand",
                                 thread.resolved && "opacity-60"
                             )}
                         >
@@ -223,6 +279,8 @@ export function CommentsPanel({
                                 )
                             )}
                         </article>
+                            ))}
+                        </React.Fragment>
                     ))}
                 </div>
             </ScrollArea>

--- a/apps/web/src/app/employer/mindmap/_mindmap/ui/Inspector.tsx
+++ b/apps/web/src/app/employer/mindmap/_mindmap/ui/Inspector.tsx
@@ -80,6 +80,7 @@ import {
     IconToggle,
     Label,
     NumberField,
+    PresetNumberField,
     Row,
     Section,
     Segmented,
@@ -99,6 +100,26 @@ import { useCommittedDoc, useEditor, useStore } from "./EditorContext";
  */
 
 const selectSelection = (s: EditorState) => s.selection;
+
+/** Stroke weights people ask for by name; the field still takes any number. */
+const WEIGHT_PRESETS = [
+    { label: "Hairline", value: 0.75 },
+    { label: "Thin", value: 1 },
+    { label: "Regular", value: 1.5 },
+    { label: "Medium", value: 2.5 },
+    { label: "Bold", value: 4 },
+    { label: "Heavy", value: 6 },
+] as const;
+
+/** Type sizes by role rather than by pixel. */
+const FONT_SIZE_PRESETS = [
+    { label: "Small", value: 11 },
+    { label: "Body", value: 14 },
+    { label: "Emphasis", value: 16 },
+    { label: "Subheading", value: 20 },
+    { label: "Heading", value: 24 },
+    { label: "Display", value: 32 },
+] as const;
 
 /** Common value across a set, or `null` when they disagree. */
 function common<T, K>(items: readonly T[], read: (item: T) => K): K | null {
@@ -288,7 +309,9 @@ function NodeSections({ nodes }: { nodes: DiagramNode[] }) {
                         <SelectValue placeholder="Mixed shapes" />
                     </SelectTrigger>
                     <SelectContent className="max-h-72">
-                        {SHAPES.map(def => (
+                        {/* Hidden duplicates stay listable only while one is the
+                            current value, so a legacy node's select isn't blank. */}
+                        {SHAPES.filter(def => !def.paletteHidden || def.id === shape).map(def => (
                             <SelectItem key={def.id} value={def.id} className="text-[12px]">
                                 {def.name}
                             </SelectItem>
@@ -320,8 +343,9 @@ function NodeSections({ nodes }: { nodes: DiagramNode[] }) {
                 </Row>
                 <Row>
                     <Label>Weight</Label>
-                    <NumberField
+                    <PresetNumberField
                         aria-label="Stroke width"
+                        presets={WEIGHT_PRESETS}
                         value={strokeWidth ?? 1.5}
                         mixed={strokeWidth === null}
                         min={0}
@@ -394,8 +418,9 @@ function NodeSections({ nodes }: { nodes: DiagramNode[] }) {
                 </Row>
                 <Row>
                     <Label>Size</Label>
-                    <NumberField
+                    <PresetNumberField
                         aria-label="Font size"
+                        presets={FONT_SIZE_PRESETS}
                         value={fontSize ?? 14}
                         mixed={fontSize === null}
                         min={6}
@@ -587,8 +612,9 @@ function EdgeSections({ edges }: { edges: DiagramEdge[] }) {
             </Row>
             <Row>
                 <Label>Weight</Label>
-                <NumberField
+                <PresetNumberField
                     aria-label="Connector width"
+                    presets={WEIGHT_PRESETS}
                     value={strokeWidth ?? 1.8}
                     mixed={strokeWidth === null}
                     min={0.5}

--- a/apps/web/src/app/employer/mindmap/_mindmap/ui/MindmapEditor.tsx
+++ b/apps/web/src/app/employer/mindmap/_mindmap/ui/MindmapEditor.tsx
@@ -187,6 +187,7 @@ export function MindmapEditor(props: MindmapEditorProps) {
             onContextMenuAt: () => undefined,
             onEditText: (target: { kind: "node" | "edge-label"; id: string; index?: number }) =>
                 store.setEditing(target),
+            onOpenComments: () => setLeftTab("comments"),
         }),
         [store]
     );

--- a/apps/web/src/app/employer/mindmap/_mindmap/ui/SelectionOverlay.tsx
+++ b/apps/web/src/app/employer/mindmap/_mindmap/ui/SelectionOverlay.tsx
@@ -97,6 +97,27 @@ function SingleNodeChrome({
             </g>
             {!interacting && !node.locked && (
                 <>
+                    {/* The outline's own sides resize too, Lucid-style — a
+                        thin invisible band straddling each edge, so grabbing
+                        anywhere along a side works, not just the mid grip. */}
+                    <g transform={transform} style={{ pointerEvents: "all" }}>
+                        {(["n", "e", "s", "w"] as const).map(side => {
+                            const band = px(6);
+                            const horizontal = side === "n" || side === "s";
+                            return (
+                                <rect
+                                    key={side}
+                                    data-handle={side}
+                                    x={horizontal ? 0 : side === "w" ? -band : node.w - band}
+                                    y={horizontal ? (side === "n" ? -band : node.h - band) : 0}
+                                    width={horizontal ? node.w : band * 2}
+                                    height={horizontal ? band * 2 : node.h}
+                                    fill="transparent"
+                                    style={{ cursor: rotatedCursor(side, node.rotation) }}
+                                />
+                            );
+                        })}
+                    </g>
                     {HANDLE_ORDER.map(handle => {
                         const p = handlePosition(node, handle);
                         return (

--- a/apps/web/src/app/employer/mindmap/_mindmap/ui/ShapePalette.tsx
+++ b/apps/web/src/app/employer/mindmap/_mindmap/ui/ShapePalette.tsx
@@ -9,7 +9,7 @@ import { cn } from "~/lib/utils";
 
 import { createNode } from "../model/factory";
 import { themeMode, type ThemeMode } from "../model/palette";
-import { SHAPES, SHAPE_CATEGORIES, shapeGeometry, type ShapeDef } from "../model/shapes";
+import { SHAPE_CATEGORIES, searchShapes, shapeGeometry, type ShapeDef } from "../model/shapes";
 import type { EditorState } from "../model/store";
 import type { NodeStyle, ShapeCategory, ShapeId } from "../model/types";
 import { useCommittedDoc, useEditor, useStore } from "./EditorContext";
@@ -49,15 +49,7 @@ export function ShapePalette() {
     const mode = themeMode(doc.settings.paletteId);
 
     const grouped = useMemo(() => {
-        const q = query.trim().toLowerCase();
-        const matches = q
-            ? SHAPES.filter(
-                  s =>
-                      s.name.toLowerCase().includes(q) ||
-                      s.id.includes(q) ||
-                      s.keywords.some(k => k.includes(q))
-              )
-            : SHAPES;
+        const matches = searchShapes(query);
         const byCategory = new Map<ShapeCategory, ShapeDef[]>();
         for (const shape of matches) {
             const list = byCategory.get(shape.category);

--- a/apps/web/src/app/employer/mindmap/_mindmap/ui/TextEditorOverlay.tsx
+++ b/apps/web/src/app/employer/mindmap/_mindmap/ui/TextEditorOverlay.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import React, { useEffect, useLayoutEffect, useRef, useState } from "react";
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 
 import { addChildTopic, addSiblingTopic, setEdgeLabel, setNodeText } from "../model/commands";
-import { activePage, nodeById, nodeLookup } from "../model/doc";
+import { activePage, nodeById, nodeLookup, removeNodes } from "../model/doc";
 import { worldToScreen } from "../model/geometry";
 import { labelAnchor, routeEdge } from "../model/routing";
 import { shapeTextBox } from "../model/shapes";
-import { fontFamilyCss } from "../model/text";
+import { fontFamilyCss, layoutText } from "../model/text";
 import type { EditorState } from "../model/store";
 import { useCommittedDoc, useEditor, useStore } from "./EditorContext";
 
@@ -37,26 +37,61 @@ export function TextEditorOverlay() {
     const [value, setValue] = useState("");
     /** Set when a keystroke already decided what happens after committing. */
     const followUp = useRef<"child" | "sibling" | null>(null);
+    /**
+     * Whether this editing session has been settled (committed or cancelled).
+     * Clicking the canvas clears `editing` at pointerdown, which unmounts the
+     * field — and a removed element fires no blur, so `onBlur` alone silently
+     * dropped everything typed. The teardown effect below settles any session
+     * the DOM never got to.
+     */
+    const settled = useRef(true);
+    const settleRef = useRef<() => void>(() => undefined);
 
     const page = activePage(doc);
     const node = editing?.kind === "node" ? nodeById(page, editing.id) : undefined;
     const edge =
         editing?.kind === "edge-label" ? page.edges.find(e => e.id === editing.id) : undefined;
 
+    // Focus the field the moment it exists. A callback ref rather than an
+    // effect, because the field can be unmounted and remounted within one
+    // editing session (a gesture clears `editing` and the dblclick restores
+    // it) without the effect's deps ever changing — that gap is exactly the
+    // "typed into a mounted-but-unfocused field, everything vanished" bug.
+    // `preventScroll` is what keeps the browser from scrolling to a field
+    // whose position hasn't painted yet.
+    const takeFocus = () => {
+        const el = ref.current;
+        if (el && document.activeElement !== el) {
+            el.focus({ preventScroll: true });
+            el.select();
+        }
+    };
+    const attachRef = useCallback((el: HTMLTextAreaElement | null) => {
+        ref.current = el;
+        if (el && document.activeElement !== el) {
+            el.focus({ preventScroll: true });
+            el.select();
+        }
+    }, []);
+
     useLayoutEffect(() => {
         if (!editing) return;
         if (node) setValue(node.text);
         else if (edge) setValue(edge.labels[editing.index ?? 0]?.text ?? "");
         else setValue("");
-        // Focus after the position lands, otherwise the browser scrolls the
-        // page to a textarea that is still at 0,0.
-        const id = requestAnimationFrame(() => {
-            const el = ref.current;
-            if (!el) return;
-            el.focus();
-            el.select();
-        });
-        return () => cancelAnimationFrame(id);
+        settled.current = false;
+        // The element is reused when the edit target changes, so the callback
+        // ref won't re-fire — focus here too, and re-assert a frame later in
+        // case something in the same gesture pulled focus away.
+        takeFocus();
+        const id = requestAnimationFrame(takeFocus);
+        return () => {
+            cancelAnimationFrame(id);
+            // The session is ending from outside (canvas click, target
+            // switch, editor unmount) — commit what was typed before the
+            // field disappears with it.
+            if (!settled.current) settleRef.current();
+        };
         // Re-running on every node mutation would clobber what is being typed;
         // the identity of the edit target is the only trigger that matters.
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -66,11 +101,38 @@ export function TextEditorOverlay() {
         if (!editing) followUp.current = null;
     }, [editing]);
 
+    // Grow the field with its content. The box has no scrollbar (`overflow:
+    // hidden`), so without this, text past the shape's height is being typed
+    // blind. Runs after every render; only ever grows — the commit fit is
+    // what settles the final size.
+    useLayoutEffect(() => {
+        const el = ref.current;
+        if (el && el.scrollHeight > el.clientHeight) {
+            el.style.height = `${el.scrollHeight}px`;
+        }
+    });
+
     if (!editing) return null;
 
+    // A bare text mark is invisible on the canvas — no fill, no stroke — so an
+    // empty one left behind can never be found or selected again. Editing one
+    // down to nothing (or abandoning a fresh one) removes it instead.
+    const removeEmptyText = () => {
+        if (!node) return;
+        store.updatePage(page => removeNodes(page, [node.id]), { label: "Remove empty text" });
+    };
+
     const commit = () => {
+        settled.current = true;
         if (editing.kind === "node" && node) {
-            if (value !== node.text) setNodeText(store, node.id, value);
+            const isTextMark = node.shape === "text";
+            if (isTextMark && value.trim() === "") {
+                removeEmptyText();
+            } else if (value !== node.text) {
+                // A text mark hugs its content: nobody sizes a caption first
+                // and types second, so the box follows the words.
+                setNodeText(store, node.id, value, { fit: isTextMark });
+            }
         } else if (editing.kind === "edge-label" && edge) {
             setEdgeLabel(store, edge.id, editing.index ?? 0, value);
         }
@@ -84,9 +146,16 @@ export function TextEditorOverlay() {
     };
 
     const cancel = () => {
+        settled.current = true;
         followUp.current = null;
+        if (editing.kind === "node" && node?.shape === "text" && node.text.trim() === "") {
+            removeEmptyText();
+        }
         store.setEditing(null);
     };
+    // The teardown effect reaches commit through a ref because it must run
+    // the *last* render's commit — the one that saw the final keystroke.
+    settleRef.current = commit;
 
     // -- geometry ----------------------------------------------------------
 
@@ -101,10 +170,22 @@ export function TextEditorOverlay() {
         const box = shapeTextBox(node.shape, node.w, node.h);
         const topLeft = worldToScreen(viewport, { x: node.x + box.x, y: node.y + box.y });
         left = topLeft.x;
-        top = topLeft.y;
         width = Math.max(box.w * viewport.zoom, 40);
-        height = Math.max(box.h * viewport.zoom, 24);
         rotation = node.rotation;
+        // The field *is* the label while it's open — the SVG text hides, so
+        // the field must sit exactly where the committed lines sit, valign
+        // included, or the words visibly jump when editing starts.
+        const laid = layoutText(value.length ? value : " ", node.textStyle, Math.max(box.w, 40));
+        const boxH = Math.max(box.h * viewport.zoom, 24);
+        const blockH = laid.height * viewport.zoom;
+        const offset =
+            node.textStyle.valign === "middle"
+                ? (boxH - blockH) / 2
+                : node.textStyle.valign === "bottom"
+                  ? boxH - blockH
+                  : 0;
+        top = topLeft.y + offset;
+        height = Math.max(blockH, node.textStyle.size * viewport.zoom * 1.2);
     } else if (edge) {
         const routed = routeEdge(edge, nodeLookup(page));
         const label = edge.labels[editing.index ?? 0];
@@ -119,18 +200,9 @@ export function TextEditorOverlay() {
     if (!style) return null;
     const fontSize = style.size * viewport.zoom;
 
-    // The field stands in for the shape, so it has to be painted in the
-    // shape's colours — not the chrome's. `style.color` is document data and
-    // is always a dark ink, because a diagram lives on light paper; pairing it
-    // with `var(--panel)` meant dark-on-near-black in dark theme, i.e. you
-    // could not see what you were typing. An unfilled shape (text, ink,
-    // brackets) and an edge label both sit directly on the paper, so that is
-    // what they get.
-    const surface = node && node.style.fill !== "none" ? node.style.fill : page.background.color;
-
     return (
         <textarea
-            ref={ref}
+            ref={attachRef}
             value={value}
             onChange={e => setValue(e.target.value)}
             onBlur={commit}
@@ -167,12 +239,14 @@ export function TextEditorOverlay() {
                 margin: 0,
                 padding: 0,
                 border: "none",
-                outline: `2px solid var(--accent)`,
-                outlineOffset: 2,
-                borderRadius: 3,
+                outline: "none",
                 resize: "none",
                 overflow: "hidden",
-                background: surface,
+                // In-place editing, not a floating field: the real shape shows
+                // through (its own SVG label hides while this is open), so the
+                // only thing this element paints is the live text and a caret.
+                background: "transparent",
+                caretColor: style.color,
                 color: style.color,
                 fontSize,
                 fontFamily: fontFamilyCss(style.family),
@@ -181,7 +255,6 @@ export function TextEditorOverlay() {
                 lineHeight: style.lineHeight,
                 textAlign: style.align,
                 zIndex: 20,
-                boxShadow: "0 6px 24px var(--scrim-shadow)",
             }}
         />
     );

--- a/apps/web/src/app/employer/mindmap/_mindmap/ui/controls.tsx
+++ b/apps/web/src/app/employer/mindmap/_mindmap/ui/controls.tsx
@@ -4,6 +4,12 @@ import React, { useEffect, useRef, useState } from "react";
 import { Check, ChevronDown, Minus } from "lucide-react";
 
 import { Input } from "~/components/ui/input";
+import {
+    DropdownMenu,
+    DropdownMenuContent,
+    DropdownMenuItem,
+    DropdownMenuTrigger,
+} from "~/components/ui/dropdown-menu";
 import { cn } from "~/lib/utils";
 
 import { DARK_SWATCHES, SWATCHES, THEMES } from "../model/palette";
@@ -141,6 +147,53 @@ export function NumberField({
                     {suffix}
                 </span>
             )}
+        </div>
+    );
+}
+
+export interface NumberPreset {
+    /** The word people think in — "Thin", "Heading" — not the number. */
+    label: string;
+    value: number;
+}
+
+/**
+ * A NumberField with named presets beside it: pick "Bold" from the menu or
+ * keep typing/scrubbing an exact value. Most choices here are made in words,
+ * and the number stays for the case the words don't cover.
+ */
+export function PresetNumberField({
+    presets,
+    ...props
+}: NumberFieldProps & { presets: readonly NumberPreset[] }) {
+    return (
+        <div className="flex flex-1 items-center gap-1">
+            <NumberField {...props} />
+            <DropdownMenu>
+                <DropdownMenuTrigger
+                    aria-label={`${props["aria-label"] ?? "Value"} presets`}
+                    className="border-line text-ink-3 hover:bg-panel-2 hover:text-ink-2 flex h-7 w-5 shrink-0 items-center justify-center rounded-md border"
+                >
+                    <ChevronDown className="size-3" />
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="min-w-[9.5rem]">
+                    {presets.map(preset => (
+                        <DropdownMenuItem
+                            key={preset.label}
+                            onSelect={() => props.onChange(preset.value)}
+                            className="flex items-center justify-between gap-3 text-[12px]"
+                        >
+                            <span>{preset.label}</span>
+                            <span className="text-ink-3 flex items-center gap-1 font-mono text-[11px]">
+                                {preset.value}
+                                {!props.mixed && props.value === preset.value && (
+                                    <Check className="size-3" />
+                                )}
+                            </span>
+                        </DropdownMenuItem>
+                    ))}
+                </DropdownMenuContent>
+            </DropdownMenu>
         </div>
     );
 }

--- a/apps/web/src/app/employer/mindmap/_mindmap/ui/useCanvasInteractions.ts
+++ b/apps/web/src/app/employer/mindmap/_mindmap/ui/useCanvasInteractions.ts
@@ -26,6 +26,8 @@ import {
     nodeRect,
     nodesBounds,
     normalizeRect,
+    portNormal,
+    portPoint,
     rectContains,
     rectsIntersect,
     screenToWorld,
@@ -133,6 +135,12 @@ const IDLE: Gesture = {
 /** Pointer travel (screen px) before a click becomes a drag. */
 const DRAG_THRESHOLD = 3;
 
+/**
+ * Contextmenu events this hook raised itself after a right-click released
+ * without travelling. The handler lets these through the right-drag guard.
+ */
+const reopenedMenuEvents = new WeakSet<Event>();
+
 export interface CanvasInteractions {
     onPointerDown: (e: ReactPointerEvent<SVGSVGElement>) => void;
     onPointerMove: (e: ReactPointerEvent<SVGSVGElement>) => void;
@@ -154,6 +162,8 @@ export interface CanvasCallbacks {
     ) => void;
     /** Begin editing a node's or edge label's text. */
     onEditText: (target: { kind: "node" | "edge-label"; id: string; index?: number }) => void;
+    /** Bring the comments panel forward (a pin on the canvas was clicked). */
+    onOpenComments?: () => void;
 }
 
 export function useCanvasInteractions(
@@ -163,6 +173,14 @@ export function useCanvasInteractions(
 ): CanvasInteractions {
     const gesture = useRef<Gesture>({ ...IDLE });
     const spaceHeld = useRef(false);
+    /** A right-button drag pans; while it lasts the context menu is deferred. */
+    const rightPan = useRef(false);
+    /**
+     * The browser's own `contextmenu` timing differs per platform (macOS fires
+     * it at press, Windows at release), so after a right release the handler
+     * ignores the native event for a beat — pointerup already decided.
+     */
+    const ignoreMenuUntil = useRef(0);
     /**
      * What the last pointerdown actually landed on.
      *
@@ -276,14 +294,57 @@ export function useCanvasInteractions(
     // Pointer down
     // -----------------------------------------------------------------------
 
+    const openMenuFor = useCallback(
+        (clientX: number, clientY: number, target: Element | null) => {
+            const nodeId = target?.closest("[data-node-id]")?.getAttribute("data-node-id");
+            const edgeId = target?.closest("[data-edge-id]")?.getAttribute("data-edge-id");
+            if (nodeId) {
+                if (!store.isSelected("node", nodeId)) store.selectNodes([nodeId]);
+                cb.current.onContextMenuAt(
+                    { x: clientX, y: clientY },
+                    { kind: "node", id: nodeId }
+                );
+                return;
+            }
+            if (edgeId) {
+                if (!store.isSelected("edge", edgeId)) {
+                    store.setSelection([{ kind: "edge", id: edgeId }]);
+                }
+                cb.current.onContextMenuAt(
+                    { x: clientX, y: clientY },
+                    { kind: "edge", id: edgeId }
+                );
+                return;
+            }
+            cb.current.onContextMenuAt({ x: clientX, y: clientY }, { kind: "canvas" });
+        },
+        [store]
+    );
+
     const onPointerDown = useCallback(
         (e: ReactPointerEvent<SVGSVGElement>) => {
-            if (e.button === 2) return; // handled by onContextMenu
             const state = store.getState();
             if (state.presenting) return;
 
             const world = toWorld(e.clientX, e.clientY);
             const screen = toScreen(e.clientX, e.clientY);
+
+            // The right button drags the canvas around, Lucid-style. The
+            // context menu still exists — it opens from pointerup, and only
+            // when the button never travelled (see `onContextMenu`).
+            if (e.button === 2) {
+                svgRef.current?.setPointerCapture(e.pointerId);
+                store.setEditing(null);
+                rightPan.current = true;
+                gesture.current = {
+                    ...IDLE,
+                    kind: "pan",
+                    origin: world,
+                    originScreen: screen,
+                };
+                store.setDrag({ kind: "pan" });
+                return;
+            }
             const target = e.target as Element | null;
             const additive = e.shiftKey || e.metaKey || e.ctrlKey;
 
@@ -741,11 +802,20 @@ export function useCanvasInteractions(
                 }
 
                 case "connect": {
-                    const target = e.target;
+                    // The svg holds pointer capture for the drag, so every
+                    // move's `target` IS the svg — it can never say what the
+                    // pointer is over, and reading it here meant a drop on a
+                    // shape never bound to it. Hit-test the point instead;
+                    // the draft line and selection chrome are
+                    // pointer-transparent, so the top element is the truth.
+                    const under =
+                        typeof document.elementFromPoint === "function"
+                            ? document.elementFromPoint(e.clientX, e.clientY)
+                            : e.target;
                     const overNode =
-                        target?.closest("[data-node-id]")?.getAttribute("data-node-id") ?? null;
+                        under?.closest("[data-node-id]")?.getAttribute("data-node-id") ?? null;
                     const overPort =
-                        target?.closest("[data-port]")?.getAttribute("data-port") ?? null;
+                        under?.closest("[data-port]")?.getAttribute("data-port") ?? null;
                     const drag = state.drag;
                     if (drag.kind === "connect") {
                         store.setDrag({
@@ -950,7 +1020,10 @@ export function useCanvasInteractions(
                 }
 
                 case "connect": {
-                    finishConnect(store, g, world);
+                    const spawned = finishConnect(store, g, world);
+                    if (spawned && shapeHoldsText(spawned.shape)) {
+                        cb.current.onEditText({ kind: "node", id: spawned.id });
+                    }
                     break;
                 }
 
@@ -994,6 +1067,35 @@ export function useCanvasInteractions(
                 }
 
                 case "pan":
+                    if (rightPan.current) {
+                        rightPan.current = false;
+                        // Whatever the platform's contextmenu timing, the
+                        // release has decided: swallow any trailing native
+                        // event…
+                        ignoreMenuUntil.current = performance.now() + 350;
+                        if (!g.moved) {
+                            // …and for a right *click*, raise a marked one of
+                            // our own so the menu opens on release. Dispatch
+                            // it on whatever is under the pointer (capture
+                            // made `e.target` the svg), so a right-click on a
+                            // shape selects and targets that shape.
+                            const under =
+                                (typeof document.elementFromPoint === "function"
+                                    ? document.elementFromPoint(e.clientX, e.clientY)
+                                    : null) ?? svgRef.current;
+                            if (under) {
+                                const reopened = new MouseEvent("contextmenu", {
+                                    bubbles: true,
+                                    cancelable: true,
+                                    clientX: e.clientX,
+                                    clientY: e.clientY,
+                                });
+                                reopenedMenuEvents.add(reopened);
+                                under.dispatchEvent(reopened);
+                            }
+                        }
+                    }
+                    break;
                 default:
                     break;
             }
@@ -1069,31 +1171,22 @@ export function useCanvasInteractions(
 
     const onContextMenu = useCallback(
         (e: ReactMouseEvent<SVGSVGElement>) => {
-            e.preventDefault();
-            const target = e.target as Element | null;
-            const nodeId = target?.closest("[data-node-id]")?.getAttribute("data-node-id");
-            const edgeId = target?.closest("[data-edge-id]")?.getAttribute("data-edge-id");
-            if (nodeId) {
-                if (!store.isSelected("node", nodeId)) store.selectNodes([nodeId]);
-                cb.current.onContextMenuAt(
-                    { x: e.clientX, y: e.clientY },
-                    { kind: "node", id: nodeId }
-                );
+            // A right press is a pan until proven otherwise: swallow the
+            // native event (preventDefault also stops the Radix trigger
+            // above us, which skips a default-prevented event) and let
+            // pointerup re-dispatch a marked one if the pointer never moved.
+            if (
+                !reopenedMenuEvents.has(e.nativeEvent) &&
+                (rightPan.current || performance.now() < ignoreMenuUntil.current)
+            ) {
+                e.preventDefault();
                 return;
             }
-            if (edgeId) {
-                if (!store.isSelected("edge", edgeId)) {
-                    store.setSelection([{ kind: "edge", id: edgeId }]);
-                }
-                cb.current.onContextMenuAt(
-                    { x: e.clientX, y: e.clientY },
-                    { kind: "edge", id: edgeId }
-                );
-                return;
-            }
-            cb.current.onContextMenuAt({ x: e.clientX, y: e.clientY }, { kind: "canvas" });
+            // Fix the selection, then let the event bubble on unprevented —
+            // the Radix trigger wrapping the canvas opens the menu from it.
+            openMenuFor(e.clientX, e.clientY, e.target as Element | null);
         },
-        [store]
+        [openMenuFor]
     );
 
     const isPanning = useCallback(() => spaceHeld.current, []);
@@ -1182,7 +1275,11 @@ function reparentIntoContainers(store: EditorStore, movedIds: readonly string[])
     );
 }
 
-function finishConnect(store: EditorStore, g: Gesture, world: Point): void {
+/**
+ * Ends a connector gesture. Returns the node a port *click* spawned (so the
+ * caller can drop the user into its label), null for every other outcome.
+ */
+function finishConnect(store: EditorStore, g: Gesture, world: Point): DiagramNode | null {
     const state = store.getState();
     const drag = state.drag;
     const hoverNodeId = drag.kind === "connect" ? drag.hoverNodeId : null;
@@ -1202,41 +1299,47 @@ function finishConnect(store: EditorStore, g: Gesture, world: Point): void {
             { transient: true }
         );
         store.endInteraction();
-        return;
+        return null;
     }
 
     const page = activePage(state.doc);
     const fromNodeId = g.fromNodeId;
 
-    // Dragging out of a port into empty space creates the target topic — the
-    // single most-used gesture in a mindmap, so it must not require a second
-    // click on the shape palette.
+    // Dragging out of a *topic's* port into empty space creates the next
+    // topic — the single most-used gesture in a mindmap, so it must not
+    // require a second click on the shape palette. Every other shape gets
+    // what the gesture looks like and no more: a connector, left dangling at
+    // the drop point (re-drag the arrowhead to attach it). A missed drop on
+    // a flowchart must not invent a box.
     let targetNodeId = hoverNodeId;
     let created: DiagramNode | null = null;
     if (!targetNodeId) {
         if (!g.moved) {
-            store.cancelInteraction();
-            return;
+            return spawnFromPortClick(store, g);
         }
         const source = fromNodeId ? nodeById(page, fromNodeId) : undefined;
-        // The new topic inherits its parent's look unless the parent is the
-        // root, whose filled-pill styling would swamp a child.
-        created = createNodeAt("mind-branch", world, {
-            mode: docMode(store),
-            w: source && source.shape !== "mind-root" ? source.w : 160,
-            h: source && source.shape !== "mind-root" ? source.h : 54,
-        });
-        targetNodeId = created.id;
+        if (source?.shape.startsWith("mind-")) {
+            // The new topic inherits its parent's look unless the parent is
+            // the root, whose filled-pill styling would swamp a child.
+            created = createNodeAt("mind-branch", world, {
+                mode: docMode(store),
+                w: source.shape !== "mind-root" ? source.w : 160,
+                h: source.shape !== "mind-root" ? source.h : 54,
+            });
+            targetNodeId = created.id;
+        }
     }
 
     if (fromNodeId && targetNodeId === fromNodeId && !created) {
         store.cancelInteraction();
-        return;
+        return null;
     }
 
     const edge = createEdge({
         from: fromNodeId ? { nodeId: fromNodeId, port: g.fromPort ?? "auto" } : { point: g.origin },
-        to: { nodeId: targetNodeId, port: (hoverPort ?? "auto") as PortId },
+        to: targetNodeId
+            ? { nodeId: targetNodeId, port: (hoverPort ?? "auto") as PortId }
+            : { point: world },
         kind: state.doc.settings.defaultEdgeKind,
     });
 
@@ -1250,4 +1353,53 @@ function finishConnect(store: EditorStore, g: Gesture, world: Point): void {
     );
     store.endInteraction();
     if (created) store.selectNodes([created.id]);
+    return null;
+}
+
+/**
+ * Lucid's click-a-port: a plain click on a port (no drag) mints the next
+ * shape one step out in the port's direction, already connected. A topic
+ * spawns a topic; anything else spawns its own kind, in its own colours.
+ */
+function spawnFromPortClick(store: EditorStore, g: Gesture): DiagramNode | null {
+    const state = store.getState();
+    const page = activePage(state.doc);
+    const source = g.fromNodeId ? nodeById(page, g.fromNodeId) : undefined;
+    const port = g.fromPort;
+    if (!source || !port || port === "auto") {
+        store.cancelInteraction();
+        return null;
+    }
+
+    const isMind = source.shape.startsWith("mind-");
+    const shape: ShapeId = isMind ? "mind-branch" : source.shape;
+    const w = source.shape === "mind-root" ? 160 : source.w;
+    const h = source.shape === "mind-root" ? 54 : source.h;
+
+    const at = portPoint(source, port);
+    const dir = portNormal(source, port);
+    const GAP = 56;
+    let spawned = createNodeAt(
+        shape,
+        {
+            x: at.x + dir.x * (GAP + w / 2),
+            y: at.y + dir.y * (GAP + h / 2),
+        },
+        { mode: docMode(store), w, h }
+    );
+    if (!isMind) {
+        spawned = { ...spawned, style: { ...source.style }, textStyle: { ...source.textStyle } };
+    }
+
+    const edge = createEdge({
+        from: { nodeId: source.id, port },
+        to: { nodeId: spawned.id, port: "auto" },
+        kind: state.doc.settings.defaultEdgeKind,
+    });
+    store.updatePage(p => ({ ...p, nodes: [...p.nodes, spawned], edges: [...p.edges, edge] }), {
+        transient: true,
+    });
+    store.endInteraction();
+    store.selectNodes([spawned.id]);
+    return spawned;
 }


### PR DESCRIPTION
## Summary

- Fixes silent data loss in label editing: canvas clicks unmounted the edit field before blur could fire, so **click-away never committed and typed text vanished**; the session now settles on teardown, focus is bulletproofed, editing is in-place (no floating card), text marks auto-fit and empty ones evaporate.
- Fixes connectors that only *looked* attached: pointer capture retargeted every move to the svg, so drops on a shape never bound (`to` stored a free point) — hit-testing the pointer position makes drops bind and the target highlight work. Dragging out of a non-topic shape now leaves a re-draggable dangling arrow instead of minting a mind-map topic; clicking a port spawns a connected twin of the source shape.
- Resolves user-reported UX gaps against Lucidchart: merges the duplicate-riddled Basic/Flowchart groups into one deduplicated **Standard** library (existing documents unaffected — hidden ids stay in the registry, names become search keywords), right-drag pans with the context menu on release (**which also revives the context menu — an unconditional `preventDefault` had made the Radix trigger skip every event, so it had never opened**), selection-outline edges resize, groups/frames get visible default outlines, Weight/Size fields gain named presets (Hairline…Heavy, Small…Display), and comments are selection-scoped with clickable canvas pins.

## Related

Follow-up work on the mindmap vertical (post #366). The server-side ship-blockers from the production audit (racy `baseRevision` compare-and-set, unvalidated doc jsonb, publish markdown trust) are documented but deliberately **not** in this PR.

## Checklist

- [x] `pnpm check` passes (lint + typecheck)
- [x] `pnpm --filter @launchstack/web test` passes
- [ ] Changeset added (if `packages/core/` changed — `pnpm changeset`) — n/a, no package changes
- [ ] New env vars documented — n/a
- [x] UI changes exercised in a browser (not just a green build)
- [x] Docs updated if behavior changed — README statements about the palette/editor remain accurate

## Testing

- 488 jest tests across 24 suites, 23 of them new: label commit-on-teardown, focus on mount/remount/retarget, fit-and-evaporate for text marks, Standard-group silhouette uniqueness (would have caught all seven duplicates), connector drop binding, dangling-vs-spawn port gestures, right-drag pan vs right-click menu, container preset visibility, and comments selection scoping.
- Every flow was also driven live on `/dev/mindmap` in a real browser: type→click-away→text persists, drop-on-shape→move target→arrow follows, port click→twin spawns into label editing, frame/group placement visibly lands, preset dropdowns apply, comment pin→selects shape and opens its scoped thread, right-click→menu opens (first time ever), right-drag→pans.

## Notes for reviewers

- `TextEditorOverlay` commit now rides a teardown effect (`settleRef`) as well as blur — the double path is deliberate: blur fires for focus-moves, teardown for unmounts; a `settled` ref prevents double-commit. Escape still cancels.
- The palette merge is presentation-only: `paletteHidden` shapes render, resolve, and remain selectable in the Inspector when a legacy node uses them.
- Connector hover uses `document.elementFromPoint` (with an `e.target` fallback for jsdom); the draft line and selection chrome are pointer-transparent so the hit is the real shape.
- The context-menu revival re-dispatches a marked `contextmenu` on right-release-without-travel; the marked event passes the right-drag guard and reaches the Radix trigger unprevented. macOS (menu at press) and Windows (menu at release) orderings are both handled.
- Known limitation left on the table: the eraser erases per-click, not by sweeping a drag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large interaction-layer and document-mutation surface (connectors, text commit, context menu timing); behavior is well covered by new tests but regressions in edge gestures are plausible.
> 
> **Overview**
> Fixes **label editing** so typed text survives canvas click-away: `TextEditorOverlay` commits on unmount via a teardown path, focuses reliably on mount/remount, edits in-place with transparent overlay, auto-fits **text** marks, and removes empty text shapes.
> 
> **Connectors** now hit-test with `elementFromPoint` during drag so drops bind to shapes; non-mindmap drags into empty space leave a free endpoint instead of spawning topics; port click spawns a connected twin and can open label edit.
> 
> **Canvas UX**: right-drag pans; context menu opens on stationary right-click (Radix trigger no longer blocked by blanket `preventDefault`); selection adds Lucid-style invisible edge resize bands; comment pins select the shape and open comments.
> 
> **Shape library** merges Basic/Flowchart into **Standard**, hides duplicate silhouettes (`paletteHidden`) while keeping legacy ids searchable/renderable; groups/frames get visible default strokes; inspector adds **PresetNumberField** for stroke weight and font size.
> 
> **Comments panel** groups threads under the selected shape with “Elsewhere on this page” below.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 663fe5a245d999a02e2022307d16b03b3660ba7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->