### PR TITLE
fix: unbreak main — a stray route export, and a source module .gitignore swallowed

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -64,6 +64,11 @@ jobs:
       - name: Dockerfile deps layers cover every workspace manifest
         run: node scripts/ci/check-dockerfile-manifests.mjs
 
+      # Same reasoning: dependency-free, runs before install, and the build
+      # error it prevents names the file but not the offending export.
+      - name: Route files export only handlers and segment config
+        run: node scripts/ci/check-route-exports.mjs
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 

--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,9 @@ backups/
 # test output
 test-output/
 
-# Personal working notes — never committed
-notes/
+# Personal working notes — never committed. Anchored to the repository root:
+# a bare `notes/` matches any directory of that name at any depth, which
+# silently swallowed apps/web/src/server/notes/ and let a commit ship three
+# imports of a module that was never added.
+/notes/
 *.tgz

--- a/apps/web/src/app/api/distribution/runs/route.ts
+++ b/apps/web/src/app/api/distribution/runs/route.ts
@@ -23,7 +23,7 @@ const CreateRunSchema = z.object({
 });
 
 /** Credits the run needs before it starts: planning plus the first candidate. */
-export const RUN_MINIMUM_CREDITS = 3_000;
+const RUN_MINIMUM_CREDITS = 3_000;
 
 export async function GET(request: NextRequest) {
     try {

--- a/apps/web/src/server/notes/document-scope.ts
+++ b/apps/web/src/server/notes/document-scope.ts
@@ -1,0 +1,106 @@
+/**
+ * Scoping notes by the document they are anchored to (ADR-010).
+ *
+ * A note belongs to its author, but an anchored note quotes a document — so
+ * when the document falls outside the reader's `DocumentScope`, the note goes
+ * with it. An unanchored note has no document to inherit from and stays
+ * visible to its workspace.
+ *
+ * Both helpers resolve the document rows themselves rather than trusting a
+ * `documentId` handed in by a caller, and re-check each row with
+ * `scopeAllows` — the same belt-and-braces pass `~/lib/authz/scope` applies
+ * after its SQL predicate.
+ *
+ * NOTE: this module was lost before it reached the repository — `.gitignore`
+ * carried a bare `notes/` rule that silently matched
+ * `apps/web/src/server/notes/`, so the commit that introduced its three
+ * callers never carried the file. It has been reconstructed from those call
+ * sites and from `~/lib/authz/scope`. The behaviour it implements is an
+ * access-control decision, so it deserves a read against the ADR-010 intent
+ * rather than a rubber stamp.
+ */
+
+import { inArray } from "drizzle-orm";
+
+import { document } from "@launchstack/store/schema";
+
+import { db } from "~/server/db";
+import { scopeAllows } from "~/lib/authz/scope";
+import { type DocumentScope } from "~/lib/authz/scope-types";
+
+/** `document_notes.document_id` is a varchar; document ids are numeric. */
+function toDocumentId(value: string | null | undefined): number | null {
+    if (value === null || value === undefined || value.trim() === "") return null;
+    const id = Number(value);
+    return Number.isFinite(id) ? id : null;
+}
+
+/**
+ * Which of `documentIds` this scope permits, resolved in one query.
+ * Ids that name no document in this company are simply absent from the result,
+ * so a dangling reference reads as "not visible" rather than as "unrestricted".
+ */
+async function visibleDocumentIds(
+    documentIds: readonly number[],
+    companyId: bigint,
+    scope: DocumentScope
+): Promise<Set<number>> {
+    if (documentIds.length === 0) return new Set();
+
+    const rows = await db
+        .select({ id: document.id, category: document.category, companyId: document.companyId })
+        .from(document)
+        .where(inArray(document.id, [...new Set(documentIds)]));
+
+    const visible = new Set<number>();
+    for (const row of rows) {
+        // Cross-company rows can never be visible, whatever the scope says.
+        if (row.companyId !== companyId) continue;
+        if (scopeAllows(scope, { id: row.id, category: row.category })) {
+            visible.add(Number(row.id));
+        }
+    }
+    return visible;
+}
+
+/**
+ * Whether a note anchored to `documentId` may be read.
+ *
+ * `null` — an unanchored note — is visible: there is no document to inherit a
+ * restriction from.
+ */
+export async function isNoteDocumentVisible(
+    documentId: string | null | undefined,
+    companyId: bigint,
+    scope: DocumentScope
+): Promise<boolean> {
+    const id = toDocumentId(documentId);
+    if (id === null) return true;
+    if (scope.kind === "everything") return true;
+
+    const visible = await visibleDocumentIds([id], companyId, scope);
+    return visible.has(id);
+}
+
+/**
+ * Drop the notes whose anchor document this scope hides. Unanchored notes are
+ * kept. One query for the whole batch, not one per note.
+ */
+export async function filterNotesByDocumentScope<T extends { documentId: string | null }>(
+    notes: readonly T[],
+    companyId: bigint,
+    scope: DocumentScope
+): Promise<T[]> {
+    if (scope.kind === "everything") return [...notes];
+
+    const anchored = notes
+        .map(note => toDocumentId(note.documentId))
+        .filter((id): id is number => id !== null);
+
+    const visible = await visibleDocumentIds(anchored, companyId, scope);
+
+    return notes.filter(note => {
+        const id = toDocumentId(note.documentId);
+        return id === null || visible.has(id);
+    });
+}

--- a/scripts/ci/check-route-exports.mjs
+++ b/scripts/ci/check-route-exports.mjs
@@ -1,0 +1,115 @@
+/**
+ * Next.js route files may export only the HTTP handlers and a fixed set of
+ * segment-config values. Any other export makes the module fail the framework's
+ * Route type check, and it fails at *build* time with a message that names the
+ * file but not the offending symbol:
+ *
+ *   Type error: Route "src/app/api/…/route.ts" does not match the required
+ *   types of a Next.js Route.
+ *
+ * That has now broken main three times — a helper constant or a shared type
+ * left exported next to the handlers. Nothing catches it before the image
+ * build, which is minutes in, so this does: it is a text scan, it needs no
+ * dependencies, and it names the export.
+ *
+ * Run:
+ *   node scripts/ci/check-route-exports.mjs
+ *
+ * Exit codes: 0 ok · 1 a route exports something it may not
+ */
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join, relative, resolve as resolvePath } from "node:path";
+
+const ROOT = resolvePath(import.meta.dirname, "../..");
+const APP_DIRS = ["apps/web/src/app", "apps/landing/src/app"];
+
+/** Everything the framework accepts from a route module. */
+const ALLOWED = new Set([
+    "GET",
+    "POST",
+    "PUT",
+    "PATCH",
+    "DELETE",
+    "HEAD",
+    "OPTIONS",
+    "dynamic",
+    "dynamicParams",
+    "revalidate",
+    "fetchCache",
+    "runtime",
+    "preferredRegion",
+    "maxDuration",
+    "generateStaticParams",
+]);
+
+function routeFiles(dir) {
+    const out = [];
+    let entries;
+    try {
+        entries = readdirSync(dir, { withFileTypes: true });
+    } catch {
+        return out;
+    }
+    for (const entry of entries) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory()) out.push(...routeFiles(full));
+        else if (/^route\.tsx?$/.test(entry.name)) out.push(full);
+    }
+    return out;
+}
+
+/**
+ * Named exports declared at the top level. Deliberately a regex rather than a
+ * parser: this has to stay dependency-free and run before install.
+ */
+function exportedNames(source) {
+    const names = [];
+    const patterns = [
+        /^export\s+(?:async\s+)?function\s+([A-Za-z0-9_$]+)/gm,
+        /^export\s+(?:const|let|var)\s+([A-Za-z0-9_$]+)/gm,
+        /^export\s+class\s+([A-Za-z0-9_$]+)/gm,
+    ];
+    for (const re of patterns) {
+        for (const m of source.matchAll(re)) names.push(m[1]);
+    }
+    // `export { a, b }` — types are erased at build, values are not.
+    for (const m of source.matchAll(/^export\s*\{([^}]*)\}/gm)) {
+        for (const part of m[1].split(",")) {
+            const name = part
+                .trim()
+                .split(/\s+as\s+/)
+                .pop()
+                ?.trim();
+            if (name && !part.trim().startsWith("type ")) names.push(name);
+        }
+    }
+    return names;
+}
+
+const offenders = [];
+for (const appDir of APP_DIRS) {
+    for (const file of routeFiles(join(ROOT, appDir))) {
+        const source = readFileSync(file, "utf8");
+        for (const name of exportedNames(source)) {
+            if (!ALLOWED.has(name)) {
+                offenders.push({ file: relative(ROOT, file), name });
+            }
+        }
+    }
+}
+
+if (offenders.length > 0) {
+    console.error(`[check-route-exports] ${offenders.length} disallowed export(s) in route files:`);
+    for (const { file, name } of offenders) {
+        console.error(`  ✗ ${file} — exports "${name}"`);
+    }
+    console.error(
+        "\nA route module may export only the HTTP handlers and the segment config\n" +
+            "(dynamic, revalidate, runtime, maxDuration, …). Move the symbol to its own\n" +
+            "module, or drop the `export` if nothing outside the file uses it."
+    );
+    process.exit(1);
+}
+
+const scanned = APP_DIRS.reduce((n, d) => n + routeFiles(join(ROOT, d)).length, 0);
+console.log(`[check-route-exports] ok — ${scanned} route files, no disallowed exports`);


### PR DESCRIPTION
`main` has not produced a deployable image for three consecutive runs, so GHCR's `:latest` is still the revision already in production — a redeploy today is a no-op. Two independent causes.

## 1 · A route exported something it may not

`apps/web/src/app/api/distribution/runs/route.ts` exported `RUN_MINIMUM_CREDITS`. A Next.js route module may export only the HTTP handlers and the segment config, so the build failed with:

```
Type error: Route "src/app/api/distribution/runs/route.ts" does not match
the required types of a Next.js Route.
```

That message names the **file** but not the **symbol**, which is why this keeps costing time. Nothing outside the file used the constant, so the `export` keyword simply goes.

**This is the third time a route export has broken `main`** (the OAuth start route was the last one). So `scripts/ci/check-route-exports.mjs` now scans every route file for exports outside the allowed set — handlers plus `dynamic`, `revalidate`, `runtime`, `maxDuration`, … — and prints the offending name:

```
✗ apps/web/src/app/api/distribution/runs/route.ts — exports "RUN_MINIMUM_CREDITS"
```

Dependency-free, runs before `install`, covers 201 route files in well under a second. Verified it fails on the real bug and passes once fixed.

## 2 · `.gitignore` silently swallowed a source module

Three route files import `~/server/notes/document-scope`. That module is **in no commit, on no branch, and on no machine.**

The cause:

```gitignore
# Personal working notes — never committed
notes/
```

A bare `notes/` matches a directory of that name **at any depth** — including `apps/web/src/server/notes/`. `git add` skipped the new file without a word, and the commit that introduced its three importers shipped imports of nothing.

The rule is now `/notes/`, anchored to the repository root. Verified both directions: the root directory is still ignored, and the source directory no longer is.

### About the reconstructed module

`document-scope.ts` is rebuilt from its three call sites and from `~/lib/authz/scope`, whose `scopeAllows` it reuses rather than reimplementing. The semantics were stated outright by a caller:

> *Notes are the author's, but an anchored note quotes its document: when the document is outside the scope, so is the note.*

So an unanchored note stays visible, and an anchored one inherits its document's scope. It also refuses cross-company rows whatever the scope says, and treats an id naming no document as not-visible rather than as unrestricted.

**Please read this one properly.** It is access-control code that went *missing* rather than code anyone reviewed, and I reconstructed it from usage — it should be checked against the ADR-010 intent rather than rubber-stamped. If the original author still has the file, theirs should win.

## Verification

`pnpm --filter @launchstack/web build` completes — the exact step that was failing. Typecheck clean (it was 3 errors, all this module). Both new guards verified in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces reconstructed access-control logic for notes visibility tied to document scope; incorrect behavior could leak or hide notes across workspaces/scopes.
> 
> **Overview**
> Unblocks deployable **`main`** builds by fixing two independent breakages and adding a CI guard so route export mistakes fail fast.
> 
> **Next.js route typing:** Removes the **`export`** on **`RUN_MINIMUM_CREDITS`** in the distribution runs route (only handlers/segment config may be exported). Adds **`scripts/ci/check-route-exports.mjs`** and runs it in CI before **`pnpm install`** so disallowed exports are reported by symbol, not only as an opaque build error.
> 
> **`.gitignore`:** Changes **`notes/`** to **`/notes/`** so personal notes at the repo root stay ignored without matching **`apps/web/src/server/notes/`**, which had prevented **`document-scope.ts`** from ever being committed while importers shipped.
> 
> **Notes authz:** Adds reconstructed **`document-scope.ts`** (**`isNoteDocumentVisible`**, **`filterNotesByDocumentScope`**) so anchored notes inherit document **`DocumentScope`** via **`scopeAllows`**; unanchored notes remain visible. Reviewers should validate behavior against ADR-010 intent — this module was rebuilt from call sites, not from an reviewed original.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8fa7d7a4abb18f31c8b2bf2eda55639b449f82e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->