### PR TITLE
ci: get the three red jobs green

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -82,9 +82,12 @@ jobs:
       # red lint state on main for months.
       - name: Lint
         env:
-            # The type-aware lint over 14 packages + 2 apps exceeds the
-            # default Node heap (exit 134 on the stock runner).
-            NODE_OPTIONS: --max-old-space-size=6144
+            # The type-aware lint builds a program over every package and
+            # both apps, and outgrows the default Node heap (exit 134 on the
+            # stock runner). 6144 was enough until the distribution,
+            # repo-workspace and workspace-access bricks landed; the runner
+            # has 16GB, so this leaves ample headroom above the peak.
+            NODE_OPTIONS: --max-old-space-size=10240
         run: pnpm lint
 
       - name: Typecheck (all workspace packages, worker included)

--- a/apps/web/src/app/dev/sessions-browser/SessionsBrowserPreview.tsx
+++ b/apps/web/src/app/dev/sessions-browser/SessionsBrowserPreview.tsx
@@ -112,7 +112,12 @@ export function SessionsBrowserPreview() {
                 typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
             if (url.includes("/api/connectors/agent-sessions")) {
                 if (init?.method === "POST") {
-                    const body = JSON.parse(String(init.body ?? "{}")) as { sourceIds?: string[] };
+                    // `BodyInit` covers Blob, FormData and streams, and String()
+                    // on those yields "[object Object]" — which would parse as
+                    // nothing useful. This shim is only ever handed a JSON
+                    // string, so anything else is treated as an empty body.
+                    const raw = typeof init.body === "string" ? init.body : "{}";
+                    const body = JSON.parse(raw) as { sourceIds?: string[] };
                     const ids =
                         body.sourceIds ?? ITEMS.filter(i => !i.imported).map(i => i.sourceId);
                     await new Promise(r => setTimeout(r, 600));

--- a/apps/web/src/server/db/schema/connectors.ts
+++ b/apps/web/src/server/db/schema/connectors.ts
@@ -77,13 +77,6 @@ export const connectorConnections = pgTable(
          * rotation) — there `accessTokenCiphertext` IS the credential.
          */
         refreshTokenCiphertext: text("refresh_token_ciphertext"),
-        /**
-         * For Google this stays null (access tokens are cached in-process);
-         * for Slack/GitHub it persists the long-lived token.
-         */
-        accessTokenCiphertext: text("access_token_ciphertext"),
-        /** Null when the stored access token does not expire. */
-        accessTokenExpiresAt: timestamp("access_token_expires_at", { withTimezone: true }),
         encryptionKeyVersion: integer("encryption_key_version").notNull().default(1),
         scopes: varchar("scopes", { length: 512 }).notNull(),
         /** 'active' | 'revoked' — revoked means reconnect is the only fix. */
@@ -93,6 +86,18 @@ export const connectorConnections = pgTable(
             .default(sql`CURRENT_TIMESTAMP`)
             .notNull(),
         updatedAt: timestamp("updated_at", { withTimezone: true }).$onUpdate(() => new Date()),
+        // Declared last because that is where they physically live: the
+        // migration adds them with ALTER TABLE ADD COLUMN, which appends. The
+        // migrations-apply job compares pg_dump output, and pg_dump prints
+        // columns in physical order — so declaring them mid-table read as
+        // schema drift even though both sides had identical columns.
+        /**
+         * For Google this stays null (access tokens are cached in-process);
+         * for Slack/GitHub it persists the long-lived token.
+         */
+        accessTokenCiphertext: text("access_token_ciphertext"),
+        /** Null when the stored access token does not expire. */
+        accessTokenExpiresAt: timestamp("access_token_expires_at", { withTimezone: true }),
     },
     table => ({
         companyProviderAccountUnique: uniqueIndex(

--- a/scripts/ci/e2e-ingest.mjs
+++ b/scripts/ci/e2e-ingest.mjs
@@ -27,10 +27,10 @@ const { createDocumentLifecycle } = await import(
   "../../packages/orchestration/src/source-lifecycle/lifecycle.ts"
 );
 const { createCompanyBM25Retriever } = await import(
-  "../../packages/retrieval/src/retrievers/bm25-retriever.ts"
+  "../../packages/retrieval/src/algorithms/bm25/bm25.ts"
 );
 const { buildCitations } = await import(
-  "../../packages/retrieval/src/citation-builder.ts"
+  "../../packages/retrieval/src/tools/citation-builder/citation-builder.ts"
 );
 
 const handle = createDb({ url: DATABASE_URL });


### PR DESCRIPTION
`main`'s CI had three red jobs. They turned out to be three unrelated problems, and only one of them was a real code defect.

## `check` → Lint: out of memory, not a rule

```
FATAL ERROR: Ineffective mark-compacts near heap limit
Allocation failed - JavaScript heap out of memory
##[error]Process completed with exit code 134.
```

The type-aware lint builds a program over every package and both apps. The heap was already raised to 6144MB for exactly this reason, and that was enough until the distribution, repo-workspace and workspace-access bricks landed. Raised to **10240MB** — the runner has 16GB, so this sits well clear of the peak.

Worth knowing this is a ceiling that will be hit again as the workspace grows; the durable fix is linting in chunks, which is a bigger change than unbreaking `main`.

## `compose-smoke` → e2e ingestion: stale imports

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
'…/packages/retrieval/src/retrievers/bm25-retriever.ts'
imported from …/scripts/ci/e2e-ingest.mjs
```

`scripts/ci/e2e-ingest.mjs` still imported two paths that moved when `retrieval` split into `algorithms/` and `tools/`:

| was | now |
|---|---|
| `retrieval/src/retrievers/bm25-retriever.ts` | `retrieval/src/algorithms/bm25/bm25.ts` |
| `retrieval/src/citation-builder.ts` | `retrieval/src/tools/citation-builder/citation-builder.ts` |

The script died before the ingestion stack it exists to exercise was ever reached — so this job has been failing for a reason unrelated to the thing it tests. Repointed, and verified both files exist and export the symbols the script destructures.

## `migrations-apply` → drift was column *order*, not columns

The diff was two lines moving, not a schema mismatch:

```diff
     refresh_token_ciphertext text,
+    access_token_ciphertext text,
+    access_token_expires_at timestamp with time zone,
     encryption_key_version integer DEFAULT 1 NOT NULL,
...
-    updated_at timestamp with time zone,
-    access_token_ciphertext text,
-    access_token_expires_at timestamp with time zone
+    updated_at timestamp with time zone
```

Identical columns, identical types, different positions. Those two arrive via `ALTER TABLE … ADD COLUMN`, which **appends**, while `schema.ts` declared them mid-table. `pg_dump` prints columns in physical order, so the job flagged a table that was in fact the same on both sides.

Declaring them last matches where they actually live, with a comment saying why so the next person doesn't "tidy" them back.

### Verified locally, not assumed

I reproduced the job against `pgvector/pgvector:pg16` — `db:migrate` into one database, `drizzle-kit push` into another, `pg_dump` both, `diff`:

```
✓ identical (2699 lines compared)
```

## What I could and couldn't verify locally

- **migrations-apply** — reproduced end to end, passes.
- **compose-smoke** — confirmed the paths resolve and the exports exist; the full run needs the Compose stack, so CI is the proof.
- **Lint** — memory ceilings are runner-specific; CI is the proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI configuration, dev-only fetch stub, and schema declaration ordering with no runtime behavior change; e2e script import fixes only.
> 
> **Overview**
> Unblocks three failing CI paths that were unrelated: lint OOM, compose-smoke module resolution, and migrations-apply false drift.
> 
> **Lint** raises `NODE_OPTIONS` heap from **6144MB to 10240MB** so type-aware lint over the enlarged monorepo stops exiting 134 on the 16GB runner; comments note chunking as the longer-term fix.
> 
> **Compose smoke** repoints `scripts/ci/e2e-ingest.mjs` imports to the post-refactor `retrieval` layout (`algorithms/bm25/bm25.ts` and `tools/citation-builder/citation-builder.ts`) so the job can run past startup.
> 
> **Migrations-apply** moves `accessTokenCiphertext` and `accessTokenExpiresAt` to the **end** of `connector_connections` in Drizzle schema so declaration order matches columns appended by `ALTER TABLE ADD COLUMN` and `pg_dump` comparison stops flagging column-order-only diffs.
> 
> **Dev preview** hardens the agent-sessions `fetch` shim: POST bodies are `JSON.parse`’d only when `init.body` is a string, avoiding bogus parses from `String()` on non-string `BodyInit`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55cc0ae3f64c3ab7474da1f4dcdd4032da134784. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->