### PR TITLE
fix(web): drop the AskPanel tests' mock of the moved GraphView module

### DIFF
--- a/apps/web/src/app/employer/documents/_workspace/__tests__/AskPanel.citations.test.tsx
+++ b/apps/web/src/app/employer/documents/_workspace/__tests__/AskPanel.citations.test.tsx
@@ -29,7 +29,6 @@ jest.mock("../../../_chrome/EmployerWorkspaceSwitcherContext", () => ({
 jest.mock("../../hooks/useChatRoutes", () => ({
     useChatRoutes: () => ({ routes: [], loading: false }),
 }));
-jest.mock("../GraphView", () => ({ GraphView: () => null }));
 
 const SOURCES: WorkspaceSource[] = [
     {

--- a/apps/web/src/app/employer/documents/_workspace/__tests__/AskPanel.starters.test.tsx
+++ b/apps/web/src/app/employer/documents/_workspace/__tests__/AskPanel.starters.test.tsx
@@ -31,7 +31,6 @@ jest.mock("../../../_chrome/EmployerWorkspaceSwitcherContext", () => ({
 jest.mock("../../hooks/useChatRoutes", () => ({
     useChatRoutes: () => ({ routes: [], loading: false }),
 }));
-jest.mock("../GraphView", () => ({ GraphView: () => null }));
 
 const SOURCES: WorkspaceSource[] = [
     {


### PR DESCRIPTION
## Summary

- PR #390 moved `GraphView` out of the chat workspace and removed its import from `AskPanel`. Two AskPanel suites that landed on `main` in parallel (`AskPanel.starters.test.tsx`, `AskPanel.citations.test.tsx`) still `jest.mock("../GraphView")`, so jest could not resolve the module and the `check` job on `main` went red at c902e052.
- The mock only kept the graph view out of the render tree; with the import gone it has nothing to replace, so it is removed.

## Related

Follow-up to #390. Main was green at 279381d0 and red at c902e052; this restores it.

## Checklist

- [ ] `pnpm check` passes (lint + typecheck) — not run locally; CI runs it here and this PR waits for it before merging
- [x] `pnpm --filter @launchstack/web test` — the two affected suites pass locally; the full suite runs in CI
- [x] Changeset added — not applicable, test-only change
- [x] New env vars — none
- [x] UI changes exercised in a browser — none, test-only
- [x] Docs updated — not applicable

## Testing

Ran `jest` on the two suites locally: both pass. The third failure in that CI run, `founderWeeklyReview/document-version-chunks.test.ts` timing out at 5 s, is a DB integration test that passed on the previous `main` commit; this PR's CI run will show whether it was a one-off.

## Notes for reviewers

The chat route and AskPanel merge in #390 was resolved by hand; these two test files were not part of the conflict, which is how the stale mock slipped through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only cleanup with no production or runtime behavior changes.
> 
> **Overview**
> **Removes obsolete `jest.mock("../GraphView")` lines** from `AskPanel.citations.test.tsx` and `AskPanel.starters.test.tsx`.
> 
> After `GraphView` was moved out of the chat workspace (#390), `AskPanel` no longer imports that module, so these mocks made Jest fail to resolve `../GraphView` and broke CI on `main`. The mocks only stubbed a component that is no longer in the render tree, so deleting them restores the two suites without changing what they assert.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae3e58262115cda9e67d1c22758f8e5a8d2c2534. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->